### PR TITLE
chore(cli): deprecate azure-functions and fdoctor console-script aliases

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -58,31 +58,46 @@ pip install -e .
 現在のプロジェクトで doctor を実行：
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 特定のプロジェクトパスを指定して実行：
 
 ```bash
-azure-functions doctor --path ./examples/v2/http-trigger
+azure-functions-doctor doctor --path ./examples/v2/http-trigger
 ```
 
 必須項目のみをチェックするプロファイルを使用：
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 CI 用に JSON 形式で出力：
 
 ```bash
-azure-functions doctor --format json
+azure-functions-doctor doctor --format json
 ```
+
+### コマンド名と非推奨のエイリアス
+
+`azure-functions-doctor` が**正式（canonical）**コマンドです。既存の 2 つの
+コンソールスクリプトエイリアスは引き続き動作しますが、**非推奨（deprecated）**であり、
+実行時に警告を出力します：
+
+| コマンド | 状態 |
+| --- | --- |
+| `azure-functions-doctor` | 正式 — これを使用してください。 |
+| `azure-functions` | 非推奨 — **v1.0.0** で削除予定。 |
+| `fdoctor` | 非推奨 — **v1.0.0** で削除予定。 |
+
+v1.0.0 リリースでエイリアスが削除される前に、スクリプトや CI パイプラインを
+`azure-functions-doctor` に移行してください。
 
 ## Demo
 
 以下のデモは、VHS を使用して [`demo/doctor-demo.tape`](demo/doctor-demo.tape) から生成されました。
-代表的なサンプルプロジェクトと、意図的にエラーを発生させたコピーに対して実際の `azure-functions doctor` CLI を実行し、成功と失敗の対比を示しています。
+代表的なサンプルプロジェクトと、意図的にエラーを発生させたコピーに対して実際の `azure-functions-doctor doctor` CLI を実行し、成功と失敗の対比を示しています。
 
 ![Doctor demo](docs/assets/doctor-demo.gif)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -58,31 +58,46 @@ pip install -e .
 현재 프로젝트에서 doctor 실행:
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 특정 프로젝트 경로에서 실행:
 
 ```bash
-azure-functions doctor --path ./examples/v2/http-trigger
+azure-functions-doctor doctor --path ./examples/v2/http-trigger
 ```
 
 필수 항목만 점검하는 프로필 사용:
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 CI를 위한 JSON 출력:
 
 ```bash
-azure-functions doctor --format json
+azure-functions-doctor doctor --format json
 ```
+
+### 명령 이름과 사용 중단된 별칭
+
+`azure-functions-doctor`가 **표준(canonical)** 명령입니다. 두 개의 레거시
+콘솔 스크립트 별칭은 여전히 동작하지만 **사용 중단(deprecated)** 되었으며,
+실행 시 경고를 출력합니다:
+
+| 명령 | 상태 |
+| --- | --- |
+| `azure-functions-doctor` | 표준 — 이 명령을 사용하세요. |
+| `azure-functions` | 사용 중단 — **v1.0.0**에서 제거 예정. |
+| `fdoctor` | 사용 중단 — **v1.0.0**에서 제거 예정. |
+
+v1.0.0 릴리스에서 별칭이 제거되기 전에 스크립트나 CI 파이프라인을
+`azure-functions-doctor`로 마이그레이션하세요.
 
 ## Demo
 
 아래 데모는 VHS를 사용하여 [`demo/doctor-demo.tape`](demo/doctor-demo.tape)에서 생성되었습니다.
-대표적인 예시 프로젝트와 의도적으로 오류를 발생시킨 복사본에 대해 실제 `azure-functions doctor` CLI를 실행하여 성공/실패 대비를 보여줍니다.
+대표적인 예시 프로젝트와 의도적으로 오류를 발생시킨 복사본에 대해 실제 `azure-functions-doctor doctor` CLI를 실행하여 성공/실패 대비를 보여줍니다.
 
 ![Doctor demo](docs/assets/doctor-demo.gif)
 

--- a/README.md
+++ b/README.md
@@ -81,40 +81,54 @@ pip install -e .
 Run the doctor in the current project:
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 Run against a specific project:
 
 ```bash
-azure-functions doctor --path ./examples/v2/http-trigger
+azure-functions-doctor doctor --path ./examples/v2/http-trigger
 ```
 
 Use a required-only profile:
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 Output JSON for CI:
 
 ```bash
-azure-functions doctor --format json
+azure-functions-doctor doctor --format json
 ```
 
 Pin the Azure Functions target runtime explicitly:
 
 ```bash
-azure-functions doctor --target-python 3.12
+azure-functions-doctor doctor --target-python 3.12
 ```
 
 Use `--target-python` when the Python running `azure-functions-doctor`
 is not the same as the Python version your Function App will run on Azure.
 
