### PR TITLE
feat(handlers): support pyproject-only projects without requirements.txt

### DIFF
--- a/docs/rule_inventory.md
+++ b/docs/rule_inventory.md
@@ -14,7 +14,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `check_python_version` | Python version | environment | python_env | `compare_version` | Yes | minimal, full |
 | `check_venv` | Virtual environment | environment | python_env | `any_of_exists` | No | full |
 | `check_python_executable` | Python executable | environment | python_env | `path_exists` | No | full |
-| `check_requirements_txt` | requirements.txt | dependencies | python_env | `file_exists` | Yes | minimal, full |
+| `check_requirements_txt` | requirements.txt | dependencies | python_env | `dependency_manifest` | Yes | minimal, full |
 | `check_azure_functions_library` | azure-functions package | dependencies | python_env | `package_declared` | Yes | minimal, full |
 | `check_native_dependency_risk` | Native dependency risk | dependencies | python_env | `native_dependency_risk` | No | full |
 | `check_azure_functions_worker` | azure-functions-worker not pinned | dependencies | python_env | `package_forbidden` | No | full |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "jsonschema",
     "packaging",
     "rich",
+    "tomli>=2.0; python_version < '3.11'",
     "typer",
 ]
 

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -90,18 +90,18 @@
     "category": "dependencies",
     "section": "python_env",
     "label": "requirements.txt",
-    "description": "Checks if requirements.txt exists at the project root.",
-    "type": "file_exists",
+    "description": "Checks that dependencies are declared via requirements.txt or pyproject.toml.",
+    "type": "dependency_manifest",
     "required": true,
     "condition": {
       "target": "requirements.txt"
     },
-    "hint": "Add a requirements.txt file to declare your dependencies.",
+    "hint": "Add a requirements.txt file (or declare dependencies in pyproject.toml) to install your packages.",
     "hint_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#managing-dependencies",
     "source_type": "ms_learn",
     "source_title": "Azure Functions Python developer guide — Managing dependencies",
     "source_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#managing-dependencies",
-    "why_it_matters": "Azure Functions reads requirements.txt to install packages at deployment time. Without it, the runtime cannot resolve dependencies and the function app will fail to start.",
+    "why_it_matters": "Azure Functions installs from requirements.txt at deployment time. Projects that manage dependencies in pyproject.toml typically generate requirements.txt during packaging, so either manifest satisfies this check.",
     "symptoms": "ModuleNotFoundError at runtime; deployment pipeline fails with missing package errors; cold start crashes.",
     "fix_command": "pip freeze > requirements.txt",
     "check_order": 4
@@ -111,7 +111,7 @@
     "category": "dependencies",
     "section": "python_env",
     "label": "azure-functions package",
