### PR TITLE
docs: add migration guide for deprecated azure-functions/fdoctor aliases

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -94,6 +94,9 @@ azure-functions-doctor doctor --format json
 v1.0.0 リリースでエイリアスが削除される前に、スクリプトや CI パイプラインを
 `azure-functions-doctor` に移行してください。
 
+シェルスクリプト、GitHub Actions、Makefile、pre-commit フックをカバーする
+ステップバイステップの例は、[非推奨エイリアス移行ガイド](docs/deprecated-aliases.md)を参照してください。
+
 ## Demo
 
 以下のデモは、VHS を使用して [`demo/doctor-demo.tape`](demo/doctor-demo.tape) から生成されました。

--- a/README.ko.md
+++ b/README.ko.md
@@ -94,6 +94,9 @@ azure-functions-doctor doctor --format json
 v1.0.0 릴리스에서 별칭이 제거되기 전에 스크립트나 CI 파이프라인을
 `azure-functions-doctor`로 마이그레이션하세요.
 
+셸 스크립트, GitHub Actions, Makefile, pre-commit 훅을 다루는 단계별 예시는
+[사용 중단된 별칭 마이그레이션 가이드](docs/deprecated-aliases.md)를 참고하세요.
+
 ## Demo
 
 아래 데모는 VHS를 사용하여 [`demo/doctor-demo.tape`](demo/doctor-demo.tape)에서 생성되었습니다.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ aliases still work but are **deprecated** and print a warning when invoked:
 Migrate any scripts or CI pipelines to `azure-functions-doctor` before the
 v1.0.0 release removes the aliases.
 
+See the [deprecated aliases migration guide](docs/deprecated-aliases.md) for
+step-by-step examples covering shell scripts, GitHub Actions, Makefiles, and
+pre-commit hooks.
+
 ### Sample output (excerpt)
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -93,6 +93,9 @@ azure-functions-doctor doctor --format json
 请在 v1.0.0 发布移除别名之前，将脚本或 CI 流水线迁移到
 `azure-functions-doctor`。
 
+有关涵盖 shell 脚本、GitHub Actions、Makefile 和 pre-commit 钩子的逐步示例，
+请参阅[已弃用别名迁移指南](docs/deprecated-aliases.md)。
+
 ## Demo
 
 以下演示是使用 VHS 从 [`demo/doctor-demo.tape`](demo/doctor-demo.tape) 生成的。

--- a/docs/deprecated-aliases.md
+++ b/docs/deprecated-aliases.md
@@ -1,0 +1,107 @@
+# Migrating off deprecated command aliases
+
+`azure-functions-doctor` is the **canonical** command. Two legacy console-script
+aliases — `azure-functions` and `fdoctor` — still work but are **deprecated** and
+print a warning to stderr when invoked. Both are scheduled for removal in
+**v1.0.0**.
+
+This guide explains what changes, why, and exactly how to migrate scripts and CI
+pipelines before the aliases are removed.
+
+## What is deprecated
+
+| Command | Status | Action |
+| --- | --- | --- |
+| `azure-functions-doctor` | Canonical | Use this. No change needed. |
+| `azure-functions` | Deprecated (removal in v1.0.0) | Replace with `azure-functions-doctor`. |
+| `fdoctor` | Deprecated (removal in v1.0.0) | Replace with `azure-functions-doctor`. |
+
+The deprecated aliases are thin wrappers. They emit a one-line deprecation notice
+to stderr and then delegate to the exact same diagnostics engine as
+`azure-functions-doctor`, so **behavior and exit codes are identical** during the
+deprecation window. Only the invocation name changes.
+
+## Why the change
+
+Multiple entry points for one tool cause avoidable friction:
+
+- **Discoverability** — `azure-functions` collides conceptually with the
+  `azure-functions` PyPI SDK package, and `fdoctor` is not self-describing.
+- **Documentation drift** — every example, CI snippet, and troubleshooting note
+  has to be kept correct for three names instead of one.
+- **Predictable tooling** — a single canonical command is easier to pin, cache,
+  and reason about in automation.
+
+Consolidating on `azure-functions-doctor` removes that ambiguity.
+
+## How to migrate
+
+### 1. Shell scripts and local usage
+
+Replace the alias with the canonical command:
+
+```bash
+# Before
+fdoctor --path .
+azure-functions doctor --path .
+
+# After
+azure-functions-doctor doctor --path .
+```
+
+### 2. GitHub Actions
+
+```yaml
+# Before
+- run: |
+    pip install azure-functions-doctor
+    fdoctor doctor --profile minimal --format json --output doctor.json
+
+# After
+- run: |
+    pip install azure-functions-doctor
+    azure-functions-doctor doctor --profile minimal --format json --output doctor.json
+```
+
+### 3. Makefiles and task runners
+
+```makefile
+# Before
+doctor:
+	fdoctor doctor --path .
+
+# After
+doctor:
+	azure-functions-doctor doctor --path .
+```
+
+### 4. pre-commit hooks
+
+```yaml
+# Before
+- id: azure-functions-doctor
+  entry: fdoctor doctor
+# After
+- id: azure-functions-doctor
+  entry: azure-functions-doctor doctor
+```
+
+## Finding remaining usages
+
+Search your repository for the deprecated names before v1.0.0:
+
+```bash
+grep -rnE '\b(fdoctor|azure-functions doctor)\b' \
+  --include='*.sh' --include='*.yml' --include='*.yaml' \
+  --include='Makefile' --include='*.mk' .
+```
+
+Anything the search returns should be updated to `azure-functions-doctor`.
+
+## Timeline
+
+- **Now** — Aliases work and print a deprecation warning on stderr. No breakage.
+- **v1.0.0** — Aliases are removed. `fdoctor` and `azure-functions` will no longer
+  resolve; only `azure-functions-doctor` remains.
+
+Migrate before upgrading to v1.0.0 to avoid `command not found` failures in CI.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - Configuration: configuration.md
   - User Guide:
       - CLI Usage: usage.md
+      - Deprecated Aliases: deprecated-aliases.md
       - Diagnostics: diagnostics.md
       - Rules: rules.md
       - Rule Inventory: rule_inventory.md


### PR DESCRIPTION
## Context

#237 deprecated the `azure-functions` and `fdoctor` console-script aliases in favor of the canonical `azure-functions-doctor` (removal targeted for v1.0.0). This adds the consolidated migration guide that was missing.

## What changed

- **New `docs/deprecated-aliases.md`**: what is deprecated, why `azure-functions-doctor` is canonical, the v1.0.0 removal timeline, and before/after examples for shell scripts, GitHub Actions, Makefiles, and pre-commit — plus a `grep` recipe to find remaining usages.
- **Cross-link** from the README deprecation notice.
- **Docs nav** wired (User Guide → Deprecated Aliases).
- **Translated READMEs** (ko/ja/zh-CN) updated in the same PR per repo policy.

## Out of scope

- Actually removing the aliases (that is the v1.0.0 change).

## Verification

- `make check-all` → EXIT=0, 446 passed, coverage 96.28%.
- `make docs` → EXIT=0 (nav + links resolve).

Closes #243