+### Command name and deprecated aliases
+
+`azure-functions-doctor` is the **canonical** command. Two legacy console-script
+aliases still work but are **deprecated** and print a warning when invoked:
+
+| Command | Status |
+| --- | --- |
+| `azure-functions-doctor` | Canonical — use this. |
+| `azure-functions` | Deprecated — removal targeted for **v1.0.0**. |
+| `fdoctor` | Deprecated — removal targeted for **v1.0.0**. |
+
+Migrate any scripts or CI pipelines to `azure-functions-doctor` before the
+v1.0.0 release removes the aliases.
+
 ### Sample output (excerpt)
 
 ```bash
-azure-functions doctor --path ./examples/v2/http-trigger
+azure-functions-doctor doctor --path ./examples/v2/http-trigger
 ```
 
 ```text
@@ -155,7 +169,7 @@ Use `azure-functions-doctor` as a CI gate to block deployments on required failu
 - name: Run azure-functions-doctor
   run: |
     pip install azure-functions-doctor
-    azure-functions doctor --profile minimal --format json --output doctor.json
+    azure-functions-doctor doctor --profile minimal --format json --output doctor.json
 
 - name: Upload report
   if: always()
@@ -182,7 +196,7 @@ See [docs/examples/ci_integration.md](docs/examples/ci_integration.md) for Azure
 ## Demo
 
 The demo below is generated from [`demo/doctor-demo.tape`](demo/doctor-demo.tape) with VHS.
-It runs the real `azure-functions doctor` CLI against the representative example
+It runs the real `azure-functions-doctor doctor` CLI against the representative example
 and then against an intentionally broken copy to show the pass/fail contrast.
 
 ![Doctor demo](docs/assets/doctor-demo.gif)
@@ -231,7 +245,7 @@ The default ruleset includes checks for:
 
 ## How It Works
 
-`azure-functions doctor` loads a JSON ruleset, dispatches each rule to a
+`azure-functions-doctor doctor` loads a JSON ruleset, dispatches each rule to a
 type-based handler, and aggregates the results into per-section output:
 
 ```mermaid

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,31 +58,45 @@ pip install -e .
 在当前项目中运行 doctor：
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 针对特定项目路径运行：
 
 ```bash
-azure-functions doctor --path ./examples/v2/http-trigger
+azure-functions-doctor doctor --path ./examples/v2/http-trigger
 ```
 
 使用仅包含必要检查项的配置：
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 为 CI 输出 JSON 格式：
 
 ```bash
-azure-functions doctor --format json
+azure-functions-doctor doctor --format json
 ```
+
+### 命令名称与已弃用的别名
+
+`azure-functions-doctor` 是**正式（canonical）**命令。两个旧的控制台
+脚本别名仍可使用，但已**弃用（deprecated）**，调用时会打印警告：
+
+| 命令 | 状态 |
+| --- | --- |
+| `azure-functions-doctor` | 正式 — 请使用此命令。 |
+| `azure-functions` | 已弃用 — 计划在 **v1.0.0** 移除。 |
+| `fdoctor` | 已弃用 — 计划在 **v1.0.0** 移除。 |
+
+请在 v1.0.0 发布移除别名之前，将脚本或 CI 流水线迁移到
+`azure-functions-doctor`。
 
 ## Demo
 
 以下演示是使用 VHS 从 [`demo/doctor-demo.tape`](demo/doctor-demo.tape) 生成的。
-它通过对代表性示例项目以及一个故意损坏的副本运行真实的 `azure-functions doctor` CLI，来展示成功与失败的对比。
+它通过对代表性示例项目以及一个故意损坏的副本运行真实的 `azure-functions-doctor doctor` CLI，来展示成功与失败的对比。
 
 ![Doctor demo](docs/assets/doctor-demo.gif)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 The public entry point for programmatic usage is
 `azure_functions_doctor.api.run_diagnostics(path, profile, rules_path)`.
-It uses the same diagnostics engine as `azure-functions doctor`, then returns
+It uses the same diagnostics engine as `azure-functions-doctor doctor`, then returns
 structured results that can be consumed in scripts, CI pipelines, or custom tooling.
 
 ## Public API at a Glance

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ This page explains how runtime behavior changes with flags, profiles, formats, a
 ## Command shape
 
 ```bash
-azure-functions doctor [OPTIONS]
+azure-functions-doctor doctor [OPTIONS]
 ```
 
 Core options:
@@ -25,13 +25,13 @@ Core options:
 By default, diagnostics run against the current directory.
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 To check another project:
 
 ```bash
-azure-functions doctor --path ./apps/orders-function
+azure-functions-doctor doctor --path ./apps/orders-function
 ```
 
 Path validation behavior:
@@ -59,7 +59,7 @@ Profiles control which rules execute.
 - Stable contract for pass/fail baseline
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 See [Minimal Profile](minimal_profile.md) for complete rule coverage.
@@ -89,7 +89,7 @@ See [Minimal Profile](minimal_profile.md) for complete rule coverage.
 Example:
 
 ```bash
-azure-functions doctor --format json --output artifacts/doctor.json
+azure-functions-doctor doctor --format json --output artifacts/doctor.json
 ```
 
 !!! note
@@ -108,7 +108,7 @@ If `--output` is provided:
 Example:
 
 ```bash
-azure-functions doctor --format sarif --output reports/doctor.sarif
+azure-functions-doctor doctor --format sarif --output reports/doctor.sarif
 ```
 
 ## Verbose and debug modes
@@ -118,7 +118,7 @@ azure-functions doctor --format sarif --output reports/doctor.sarif
 Shows fix hints for non-passing checks in table output.
 
 ```bash
-azure-functions doctor --verbose
+azure-functions-doctor doctor --verbose
 ```
 
 ### `--debug`
@@ -126,7 +126,7 @@ azure-functions doctor --verbose
 Enables debug logging output for deeper troubleshooting.
 
 ```bash
-azure-functions doctor --debug
+azure-functions-doctor doctor --debug
 ```
 
 Use debug mode when diagnosing tool behavior rather than project diagnostics.
@@ -136,7 +136,7 @@ Use debug mode when diagnosing tool behavior rather than project diagnostics.
 You can replace built-in rules with a custom file:
 
 ```bash
-azure-functions doctor --rules ./rules/custom-v2.json
+azure-functions-doctor doctor --rules ./rules/custom-v2.json
 ```
 
 Behavior:
