### PR TITLE
docs: sync documented version strings to 0.17.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ This repository includes `llms.txt` and `llms-full.txt` for LLM-friendly documen
 
 When working with this codebase, LLM assistants should:
 
-1. **Use `llms.txt` for quick reference** — package version (0.17.1), Python requirements (>=3.10,<3.15), CLI entry points
+1. **Use `llms.txt` for quick reference** — package version (0.17.2), Python requirements (>=3.10,<3.15), CLI entry points
 2. **Refer to `llms-full.txt` for implementation details** — output contracts, rule structure, custom rule patterns, handler types
 3. **Check `src/azure_functions_doctor/cli.py`** — authoritative source for CLI options and validation
 4. **Review `src/azure_functions_doctor/assets/rules/v2.json`** — complete ruleset with check definitions

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,7 +47,7 @@ In this guide you will:
 | Azure CLI | `az --version` | [Install Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) |
 | Azure Functions Core Tools v4 | `func --version` | [Install Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools) |
 | Python 3.10-3.13 | `python3 --version` | [python.org](https://www.python.org/downloads/) |
-| Doctor CLI v0.17.1 | `pip show azure-functions-doctor` | `python3 -m pip install azure-functions-doctor` |
+| Doctor CLI v0.17.2 | `pip show azure-functions-doctor` | `python3 -m pip install azure-functions-doctor` |
 
 Install doctor if needed:
 
@@ -142,7 +142,7 @@ Representative JSON output (`doctor-report.json`):
 ```json
 {
   "metadata": {
-    "tool_version": "0.17.1",
+    "tool_version": "0.17.2",
     "target_path": "/data/GitHub/azure-functions-doctor/examples/v2/http-trigger"
   },
   "results": [
@@ -171,7 +171,7 @@ Representative SARIF output (`doctor-report.sarif`):
       "tool": {
         "driver": {
           "name": "azure-functions-doctor",
-          "version": "0.17.1"
+          "version": "0.17.2"
         }
       },
       "results": []

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5,7 +5,7 @@
 ## Package Info
 
 - PyPI: `pip install azure-functions-doctor`
-- Version: 0.17.1
+- Version: 0.17.2
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.github.io/azure-functions-doctor/
@@ -185,7 +185,7 @@ Structured output with metadata, results, and rule information:
 ```json
 {
   "metadata": {
-    "tool_version": "0.17.1",
+    "tool_version": "0.17.2",
     "generated_at": "2025-04-07T10:30:00Z",
     "target_path": "/path/to/app"
   },
@@ -223,7 +223,7 @@ Static Analysis Results Format (SARIF 2.1.0) compatible with GitHub Security tab
       "tool": {
         "driver": {
           "name": "azure-functions-doctor",
-          "version": "0.17.1",
+          "version": "0.17.2",
           "informationUri": "https://github.com/yeongseon/azure-functions-doctor",
           "rules": [...]
         }

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,7 @@
 ## Package Info
 
 - PyPI: `pip install azure-functions-doctor`
-- Version: 0.17.1
+- Version: 0.17.2
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.github.io/azure-functions-doctor/


### PR DESCRIPTION
## Summary
- Bump all documented version strings from `0.17.1` to `0.17.2` to match `__version__`.
- Fixes the failing `test(3.10)` "Check documentation consistency" step on `main`, which was blocking the open dependency PRs.

Files: `llms.txt`, `llms-full.txt`, `docs/deployment.md`, `README.md`.

Verified locally: `python scripts/check_docs_consistency.py` passes (version 0.17.2, 22 rules).

Closes #211