### PR TITLE
fix: resolve MkDocs strict-mode failures (#128)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -430,9 +430,9 @@ If deletion has completed, the command returns a not-found error.
 ## See Also
 
 - [Choose an Azure Functions Hosting Plan](choose-a-plan.md) — Plan selection guide with decision tree
-- [README](../README.md)
-- [Examples: healthy HTTP trigger](../examples/v2/http-trigger)
-- [Examples: broken missing host.json](../examples/v2/broken-missing-host-json)
+- [README](https://github.com/yeongseon/azure-functions-doctor/blob/main/README.md)
+- [Examples: healthy HTTP trigger](https://github.com/yeongseon/azure-functions-doctor/tree/main/examples/v2/http-trigger)
+- [Examples: broken missing host.json](https://github.com/yeongseon/azure-functions-doctor/tree/main/examples/v2/broken-missing-host-json)
 - [`azure-functions-scaffold`](https://github.com/yeongseon/azure-functions-scaffold)
 - [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation)
 - [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,9 @@ nav:
       - Minimal Profile: minimal_profile.md
       - JSON Output Contract: json_output_contract.md
       - Handlers: handlers.md
+  - Deployment:
+      - Choose a Plan: choose-a-plan.md
+      - Deploy to Azure: deployment.md
   - Examples:
       - Basic Check: examples/basic_check.md
       - CI Integration: examples/ci_integration.md


### PR DESCRIPTION
## Summary
- Add deployment.md, choose-a-plan.md to mkdocs.yml nav under Deployment section
- Replace ../README.md and ../examples/* links with GitHub URLs (outside docs/)

Verified: hatch run mkdocs build --strict passes clean.

Closes #128