@@ -176,7 +176,7 @@ def current_config() -> dict:
 For merge blocking:
 
 ```bash
-azure-functions doctor --profile minimal --format json --output doctor.json
+azure-functions-doctor doctor --profile minimal --format json --output doctor.json
 ```
 
 Why this shape works well:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,7 +72,7 @@ This is the core workflow for this repository: diagnose first, deploy second.
 Healthy project check:
 
 ```bash
-azure-functions doctor examples/v2/http-trigger --profile minimal
+azure-functions-doctor doctor examples/v2/http-trigger --profile minimal
 ```
 
 Representative text output:
@@ -90,7 +90,7 @@ Project Structure
 [PASS] host.json: found
 [PASS] host.json version: "2.0"
 
-Doctor summary (to see all details, run azure-functions doctor -v):
+Doctor summary (to see all details, run azure-functions-doctor doctor -v):
   0 fails, 0 warnings, 5 passed
 Exit code: 0
 ```
@@ -98,7 +98,7 @@ Exit code: 0
 Broken project detection (missing `host.json`):
 
 ```bash
-azure-functions doctor examples/v2/broken-missing-host-json --profile minimal
+azure-functions-doctor doctor examples/v2/broken-missing-host-json --profile minimal
 ```
 
 Representative text output:
@@ -116,7 +116,7 @@ Project Structure
 [FAIL] host.json: file not found (fail)
 [FAIL] host.json version: host.json missing or invalid (fail)
 
-Doctor summary (to see all details, run azure-functions doctor -v):
+Doctor summary (to see all details, run azure-functions-doctor doctor -v):
   2 fails, 0 warnings, 3 passed
 Exit code: 1
 ```
@@ -125,16 +125,16 @@ Machine-readable output formats:
 
 ```bash
 # JSON
-azure-functions doctor examples/v2/http-trigger --profile minimal --format json --output doctor-report.json
+azure-functions-doctor doctor examples/v2/http-trigger --profile minimal --format json --output doctor-report.json
 
 # SARIF (for code scanning / security tooling)
-azure-functions doctor examples/v2/http-trigger --profile minimal --format sarif --output doctor-report.sarif
+azure-functions-doctor doctor examples/v2/http-trigger --profile minimal --format sarif --output doctor-report.sarif
 
 # JUnit (for CI test dashboards)
-azure-functions doctor examples/v2/http-trigger --profile minimal --format junit --output doctor-report.xml
+azure-functions-doctor doctor examples/v2/http-trigger --profile minimal --format junit --output doctor-report.xml
 
 # Summary JSON sidecar (quick pass/fail counts)
-azure-functions doctor examples/v2/http-trigger --profile minimal --summary-json doctor-summary.json
+azure-functions-doctor doctor examples/v2/http-trigger --profile minimal --summary-json doctor-summary.json
 ```
 
 Representative JSON output (`doctor-report.json`):
@@ -228,7 +228,7 @@ az functionapp list-flexconsumption-locations -o table
 ### Step 4 — Re-run doctor on the healthy sample (deployment gate)
 
 ```bash
-azure-functions doctor examples/v2/http-trigger --profile minimal
+azure-functions-doctor doctor examples/v2/http-trigger --profile minimal
 ```
 
 Proceed only if the command exits with `0`.
@@ -312,19 +312,19 @@ jobs:
           pip install azure-functions-doctor
 
       - name: Run doctor (text)
-        run: azure-functions doctor . --profile minimal
+        run: azure-functions-doctor doctor . --profile minimal
 
       - name: Run doctor (JSON)
-        run: azure-functions doctor . --profile minimal --format json --output doctor-report.json
+        run: azure-functions-doctor doctor . --profile minimal --format json --output doctor-report.json
 
       - name: Run doctor (SARIF)
-        run: azure-functions doctor . --profile minimal --format sarif --output doctor-report.sarif
+        run: azure-functions-doctor doctor . --profile minimal --format sarif --output doctor-report.sarif
 
       - name: Run doctor (JUnit)
-        run: azure-functions doctor . --profile minimal --format junit --output doctor-report.xml
+        run: azure-functions-doctor doctor . --profile minimal --format junit --output doctor-report.xml
 
       - name: Run doctor (summary sidecar)
-        run: azure-functions doctor . --profile minimal --summary-json doctor-summary.json
+        run: azure-functions-doctor doctor . --profile minimal --summary-json doctor-summary.json
 
       - name: Publish
         if: success()
@@ -365,7 +365,7 @@ python3 --version
 az --version
 func --version
 pip show azure-functions-doctor
-azure-functions doctor . --profile minimal -v
+azure-functions-doctor doctor . --profile minimal -v
 ```
 
 ### Before opening an issue
@@ -386,7 +386,7 @@ python --version
 pip show azure-functions-doctor
 
 # 5. Doctor output on your project
-azure-functions doctor . -v
+azure-functions-doctor doctor . -v
 
 # 6. Function App status (if deployed)
 az functionapp show \

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,7 @@ make check-all
 ## Project Areas
 
 - `src/azure_functions_doctor/api.py`: stable programmatic API (`run_diagnostics`)
-- `src/azure_functions_doctor/cli.py`: Typer-based CLI (`azure-functions doctor`)
+- `src/azure_functions_doctor/cli.py`: Typer-based CLI (`azure-functions-doctor doctor`)
 - `src/azure_functions_doctor/doctor.py`: orchestration, rule loading, section aggregation
 - `src/azure_functions_doctor/handlers.py`: handler implementations and registry dispatch
 - `src/azure_functions_doctor/assets/rules/v2.json`: built-in diagnostics rules
@@ -121,7 +121,7 @@ def _handle_sample(self, rule: dict, path: Path) -> dict[str, str]:
 
 ## Debugging Tips
 
-- Use `azure-functions doctor --debug` to enable debug logging.
+- Use `azure-functions-doctor doctor --debug` to enable debug logging.
 - Use `--profile minimal` to isolate required checks first.
 - Run with `--format json` to inspect raw section/item output precisely.
 - Use `--rules <path>` to reproduce issues with a minimal custom ruleset.

--- a/docs/examples/basic_check.md
+++ b/docs/examples/basic_check.md
@@ -2,7 +2,7 @@
 
 This example shows a full local loop:
 
-1. Run `azure-functions doctor`
+1. Run `azure-functions-doctor doctor`
 2. Read failures and warnings
 3. Apply fixes
 4. Re-run until required failures are zero
@@ -19,13 +19,13 @@ Assume this project has common setup gaps:
 ## Step 1: Run the doctor
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 You can also target another folder:
 
 ```bash
