### PR TITLE
chore: rename publish environment from production to release

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    environment: production
+    environment: release
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Rename the PyPI publish environment from 'production' to 'release'.