### PR TITLE
docs: rename ruleset heading and de-hardcode version reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The final terminal state is also captured as a static image for quick inspection
 
 ![Doctor final output](docs/assets/doctor-demo-final.png)
 
-## Features
+## Default ruleset
 
 The default ruleset includes checks for:
 
@@ -285,7 +285,7 @@ This repository includes `llms.txt` and `llms-full.txt` for LLM-friendly documen
 
 When working with this codebase, LLM assistants should:
 
-1. **Use `llms.txt` for quick reference** — package version (0.17.2), Python requirements (>=3.10,<3.15), CLI entry points
+1. **Use `llms.txt` for quick reference** — package version, Python requirements (>=3.10,<3.15), CLI entry points
 2. **Refer to `llms-full.txt` for implementation details** — output contracts, rule structure, custom rule patterns, handler types
 3. **Check `src/azure_functions_doctor/cli.py`** — authoritative source for CLI options and validation
 4. **Review `src/azure_functions_doctor/assets/rules/v2.json`** — complete ruleset with check definitions


### PR DESCRIPTION
## Summary
- Rename the mislabeled `## Features` section to `## Default ruleset` (it lists the default checks, distinct from `## What it does`).
- Remove the hardcoded `0.17.2` version from the AI-assistants note to avoid staleness.

Closes #218