-azure-functions doctor --path ./examples/v2/http-trigger
+azure-functions-doctor doctor --path ./examples/v2/http-trigger
 ```
 
 ## Step 2: Read status correctly
@@ -49,7 +49,7 @@ Exit codes:
 Verbose mode prints `fix:` hints for non-passing checks.
 
 ```bash
-azure-functions doctor --verbose
+azure-functions-doctor doctor --verbose
 ```
 
 This is the fastest way to map output directly to remediation.
@@ -100,13 +100,13 @@ def health(req: func.HttpRequest) -> func.HttpResponse:
 ## Step 5: Re-run
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 Desired summary shape:
 
 ```text
-Doctor summary (to see all details, run azure-functions doctor -v):
+Doctor summary (to see all details, run azure-functions-doctor doctor -v):
   0 fails, 2 warnings, 13 passed
 Exit code: 0
 ```
@@ -116,7 +116,7 @@ Warnings can remain while required baseline is clean.
 ## Step 6: Export JSON report
 
 ```bash
-azure-functions doctor --format json --output doctor-report.json
+azure-functions-doctor doctor --format json --output doctor-report.json
 ```
 
 The output file includes `metadata` and `results` fields.
@@ -150,13 +150,13 @@ If this returns `0`, required blockers are resolved.
 ## Optional: Generate SARIF for code scanning tools
 
 ```bash
-azure-functions doctor --format sarif --output doctor.sarif
+azure-functions-doctor doctor --format sarif --output doctor.sarif
 ```
 
 ## Optional: Generate JUnit for CI test views
 
 ```bash
-azure-functions doctor --format junit --output doctor-junit.xml
+azure-functions-doctor doctor --format junit --output doctor-junit.xml
 ```
 
 ## What this example validates

--- a/docs/examples/ci_integration.md
+++ b/docs/examples/ci_integration.md
@@ -11,7 +11,7 @@ This example shows how to enforce required diagnostics in CI and publish rich ar
 Recommended command:
 
 ```bash
-azure-functions doctor --profile minimal --format json --output doctor.json
+azure-functions-doctor doctor --profile minimal --format json --output doctor.json
 ```
 
 Why this works:
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run doctor (required checks)
         run: |
-          azure-functions doctor \
+          azure-functions-doctor doctor \
             --profile minimal \
             --format json \
             --output doctor.json
@@ -78,7 +78,7 @@ If you want to always upload artifacts before failing, split gate and report ste
         id: doctor
         run: |
           set +e
-          azure-functions doctor --profile minimal --format json --output doctor.json
+          azure-functions-doctor doctor --profile minimal --format json --output doctor.json
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
       - name: Upload doctor artifact
@@ -144,9 +144,9 @@ fi
 For richer ecosystem integration, emit multiple formats in separate steps:
 
 ```bash
-azure-functions doctor --profile minimal --format json --output doctor.json
-azure-functions doctor --profile minimal --format sarif --output doctor.sarif
-azure-functions doctor --profile minimal --format junit --output doctor-junit.xml
+azure-functions-doctor doctor --profile minimal --format json --output doctor.json
+azure-functions-doctor doctor --profile minimal --format sarif --output doctor.sarif
+azure-functions-doctor doctor --profile minimal --format junit --output doctor-junit.xml
 ```
 
 Then upload artifacts for each format.
@@ -169,7 +169,7 @@ strategy:
       - apps/payments-function
 
 steps:
-  - run: azure-functions doctor --path ${{ matrix.app_path }} --profile minimal --format json --output doctor-${{ matrix.app_path }}.json
+  - run: azure-functions-doctor doctor --path ${{ matrix.app_path }} --profile minimal --format json --output doctor-${{ matrix.app_path }}.json
 ```
 
 ## Common CI pitfalls
@@ -206,7 +206,7 @@ steps:
 
   - script: |
       set +e
-      azure-functions doctor \
+      azure-functions-doctor doctor \
         --profile minimal \
         --format json \
         --output $(Build.ArtifactStagingDirectory)/doctor.json
@@ -242,7 +242,7 @@ repos:
       - id: azure-functions-doctor
         name: Azure Functions Doctor
         language: system