-    "description": "Checks if the azure-functions package is declared in requirements.txt.",
+    "description": "Checks if the azure-functions package is declared in requirements.txt or pyproject.toml.",
     "type": "package_declared",
     "required": true,
     "condition": {

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -19,6 +19,11 @@ from typing import (
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 
+try:  # Python 3.11+ ships tomllib in the stdlib
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
+    import tomli as tomllib
+
 from azure_functions_doctor.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -637,6 +642,63 @@ def _parse_requirements_names(content: str) -> set[str]:
             if name:
                 names.add(canonicalize_name(name))
     return names
+
+
+def _load_pyproject(path: Path) -> Optional[Dict[str, object]]:
+    """Load and parse ``pyproject.toml`` from ``path``.
+
+    Returns the parsed table, or ``None`` when the file is absent, unreadable,
+    or not valid TOML.
+    """
+    pyproject_path = path / "pyproject.toml"
+    if not pyproject_path.exists():
+        return None
+    try:
+        with pyproject_path.open("rb") as handle:
+            data: Dict[str, object] = tomllib.load(handle)
+            return data
+            return tomllib.load(handle)
+    except (OSError, ValueError) as exc:
+        logger.debug(f"Skip pyproject.toml at {pyproject_path}: {exc}")
+        return None
+
+
+def pyproject_dependency_names(path: Path) -> set[str]:
+    """Return canonicalized dependency names declared in ``pyproject.toml``.
+
+    Collects names from ``[project].dependencies`` and every
+    ``[project.optional-dependencies]`` group. Unparseable specifiers are
+    skipped. Returns an empty set when no manifest or dependencies exist.
+    """
+    data = _load_pyproject(path)
+    if not data:
+        return set()
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return set()
+    specs: list[str] = []
+    deps = project.get("dependencies")
+    if isinstance(deps, list):
+        specs.extend(str(item) for item in deps)
+    optional = project.get("optional-dependencies")
+    if isinstance(optional, dict):
+        for group in optional.values():
+            if isinstance(group, list):
+                specs.extend(str(item) for item in group)
+    names: set[str] = set()
+    for spec in specs:
+        try:
+            names.add(canonicalize_name(Requirement(spec).name))
+        except InvalidRequirement:
+            continue
+    return names
+
+
+def pyproject_declares_dependencies(path: Path) -> bool:
+    """Return True when ``pyproject.toml`` declares any runtime or optional
+    dependency in the standard ``[project]`` table.
+    """
+    return bool(pyproject_dependency_names(path))
 
 
 def _detect_native_dependency_risks(content: str) -> list[tuple[str, str]]:

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -43,6 +43,8 @@ from azure_functions_doctor.handlers._helpers import (
     parse_package,
     parse_source_code,
     parse_target,
+    pyproject_declares_dependencies,
+    pyproject_dependency_names,
 )
 from azure_functions_doctor.target_resolver import resolve_target_value
 
@@ -193,6 +195,33 @@ class HandlerRegistry:
         return _create_result("pass" if exists else "fail", detail)
 
     @_rule_handler
+    def _handle_dependency_manifest(
+        self, rule: Rule, path: Path, context: Optional[RuleContext] = None
+    ) -> HandlerResult:
+        """Pass when the project declares dependencies via requirements.txt OR
+        pyproject.toml.
+
+        Azure Functions installs from requirements.txt at deploy time, but many
+        modern projects manage dependencies in ``pyproject.toml`` and generate
+        requirements.txt during packaging. Accept either manifest so
+        pyproject-only projects are not reported as broken.
+        """
+        condition = rule.get("condition", {}) or {}
+        target = parse_target(condition) or "requirements.txt"
+        req_path = path / target
+        if req_path.is_file():
+            return _create_result("pass", f"{req_path} exists")
+        if pyproject_declares_dependencies(path):
+            return _create_result(
+                "pass",
+                f"{req_path} not found; dependencies declared in pyproject.toml",
+            )
+        detail = f"{req_path} not found and pyproject.toml declares no dependencies"
+        if not rule.get("required", True):
+            detail += " (optional)"
+        return _create_result("fail", detail)
+
+    @_rule_handler
     def _handle_package_installed(
         self, rule: Rule, path: Path, context: Optional[RuleContext] = None
     ) -> HandlerResult:
@@ -257,15 +286,31 @@ class HandlerRegistry:
         if params is None:
             return _create_result("fail", "Missing 'package' in condition")
         package_name, req_file = params
+        normalized_target = canonicalize_name(package_name)
         req_path = path / Path(req_file)
         if not req_path.exists():
-            return _create_result("fail", f"{req_path} not found")
+            # No requirements.txt: fall back to pyproject.toml so pyproject-only
+            # projects can still declare the package.
+            if normalized_target in pyproject_dependency_names(path):
+                return _create_result(
+                    "pass",
+                    f"Package '{package_name}' declared in pyproject.toml",
+                )
+            return _create_result(
+                "fail",
+                f"{req_path} not found and '{package_name}' not declared in pyproject.toml",
+            )
         try:
             content = req_path.read_text(encoding="utf-8")
         except Exception as exc:
             return _handle_specific_exceptions(f"reading {req_file}", exc)
         normalized = _parse_requirements_names(content)
-        declared = canonicalize_name(package_name) in normalized
+        declared = normalized_target in normalized
+        if not declared and normalized_target in pyproject_dependency_names(path):
+            return _create_result(
+                "pass",
+                f"Package '{package_name}' declared in pyproject.toml",
+            )
         return _create_result(
             "pass" if declared else "fail",
             f"Package '{package_name}' {'declared' if declared else 'not declared'} in {req_file}",

--- a/src/azure_functions_doctor/schemas/rules.schema.json
+++ b/src/azure_functions_doctor/schemas/rules.schema.json
@@ -50,6 +50,7 @@
         "enum": [
           "compare_version",
           "file_exists",
+          "dependency_manifest",
           "env_var_exists",
           "package_installed",
           "package_declared",

--- a/tests/test_pyproject_dependency_manifest.py
+++ b/tests/test_pyproject_dependency_manifest.py
@@ -1,0 +1,163 @@
+"""Tests for pyproject-only dependency declaration support (issue #242).
+
+Covers the ``dependency_manifest`` rule handler and the ``package_declared``
+pyproject.toml fallback, plus the pure pyproject helper functions, so that
+projects managing dependencies in ``pyproject.toml`` (without a
+``requirements.txt``) are not reported as broken.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+
+from azure_functions_doctor.handlers._helpers import (
+    Rule,
+    pyproject_declares_dependencies,
+    pyproject_dependency_names,
+)
+from azure_functions_doctor.handlers.registry import HandlerRegistry
+
+registry = HandlerRegistry()
+
+
+def _write(path: Path, name: str, content: str) -> None:
+    (path / name).write_text(content, encoding="utf-8")
+
+
+def _status(rule_type: str, path: Path, condition: dict[str, Any] | None = None) -> str:
+    rule = cast(
+        Rule,
+        {"type": rule_type, "required": True, "condition": condition or {}},
+    )
+    return registry.handle(rule, path)["status"]
+
+
+_PYPROJECT_WITH_DEPS = """\
+[project]
+name = "demo"
+version = "0.1.0"
+dependencies = [
+    "azure-functions>=1.17",
+    "requests[security]>=2.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+"""
+
+_PYPROJECT_NO_DEPS = """\
+[project]
+name = "demo"
+version = "0.1.0"
+"""
+
+
+# ---------------------------------------------------------------------------
+# pyproject helpers
+# ---------------------------------------------------------------------------
+
+
+def test_pyproject_dependency_names_collects_all_groups(tmp_path: Path) -> None:
+    _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
+    names = pyproject_dependency_names(tmp_path)
+    assert names == {"azure-functions", "requests", "pytest"}
+
+
+def test_pyproject_dependency_names_missing_file(tmp_path: Path) -> None:
+    assert pyproject_dependency_names(tmp_path) == set()
+
+
+def test_pyproject_dependency_names_no_project_table(tmp_path: Path) -> None:
+    _write(tmp_path, "pyproject.toml", "[build-system]\nrequires = ['hatchling']\n")
+    assert pyproject_dependency_names(tmp_path) == set()
+
+
+def test_pyproject_dependency_names_invalid_toml(tmp_path: Path) -> None:
+    _write(tmp_path, "pyproject.toml", "this is = = not toml [[[")
+    assert pyproject_dependency_names(tmp_path) == set()
+
+
+def test_pyproject_dependency_names_skips_unparseable_spec(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "pyproject.toml",
+        '[project]\nname = "d"\ndependencies = ["===bad===", "rich"]\n',
+    )
+    assert pyproject_dependency_names(tmp_path) == {"rich"}
+
+
+def test_pyproject_declares_dependencies_true_and_false(tmp_path: Path) -> None:
+    _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
+    assert pyproject_declares_dependencies(tmp_path) is True
+
+    other = tmp_path / "empty"
+    other.mkdir()
+    _write(other, "pyproject.toml", _PYPROJECT_NO_DEPS)
+    assert pyproject_declares_dependencies(other) is False
+
+
+# ---------------------------------------------------------------------------
+# dependency_manifest handler
+# ---------------------------------------------------------------------------
+
+
+def test_dependency_manifest_pass_with_requirements(tmp_path: Path) -> None:
+    _write(tmp_path, "requirements.txt", "azure-functions\n")
+    assert _status("dependency_manifest", tmp_path) == "pass"
+
+
+def test_dependency_manifest_pass_with_pyproject_only(tmp_path: Path) -> None:
+    _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
+    assert _status("dependency_manifest", tmp_path) == "pass"
+
+
+def test_dependency_manifest_fail_when_neither(tmp_path: Path) -> None:
+    assert _status("dependency_manifest", tmp_path) == "fail"
+
+
+def test_dependency_manifest_fail_pyproject_without_deps(tmp_path: Path) -> None:
+    _write(tmp_path, "pyproject.toml", _PYPROJECT_NO_DEPS)
+    assert _status("dependency_manifest", tmp_path) == "fail"
+
+
+def test_dependency_manifest_optional_marks_detail(tmp_path: Path) -> None:
+    rule = cast(
+        Rule,
+        {"type": "dependency_manifest", "required": False, "condition": {}},
+    )
+    result = registry.handle(rule, tmp_path)
+    assert result["status"] == "fail"
+    assert "(optional)" in result["detail"]
+
+
+# ---------------------------------------------------------------------------
+# package_declared pyproject fallback
+# ---------------------------------------------------------------------------
+
+_PKG_CONDITION = {"package": "azure-functions", "file": "requirements.txt"}
+
+
+def test_package_declared_requirements_still_wins(tmp_path: Path) -> None:
+    _write(tmp_path, "requirements.txt", "azure-functions\n")
+    assert _status("package_declared", tmp_path, _PKG_CONDITION) == "pass"
+
+
+def test_package_declared_pyproject_fallback_no_requirements(tmp_path: Path) -> None:
+    _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
+    assert _status("package_declared", tmp_path, _PKG_CONDITION) == "pass"
+
+
+def test_package_declared_pyproject_fallback_when_requirements_lacks_it(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path, "requirements.txt", "rich\n")
+    _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
+    assert _status("package_declared", tmp_path, _PKG_CONDITION) == "pass"
+
+
+def test_package_declared_fail_when_missing_everywhere(tmp_path: Path) -> None:
+    _write(tmp_path, "pyproject.toml", _PYPROJECT_NO_DEPS)
+    assert _status("package_declared", tmp_path, _PKG_CONDITION) == "fail"
+
+
+def test_package_declared_fail_no_manifest_at_all(tmp_path: Path) -> None:
+    assert _status("package_declared", tmp_path, _PKG_CONDITION) == "fail"


### PR DESCRIPTION
## Summary
- Adds a `dependency_manifest` rule type that passes when a project declares dependencies via **requirements.txt OR pyproject.toml**, so pyproject-only projects are no longer reported as broken.
- Lets the `package_declared` handler (used by the `azure-functions` check) fall back to `pyproject.toml` when `requirements.txt` is absent or does not list the package.
- Retypes `check_requirements_txt` from `file_exists` to `dependency_manifest` in `v2.json` and registers the new type in `rules.schema.json`.

## Details
- New pure helpers in `handlers/_helpers.py`: `_load_pyproject`, `pyproject_dependency_names`, `pyproject_declares_dependencies`, with a `tomllib` (3.11+) / `tomli` (3.10) conditional import.
- Adds `tomli>=2.0; python_version < '3.11'` to runtime dependencies.
- Regenerated `docs/rule_inventory.md`.

## Testing
- New `tests/test_pyproject_dependency_manifest.py` covers: pyproject-only pass, `azure-functions` declared in pyproject pass, requirements.txt regression, and neither-present fail.
- `make check-all` passes: 462 passed, 2 skipped, coverage 96.37% (>= 95%).

Closes #242