### PR TITLE
docs: use canonical CLI command in sample output block

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ is not the same as the Python version your Function App will run on Azure.
 ### Sample output (excerpt)
 
 ```bash
-azure-functions-doctor doctor --path ./examples/v2/http-trigger
+azure-functions doctor --path ./examples/v2/http-trigger
 ```
 
 ```text


### PR DESCRIPTION
## Summary
- Use the canonical `azure-functions doctor` invocation in the Sample output block for consistency with the rest of the README (both entry points remain valid).

Closes #216