-        entry: azure-functions doctor --profile minimal
+        entry: azure-functions-doctor doctor --profile minimal
         pass_filenames: false
         always_run: true
 ```
@@ -269,7 +269,7 @@ Run doctor from the VS Code command palette via a workspace task:
     {
       "label": "Azure Functions Doctor",
       "type": "shell",
-      "command": "azure-functions doctor --profile minimal --format json --output doctor.json",
+      "command": "azure-functions-doctor doctor --profile minimal --format json --output doctor.json",
       "group": "build",
       "presentation": {
         "echo": true,
@@ -294,7 +294,7 @@ Upload doctor results as SARIF to surface findings in the GitHub Security tab:
         id: doctor
         run: |
           set +e
-          azure-functions doctor \
+          azure-functions-doctor doctor \
             --profile minimal \
             --format sarif \
             --output doctor.sarif

--- a/docs/examples/custom_rules.md
+++ b/docs/examples/custom_rules.md
@@ -14,13 +14,13 @@ Use custom rules when built-in checks are not enough for your team policy, for e
 ## Command shape
 
 ```bash
-azure-functions doctor --rules ./rules/custom-rules.json
+azure-functions-doctor doctor --rules ./rules/custom-rules.json
 ```
 
 You can combine with profile and output flags:
 
 ```bash
-azure-functions doctor --rules ./rules/custom-rules.json --profile minimal --format json --output doctor-custom.json
+azure-functions-doctor doctor --rules ./rules/custom-rules.json --profile minimal --format json --output doctor-custom.json
 ```
 
 ## Minimal custom rules file
@@ -79,7 +79,7 @@ Create `rules/custom-rules.json`:
 ## Run with the custom file
 
 ```bash
-azure-functions doctor --rules ./rules/custom-rules.json --verbose
+azure-functions-doctor doctor --rules ./rules/custom-rules.json --verbose
 ```
 
 Expected behavior:
@@ -136,7 +136,7 @@ Current built-ins:
 Many teams keep a repository-local baseline rule file and run:
 
 ```bash
-azure-functions doctor --rules ./rules/org-baseline.json --profile minimal --format json --output doctor-org.json
+azure-functions-doctor doctor --rules ./rules/org-baseline.json --profile minimal --format json --output doctor-org.json
 ```
 
 This provides consistent policy in local and CI environments.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,13 +13,13 @@ See [Rule Inventory](rule_inventory.md) for the complete built-in list.
 ## How do I run it quickly?
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 Run against a different directory:
 
 ```bash
-azure-functions doctor --path ./my-function-app
+azure-functions-doctor doctor --path ./my-function-app
 ```
 
 ## How do I use it in CI?
@@ -27,7 +27,7 @@ azure-functions doctor --path ./my-function-app
 Use required-only profile plus JSON output:
 
 ```bash
-azure-functions doctor --profile minimal --format json --output doctor.json
+azure-functions-doctor doctor --profile minimal --format json --output doctor.json
 ```
 
 Then:
@@ -65,7 +65,7 @@ See [Minimal Profile](minimal_profile.md).
 Example:
 
 ```bash
-azure-functions doctor --format sarif --output doctor.sarif
+azure-functions-doctor doctor --format sarif --output doctor.sarif
 ```
 
 ## Is Markdown output supported?
@@ -146,7 +146,7 @@ Not by the doctor itself. Core Tools checks are optional in the built-in ruleset
 Use:
 
 ```bash
-azure-functions doctor --profile minimal --format json --output doctor.json
+azure-functions-doctor doctor --profile minimal --format json --output doctor.json
 ```
 
 That gives:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,19 +29,19 @@ Azure Functions Doctor validates v2-style projects and expects signals such as:
 Run from your project root:
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 Run against a specific path:
 
 ```bash
-azure-functions doctor --path ./my-function-app
+azure-functions-doctor doctor --path ./my-function-app
 ```
 
 Use verbose mode to show fix hints:
 
 ```bash
-azure-functions doctor --verbose
+azure-functions-doctor doctor --verbose
 ```
 
 ## 4) Understand output statuses
@@ -77,7 +77,7 @@ Python Env
 [✗] requirements.txt: /workspace/my-function-app/requirements.txt not found (fail)
 [✗] azure-functions package: Package 'azure-functions' not declared in requirements.txt (fail)
 
-Doctor summary (to see all details, run azure-functions doctor -v):
+Doctor summary (to see all details, run azure-functions-doctor doctor -v):
   2 fails, 1 warning, 5 passed
 Exit code: 1
 ```
@@ -146,13 +146,13 @@ def hello(req: func.HttpRequest) -> func.HttpResponse:
 Run all built-in checks (default behavior):
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 Run only required checks:
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 Use `minimal` for strict pass/fail gating and low-noise CI.
@@ -164,19 +164,19 @@ See [Minimal Profile](minimal_profile.md) for exact rule coverage.
 JSON:
 
 ```bash
-azure-functions doctor --format json --output doctor-report.json
+azure-functions-doctor doctor --format json --output doctor-report.json
 ```
 
 SARIF:
 
 ```bash
-azure-functions doctor --format sarif --output doctor.sarif
+azure-functions-doctor doctor --format sarif --output doctor.sarif
 ```
 
 JUnit:
 
 ```bash
-azure-functions doctor --format junit --output doctor-junit.xml
+azure-functions-doctor doctor --format junit --output doctor-junit.xml
 ```
 
 !!! note
@@ -205,7 +205,7 @@ See [API Reference](api.md) for detailed module docs.
 
 For teams adopting the doctor:
 
-1. Run `azure-functions doctor` locally during development
+1. Run `azure-functions-doctor doctor` locally during development
 2. Fix all required failures before PR creation
 3. Add CI gate using `--profile minimal --format json`
 4. Publish JSON/SARIF/JUnit artifacts for visibility

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,13 +17,13 @@ Install and run in the current project:
 
 ```bash
 python -m pip install azure-functions-doctor
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 Run required-only checks in CI:
 
 ```bash
