### PR TITLE
fix(ci): correct stale workflow repo-slug check after rename

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   stale-issues:
     runs-on: ubuntu-latest
-    if: github.repository == 'yeongseon/azure-functions-doctor'
+    if: github.repository == 'yeongseon/azure-functions-doctor-python'
 
     steps:
       - name: "Stale issues and PRs"
@@ -32,7 +32,7 @@ jobs:
 
   stale-branches:
     runs-on: ubuntu-latest
-    if: github.repository == 'yeongseon/azure-functions-doctor'
+    if: github.repository == 'yeongseon/azure-functions-doctor-python'
 
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
## Summary

Both `stale-issues` (line 15) and `stale-branches` (line 35) jobs in
`.github/workflows/stale.yml` still guarded on the pre-rename repository
slug `yeongseon/azure-functions-doctor`. After the rename to
`azure-functions-doctor-python`, the condition evaluated to \`false\` at
runtime and both jobs were silently skipped on every scheduled and
ad-hoc trigger — visible on PR #164 where both reported
\`conclusion: SKIPPED\` without executing.

Aligns the two guards with the current canonical repository slug
(\`azure-functions-doctor-python\`) so the workflow's stale-issue and
stale-branch pruning runs as intended.

## Changes

\`.github/workflows/stale.yml\`:

\`\`\`diff
 jobs:
   stale-issues:
     runs-on: ubuntu-latest
-    if: github.repository == 'yeongseon/azure-functions-doctor'
+    if: github.repository == 'yeongseon/azure-functions-doctor-python'

   stale-branches:
     runs-on: ubuntu-latest
-    if: github.repository == 'yeongseon/azure-functions-doctor'
+    if: github.repository == 'yeongseon/azure-functions-doctor-python'
\`\`\`

## Verification

Post-merge, a \`workflow_dispatch\` run on \`stale.yml\` should show both
jobs execute (not \`SKIPPED\`) since \`github.repository\` will now match
the guard.

Closes #165