### PR TITLE
chore: track issue priority via priority:* labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,17 +36,15 @@ Follow these conventions when opening issues so the backlog stays consistent wit
 - Use Conventional Commit prefixes: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `ci:`, `build:`, `perf:`.
 - Add a scope qualifier when it narrows the area: `feat(rule):`, `docs(diagnostic):`, `refactor(check):`.
 - Keep the title imperative, under ~80 characters, no trailing period.
-- Do **not** put `[P0]` / `[P1]` / `[P2]` (or any priority marker) in the title — priority lives in the body.
+- Do **not** put `[P0]` / `[P1]` / `[P2]` (or any priority marker) in the title — priority is tracked with a `priority:p0` / `priority:p1` / `priority:p2` label.
 
 ### Body
 
 Use the following sections, in order, omitting any that do not apply:
 
 ```
-## Priority: P0 | P1 | P2 (target vX.Y.Z, optional)
-
 ## Context
-What problem this issue addresses and why now.
+What problem this issue addresses and why now. Note the target release (e.g. vX.Y.Z) here if known.
 
 ## Acceptance Checklist
 - [ ] Concrete, verifiable items.
@@ -61,6 +59,7 @@ What problem this issue addresses and why now.
 ### Labels
 
 - Apply at least one of `bug`, `enhancement`, `documentation`, `chore`.
+- Apply exactly one `priority:p0` / `priority:p1` / `priority:p2` label to record priority (replaces the old `## Priority` body line).
 - Add `area:*` labels when they exist in the repository.
 - Use `blocker` only when the issue blocks a release.
 


### PR DESCRIPTION
## Summary
- Move issue priority from the `## Priority` body line into dedicated `priority:p0` / `priority:p1` / `priority:p2` labels (already created in this repo).
- Update the issue-convention **agent rules** in `AGENTS.md`: title still carries no priority marker; priority is now recorded via label; Labels section requires exactly one `priority:*` label.
- Applied consistently across all DX Toolkit sibling repos.

## Notes
- Convention change only — existing open issues are not retroactively relabeled (going-forward policy).