-azure-functions doctor --profile minimal --format json --output doctor.json
+azure-functions-doctor doctor --profile minimal --format json --output doctor.json
 ```
 
 ## What it checks
@@ -65,7 +65,7 @@ This enables direct CI usage without custom gate wrappers.
 
 ## CLI and API entry points
 
-- CLI: `azure-functions doctor`
+- CLI: `azure-functions-doctor doctor`
 - API: `from azure_functions_doctor.api import run_diagnostics`
 
 Programmatic example:
@@ -116,7 +116,7 @@ def has_required_failures(path: str) -> bool:
 ## Typical adoption path
 
 1. Install package in your development environment
-2. Run `azure-functions doctor` locally and fix required failures
+2. Run `azure-functions-doctor doctor` locally and fix required failures
 3. Add CI job using `--profile minimal --format json`
 4. Publish JSON/SARIF/JUnit artifacts for visibility
 5. Add optional custom rules for organization-specific policy

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,7 +73,7 @@ azure-functions --help
 Run a first diagnostic in current directory:
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 If the command is available, installation succeeded. If checks fail, that means the tool is running correctly and found project issues.

--- a/docs/json_output_contract.md
+++ b/docs/json_output_contract.md
@@ -7,7 +7,7 @@ This page defines field meanings, stability guarantees, and parser examples.
 ## Emit JSON
 
 ```bash
-azure-functions doctor --format json --output doctor.json
+azure-functions-doctor doctor --format json --output doctor.json
 ```
 
 If `--output` is omitted, JSON is printed to stdout.

--- a/docs/minimal_profile.md
+++ b/docs/minimal_profile.md
@@ -74,19 +74,19 @@ These remain available in full profile.
 Local blocker-only check:
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 CI-friendly JSON artifact:
 
 ```bash
-azure-functions doctor --profile minimal --format json --output doctor.json
+azure-functions-doctor doctor --profile minimal --format json --output doctor.json
 ```
 
 Path-targeted monorepo check:
 
 ```bash
-azure-functions doctor --path ./apps/orders-function --profile minimal
+azure-functions-doctor doctor --path ./apps/orders-function --profile minimal
 ```
 
 ## Exit code behavior in minimal

--- a/docs/scaffold_integration.md
+++ b/docs/scaffold_integration.md
@@ -31,7 +31,7 @@ The intended handoff: scaffold creates the project skeleton, doctor confirms it 
 scaffold new project
       │
       ▼
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
       │
       ├── all pass → ready for development
       │
@@ -51,7 +51,7 @@ func new --name HttpTrigger --template "HTTP trigger"
 **2. Run doctor immediately:**
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 A freshly scaffolded project should pass all five required checks:
@@ -69,13 +69,13 @@ A freshly scaffolded project should pass all five required checks:
 ```bash
 # Example: missing azure-functions in requirements.txt
 echo "azure-functions" >> requirements.txt
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 **4. Optionally run full diagnostics for local guidance:**
 
 ```bash
-azure-functions doctor --verbose
+azure-functions-doctor doctor --verbose
 ```
 
 This surfaces optional warnings (virtual environment, Core Tools version, extension bundle, etc.) without blocking on them.
@@ -111,7 +111,7 @@ jobs:
 
       - name: Run preflight check
         run: |
-          azure-functions doctor \
+          azure-functions-doctor doctor \
             --profile minimal \
             --format json \
             --output doctor.json
@@ -134,7 +134,7 @@ The artifact upload uses `if: always()` to preserve the report even on failure.
 Use `--format json` to produce a machine-readable report for downstream processing.
 
 ```bash
-azure-functions doctor --profile minimal --format json --output doctor.json
+azure-functions-doctor doctor --profile minimal --format json --output doctor.json
 ```
 
 The output structure:
@@ -193,7 +193,7 @@ Surface doctor findings in the GitHub Security tab by emitting SARIF and uploadi
         id: doctor
         run: |
           set +e
-          azure-functions doctor \
+          azure-functions-doctor doctor \
             --profile minimal \
             --format sarif \
             --output doctor.sarif
@@ -235,7 +235,7 @@ The SARIF report maps:
 Use `--format junit` to emit a JUnit XML report compatible with GitHub Actions test summaries, Azure DevOps test results, and Jenkins.
 
 ```bash
-azure-functions doctor --profile minimal --format junit --output doctor-junit.xml
+azure-functions-doctor doctor --profile minimal --format junit --output doctor-junit.xml
 ```
 
 GitHub Actions test summary:
@@ -243,7 +243,7 @@ GitHub Actions test summary:
 ```yaml
       - name: Run doctor (JUnit)
         run: |
-          azure-functions doctor \
+          azure-functions-doctor doctor \
             --profile minimal \
             --format junit \
             --output doctor-junit.xml
@@ -262,9 +262,9 @@ GitHub Actions test summary:
 Emit all formats in a single pipeline run for maximum ecosystem coverage:
 
 ```bash
-azure-functions doctor --profile minimal --format json   --output doctor.json
-azure-functions doctor --profile minimal --format sarif  --output doctor.sarif
-azure-functions doctor --profile minimal --format junit  --output doctor-junit.xml
+azure-functions-doctor doctor --profile minimal --format json   --output doctor.json
+azure-functions-doctor doctor --profile minimal --format sarif  --output doctor.sarif
+azure-functions-doctor doctor --profile minimal --format junit  --output doctor-junit.xml
 ```
 
 The exit code of the first command drives pass/fail.
@@ -287,7 +287,7 @@ strategy:
 steps:
   - name: Run doctor
     run: |
-      azure-functions doctor \
+      azure-functions-doctor doctor \
         --path ${{ matrix.app_path }} \
         --profile minimal \
         --format json \

--- a/docs/supported_versions.md
+++ b/docs/supported_versions.md
@@ -69,7 +69,7 @@ strategy:
 
 ## CLI and API Compatibility Expectations
 
-- CLI command surface: `azure-functions doctor` with documented options.
+- CLI command surface: `azure-functions-doctor doctor` with documented options.
 - Public API surface: `run_diagnostics(path, profile, rules_path)`.
 - Changes to public behavior should be reflected in tests, docs, and release notes.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,7 +61,7 @@ The CLI validates that target path:
 Action:
 
 ```bash
