### PR TITLE
docs: fix From-source clone directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ From source:
 
 ```bash
 git clone https://github.com/yeongseon/azure-functions-doctor-python.git
-cd azure-functions-doctor
+cd azure-functions-doctor-python
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -e .


### PR DESCRIPTION
## Summary
- The README "From source" block clones `azure-functions-doctor-python` but then `cd azure-functions-doctor`, which does not match the clone directory.
- Fixed the `cd` target to `azure-functions-doctor-python`.

Closes #188