### PR TITLE
docs(i18n): align translated README badges with canonical -python repository

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,12 +2,12 @@
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-doctor.svg)](https://pypi.org/project/azure-functions-doctor/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-doctor/)
-[![CI](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/release.yml)
-[![Security Scans](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-doctor/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-doctor)
+[![CI](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/ci-test.yml)
+[![Release](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/publish-pypi.yml)
+[![Security Scans](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-doctor-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-doctor-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-doctor/)
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-doctor-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
@@ -45,7 +45,7 @@ pip install azure-functions-doctor
 ソースからインストール：
 
 ```bash
-git clone https://github.com/yeongseon/azure-functions-doctor.git
+git clone https://github.com/yeongseon/azure-functions-doctor-python.git
 cd azure-functions-doctor
 python3 -m venv .venv
 source .venv/bin/activate

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,12 +2,12 @@
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-doctor.svg)](https://pypi.org/project/azure-functions-doctor/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-doctor/)
-[![CI](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/release.yml)
-[![Security Scans](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-doctor/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-doctor)
+[![CI](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/ci-test.yml)
+[![Release](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/publish-pypi.yml)
+[![Security Scans](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-doctor-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-doctor-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-doctor/)
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-doctor-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -45,7 +45,7 @@ pip install azure-functions-doctor
 소스에서 설치:
 
 ```bash
-git clone https://github.com/yeongseon/azure-functions-doctor.git
+git clone https://github.com/yeongseon/azure-functions-doctor-python.git
 cd azure-functions-doctor
 python3 -m venv .venv
 source .venv/bin/activate


### PR DESCRIPTION
## Summary

Updates both \`README.ja.md\` and \`README.ko.md\` to match the canonical
repository slug (\`azure-functions-doctor-python\`) and the current
workflow filename established in the main \`README.md\` after PR #164.

## Changes (per file: README.ja.md, README.ko.md)

| Line | Element | Change |
|------|---------|--------|
| 5 | CI badge | slug: \`-doctor\` → \`-doctor-python\` |
| 6 | Release badge | slug + workflow rename: \`release.yml\` → \`publish-pypi.yml\` |
| 7 | Security Scans badge | slug: \`-doctor\` → \`-doctor-python\` |
| 8 | Codecov badge | slug: \`-doctor\` → \`-doctor-python\` |
| 10 | Docs (gh-pages) badge | slug: \`-doctor\` → \`-doctor-python\` |
| 48 | \`git clone\` URL | slug: \`-doctor.git\` → \`-doctor-python.git\` |

### Extra fix beyond acceptance checklist

Line 6 also renames \`release.yml\` → \`publish-pypi.yml\` because the
release workflow was renamed and the translated READMEs' badges were
silently 404-ing. This matches the main \`README.md\` (post-rename).

### Out of scope

- Lines 3, 4 (PyPI badge, Python version) — point at PyPI package
  identity, not the repository URL; PyPI package name is unchanged.
- Line 9 (pre-commit badge) — repo-agnostic.
- Line 11 (License badge) — points at local \`LICENSE\` file, not URL.
- Line 49 \`cd azure-functions-doctor\` — inconsistent (\`git clone\`
  creates \`-python/\` directory) but mirrors the same inconsistency
  in the main \`README.md\`. Deferred to a follow-up if needed.

## Verification

Post-merge, all badges in \`README.ja.md\` and \`README.ko.md\` should
resolve without redirects. GitHub Discussions link and \`git clone\`
example should target the canonical slug directly.

Closes #167