-azure-functions doctor --path ./correct/project/path
+azure-functions-doctor doctor --path ./correct/project/path
 ```
 
 ### Problem: unknown profile error
@@ -71,7 +71,7 @@ Only `minimal` and `full` are valid profile values.
 Action:
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 ### Problem: invalid format error
@@ -154,7 +154,7 @@ Common causes:
 Action:
 
 ```bash
-azure-functions doctor --format json --output doctor.json
+azure-functions-doctor doctor --format json --output doctor.json
 ```
 
 Then parse `doctor.json` only.
@@ -237,19 +237,19 @@ Recommended issue report contents:
 Verbose local run:
 
 ```bash
-azure-functions doctor --verbose
+azure-functions-doctor doctor --verbose
 ```
 
 Debug run:
 
 ```bash
-azure-functions doctor --debug
+azure-functions-doctor doctor --debug
 ```
 
 Required-only CI run:
 
 ```bash
-azure-functions doctor --profile minimal --format json --output doctor.json
+azure-functions-doctor doctor --profile minimal --format json --output doctor.json
 ```
 
 ## Related docs

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,13 +1,13 @@
 # CLI Usage
 
-`azure-functions doctor` validates Azure Functions Python v2 projects and reports required failures versus optional warnings.
+`azure-functions-doctor doctor` validates Azure Functions Python v2 projects and reports required failures versus optional warnings.
 
 This page is the complete command and workflow reference.
 
 ## Command summary
 
 ```bash
-azure-functions doctor [OPTIONS]
+azure-functions-doctor doctor [OPTIONS]
 ```
 
 The command supports human-readable and machine-readable workflows:
@@ -22,37 +22,37 @@ The command supports human-readable and machine-readable workflows:
 Current directory:
 
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 Specific path:
 
 ```bash
-azure-functions doctor --path ./apps/orders-function
+azure-functions-doctor doctor --path ./apps/orders-function
 ```
 
 Required-only profile:
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 JSON artifact:
 
 ```bash
-azure-functions doctor --format json --output doctor.json
+azure-functions-doctor doctor --format json --output doctor.json
 ```
 
 Verbose fix hints:
 
 ```bash
-azure-functions doctor --verbose
+azure-functions-doctor doctor --verbose
 ```
 
 Target runtime override:
 
 ```bash
-azure-functions doctor --target-python 3.12
+azure-functions-doctor doctor --target-python 3.12
 ```
 
 ## Full option reference
@@ -95,7 +95,7 @@ Section status is `fail` if any required check in the section failed.
 Best for local terminal feedback.
 
 ```bash
-azure-functions doctor --format table
+azure-functions-doctor doctor --format table
 ```
 
 Includes:
@@ -110,7 +110,7 @@ Includes:
 Best for CI automation and post-processing.
 
 ```bash
-azure-functions doctor --format json --output doctor.json
+azure-functions-doctor doctor --format json --output doctor.json
 ```
 
 JSON includes:
@@ -125,7 +125,7 @@ Contract details: [JSON Output Contract](json_output_contract.md)
 Best for code scanning integrations.
 
 ```bash
-azure-functions doctor --format sarif --output doctor.sarif
+azure-functions-doctor doctor --format sarif --output doctor.sarif
 ```
 
 Generated document follows SARIF `2.1.0` structure.
@@ -135,7 +135,7 @@ Generated document follows SARIF `2.1.0` structure.
 Best for CI systems that visualize test suites.
 
 ```bash
-azure-functions doctor --format junit --output doctor-junit.xml
+azure-functions-doctor doctor --format junit --output doctor-junit.xml
 ```
 
 Each diagnostic item is represented as a test case.
@@ -145,13 +145,13 @@ Each diagnostic item is represented as a test case.
 Single app repository:
 
 ```bash
-azure-functions doctor --path .
+azure-functions-doctor doctor --path .
 ```
 
 Monorepo app path:
 
 ```bash
-azure-functions doctor --path ./services/payments-function
+azure-functions-doctor doctor --path ./services/payments-function
 ```
 
 Use explicit paths in CI to avoid accidental root-level checks.
@@ -176,7 +176,7 @@ tool runtime and table output adds `Target Python: X.Y (override)` near the head
 Example:
 
 ```bash
-azure-functions doctor --path ./apps/orders-function --target-python 3.12
+azure-functions-doctor doctor --path ./apps/orders-function --target-python 3.12
 ```
 
 When omitted, doctor keeps checking the current interpreter and labels it as the
@@ -194,7 +194,7 @@ If `--profile` is omitted, behavior is equivalent to `full`.
 ### Minimal profile
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 `minimal` includes only `required: true` rules.
@@ -212,7 +212,7 @@ Reference: [Minimal Profile](minimal_profile.md)
 Run with custom rule file:
 
 ```bash
-azure-functions doctor --rules ./rules/custom.json
+azure-functions-doctor doctor --rules ./rules/custom.json
 ```
 
 The file must:
@@ -230,7 +230,7 @@ Reference: [Rules](rules.md), [Custom Rules Example](examples/custom_rules.md)
 ### Verbose mode
 
 ```bash
