### PR TITLE
fix(sarif): align SARIF informationUri with canonical -python repository

### DIFF
--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -291,7 +291,7 @@ def doctor(
                         "driver": {
                             "name": "azure-functions-doctor",
                             "version": __version__,
-                            "informationUri": "https://github.com/yeongseon/azure-functions-doctor",
+                            "informationUri": "https://github.com/yeongseon/azure-functions-doctor-python",
                             "rules": driver_rules,
                         }
                     },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,7 @@ def test_cli_sarif_output() -> None:
     tool = run["tool"]["driver"]
     assert tool["name"] == "azure-functions-doctor"
     assert tool["version"]
+    assert tool["informationUri"] == "https://github.com/yeongseon/azure-functions-doctor-python"
     assert run["properties"]["programming_model"]
 
     has_error = any(item.get("level") == "error" for item in run.get("results", []))


### PR DESCRIPTION
## Summary

The SARIF output produced by \`azure-functions-doctor\` embedded a
\`tool.driver.informationUri\` referencing the pre-rename repository
slug \`yeongseon/azure-functions-doctor\`. SARIF is **published tool
metadata** ingested by GitHub Code Scanning and third-party SARIF
viewers — downstream consumers were being linked back to the
redirected slug instead of the canonical \`-python\` slug.

Aligns the field with \`pyproject.toml\` (canonicalized in PR #164).

## Changes

- \`src/azure_functions_doctor/cli.py:294\` — \`informationUri\` now
  points at \`https://github.com/yeongseon/azure-functions-doctor-python\`
- \`tests/test_cli.py:92\` — new assertion in \`test_cli_sarif_output()\`
  pins the exact \`informationUri\` value to prevent future drift.

## Verification

- Full test suite: **380 passed, 2 skipped, coverage 95.95%** (above 95%)
- \`hatch run lint\`: **All checks passed** (33 source files clean)
- SARIF-specific tests: **3/3 passed** including new assertion

Closes #168