### PR TITLE
docs: add discoverability metadata (pepy badge + llms.txt)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,7 @@
 # Azure Functions Doctor
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-doctor.svg)](https://pypi.org/project/azure-functions-doctor/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-doctor/month)](https://pepy.tech/project/azure-functions-doctor)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-doctor/)
 [![CI](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/publish-pypi.yml)

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,7 @@
 # Azure Functions Doctor
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-doctor.svg)](https://pypi.org/project/azure-functions-doctor/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-doctor/month)](https://pepy.tech/project/azure-functions-doctor)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-doctor/)
 [![CI](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/publish-pypi.yml)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > Part of the **Azure Functions Python DX Toolkit** — dogfood-tested by [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python).
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-doctor.svg)](https://pypi.org/project/azure-functions-doctor/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-doctor/month)](https://pepy.tech/project/azure-functions-doctor)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-doctor/)
 [![CI](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/publish-pypi.yml)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,7 @@
 # Azure Functions Doctor
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-doctor.svg)](https://pypi.org/project/azure-functions-doctor/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-doctor/month)](https://pepy.tech/project/azure-functions-doctor)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-doctor/)
 [![CI](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor/actions/workflows/release.yml)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,26 @@
+# Azure Functions Doctor
+
+> Diagnostic tool for the Azure Functions Python v2 programming model.
+
+Part of the **Azure Functions Python DX Toolkit**. A CLI that diagnoses common configuration, environment, and project-structure issues in Azure Functions Python v2 apps, emitting a machine-readable JSON contract for CI. Install from PyPI with `pip install azure-functions-doctor`.
+
+## Getting Started
+- [Installation](https://yeongseon.github.io/azure-functions-doctor-python/installation/): Install the CLI.
+- [Quickstart](https://yeongseon.github.io/azure-functions-doctor-python/getting-started/): Run your first diagnostic.
+- [Configuration](https://yeongseon.github.io/azure-functions-doctor-python/configuration/): Configure checks and profiles.
+
+## User Guide
+- [CLI Usage](https://yeongseon.github.io/azure-functions-doctor-python/usage/): Command reference.
+- [Diagnostics](https://yeongseon.github.io/azure-functions-doctor-python/diagnostics/): What gets checked and why.
+- [Rules](https://yeongseon.github.io/azure-functions-doctor-python/rules/): Rule model and inventory.
+- [JSON Output Contract](https://yeongseon.github.io/azure-functions-doctor-python/json_output_contract/): Machine-readable output for CI.
+
+## Reference
+- [API Reference](https://yeongseon.github.io/azure-functions-doctor-python/api/): Public API surface.
+- [Architecture](https://yeongseon.github.io/azure-functions-doctor-python/architecture/): How the rule engine works.
+- [FAQ](https://yeongseon.github.io/azure-functions-doctor-python/faq/): Frequently asked questions.
+- [Troubleshooting](https://yeongseon.github.io/azure-functions-doctor-python/troubleshooting/): Common issues and fixes.
+
+## Optional
+- [CI Integration](https://yeongseon.github.io/azure-functions-doctor-python/examples/ci_integration/): Use in pipelines.
+- [Changelog](https://yeongseon.github.io/azure-functions-doctor-python/changelog/): Release history.


### PR DESCRIPTION
## Summary

Discoverability improvements (no code changes):

- **pepy.tech monthly download badge** added to `README.md` and locale READMEs (after the PyPI badge).
- **`docs/llms.txt`** added — an llmstxt.org-style summary served at the gh-pages site root (`/llms.txt`) with curated links to key docs.

## Verification
- `mkdocs build --strict` passes; `llms.txt` present at site root.

Closes #199