-azure-functions doctor --verbose
+azure-functions-doctor doctor --verbose
 ```
 
 Shows `fix:` guidance for non-passing checks in table output.
@@ -238,7 +238,7 @@ Shows `fix:` guidance for non-passing checks in table output.
 ### Debug mode
 
 ```bash
-azure-functions doctor --debug
+azure-functions-doctor doctor --debug
 ```
 
 Enables debug logging for diagnosing CLI internals and environment issues.
@@ -248,31 +248,31 @@ Enables debug logging for diagnosing CLI internals and environment issues.
 ### Local fast check
 
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 ### Local full quality sweep
 
 ```bash
-azure-functions doctor --profile full --verbose
+azure-functions-doctor doctor --profile full --verbose
 ```
 
 ### CI gate (required only)
 
 ```bash
-azure-functions doctor --profile minimal --format json --output doctor.json
+azure-functions-doctor doctor --profile minimal --format json --output doctor.json
 ```
 
 ### SARIF generation
 
 ```bash
-azure-functions doctor --profile minimal --format sarif --output doctor.sarif
+azure-functions-doctor doctor --profile minimal --format sarif --output doctor.sarif
 ```
 
 ### JUnit publishing
 
 ```bash
-azure-functions doctor --profile minimal --format junit --output doctor-junit.xml
+azure-functions-doctor doctor --profile minimal --format junit --output doctor-junit.xml
 ```
 
 ## CI usage patterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,10 @@ docs = [
 ]
 
 [project.scripts]
-azure-functions = "azure_functions_doctor.cli:cli"
 azure-functions-doctor = "azure_functions_doctor.cli:cli"
-fdoctor = "azure_functions_doctor.cli:cli"
+# Deprecated aliases (removal targeted for v1.0.0); emit a deprecation notice.
+azure-functions = "azure_functions_doctor.cli:azure_functions_alias"
+fdoctor = "azure_functions_doctor.cli:fdoctor_alias"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -384,7 +384,7 @@ def doctor(
     # Use the precomputed counts from earlier for final output
     console.print()
     # Print Doctor summary at the bottom like the requested sample
-    console.print("Doctor summary (to see all details, run azure-functions doctor -v):")
+    console.print("Doctor summary (to see all details, run azure-functions-doctor doctor -v):")
     # Use singular/plural simple form as in sample (error vs errors)
     # Summary now reflects canonical statuses: fails, warnings, passed
     w_label = "warning" if warning_count == 1 else "warnings"
@@ -399,6 +399,34 @@ def doctor(
 
 # Explicit command registration (test-friendly)
 cli.command()(doctor)
+
+
+# Deprecated console-script aliases. `azure-functions-doctor` is the canonical
+# command; these wrappers emit a deprecation notice (to stderr, so structured
+# stdout output such as JSON/SARIF stays clean) and then delegate to the CLI.
+# Removal is targeted for the next major release (v1.0.0).
+_CANONICAL_COMMAND = "azure-functions-doctor"
+
+
+def _warn_deprecated_alias(alias: str) -> None:
+    """Emit a deprecation notice for a legacy console-script alias."""
+    Console(stderr=True).print(
+        f"[yellow]Warning:[/yellow] the '{alias}' command is deprecated and will be "
+        f"removed in a future release (targeted for v1.0.0). "
+        f"Use '{_CANONICAL_COMMAND}' instead."
+    )
+
+
+def azure_functions_alias() -> None:
+    """Deprecated alias entry point for the `azure-functions` console script."""
+    _warn_deprecated_alias("azure-functions")
+    cli()
+
+
+def fdoctor_alias() -> None:
+    """Deprecated alias entry point for the `fdoctor` console script."""
+    _warn_deprecated_alias("fdoctor")
+    cli()
 
 if __name__ == "__main__":
     cli()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -275,3 +275,35 @@ def test_validate_inputs_invalid_output_path_raises(
 def test_cli_debug_mode_prints_debug_banner() -> None:
     result = runner.invoke(app, ["doctor", "--debug"])
     assert "Debug logging enabled" in result.output
+
+
+def test_azure_functions_alias_warns_and_delegates(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Deprecated `azure-functions` alias warns on stderr and delegates to cli()."""
+    cli_mock = Mock()
+    monkeypatch.setattr(cli_module, "cli", cli_mock)
+
+    cli_module.azure_functions_alias()
+
+    cli_mock.assert_called_once_with()
+    err = capsys.readouterr().err
+    assert "deprecated" in err
+    assert "v1.0.0" in err
+
+
+def test_fdoctor_alias_warns_and_delegates(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Deprecated `fdoctor` alias warns on stderr and delegates to cli()."""
+    cli_mock = Mock()
+    monkeypatch.setattr(cli_module, "cli", cli_mock)
+
+    cli_module.fdoctor_alias()
+
+    cli_mock.assert_called_once_with()
+    err = capsys.readouterr().err
+    assert "deprecated" in err
+    assert "v1.0.0" in err


### PR DESCRIPTION
## Summary
Consolidates on `azure-functions-doctor` as the canonical console command and deprecates the `azure-functions` and `fdoctor` aliases.

- `pyproject.toml` aliases now point to dedicated wrapper entry points (`azure_functions_alias`, `fdoctor_alias`) that emit a deprecation notice on **stderr** (so JSON/SARIF stdout stays clean) and then delegate to the CLI. Removal targeted for **v1.0.0**.
- README + `README.ko.md` / `README.ja.md` / `README.zh-CN.md` updated to use the canonical command and document the deprecation/removal timeline.
- Added tests for both alias wrappers.

## Testing
- `make check-all` passes (coverage >= 95%).

Closes #235