### PR TITLE
chore(templates): align issue template URLs with canonical -python repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: GitHub Discussions
-    url: https://github.com/yeongseon/azure-functions-doctor/discussions
+    url: https://github.com/yeongseon/azure-functions-doctor-python/discussions
     about: Ask questions and discuss ideas with the community
   - name: Documentation
-    url: https://github.com/yeongseon/azure-functions-doctor/blob/main/README.md
+    url: https://github.com/yeongseon/azure-functions-doctor-python/blob/main/README.md
     about: Check the documentation for usage guides and examples

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -10,7 +10,7 @@ body:
       value: |
         Thank you for opening an issue! This template is for general issues that don't fit into bug reports or feature requests.
         
-        **Note**: For questions or discussions, consider using [GitHub Discussions](https://github.com/yeongseon/azure-functions-doctor/discussions) instead.
+        **Note**: For questions or discussions, consider using [GitHub Discussions](https://github.com/yeongseon/azure-functions-doctor-python/discussions) instead.
 
   - type: dropdown
     id: issue-type


### PR DESCRIPTION
## Summary

Updates three pre-rename repository URLs in the GitHub issue template
configuration to reference the canonical \`azure-functions-doctor-python\`
slug directly (aligned with \`pyproject.toml\` after PR #164).

## Changes

- \`.github/ISSUE_TEMPLATE/config.yml:4\` — Discussions URL
- \`.github/ISSUE_TEMPLATE/config.yml:7\` — README contact link
- \`.github/ISSUE_TEMPLATE/general_issue.yml:13\` — Discussions link

Previously these relied on GitHub's repository redirect to resolve. This
aligns the source-of-truth so the rendered \"New Issue\" page links
directly to the canonical repository.

## Out of scope

PyPI package name (\`azure-functions-doctor\`, still canonical on PyPI)
in \`general_issue.yml:61\` and \`bug_report.yml:60\` intentionally left
unchanged — **package identity is distinct from repository URL**.

## Verification

Post-merge, the New Issue page (\`/issues/new/choose\`) should show both
contact-link entries linking directly to \`azure-functions-doctor-python\`
without redirect.

Closes #166