### PR TITLE
fix(handlers): remove duplicate expected_order assignment in decorator-order check

### DIFF
--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -666,7 +666,6 @@ class HandlerRegistry:
         # and last entries are surfaced in the fix message below, which is exact
         # for the shipped two-element pairing.
         expected_order = condition.get("decorators") or ["with_context", "validate_http"]
-        expected_order = condition.get("decorators") or ["with_context", "validate_http"]
         inverted = _collect_inverted_decorator_order(path, expected_order)
 
         if not inverted:


### PR DESCRIPTION
## Context
The `_handle_decorator_order` check in `handlers/registry.py` assigned `expected_order` twice with an identical expression:

```python
expected_order = condition.get("decorators") or ["with_context", "validate_http"]
expected_order = condition.get("decorators") or ["with_context", "validate_http"]
```

The second assignment is dead code with no behavioral effect. This removes it.

## Changes
- Delete the redundant second `expected_order` assignment (1 line).

## Verification
- `make check-all` → EXIT=0 (all tests + security scan passed).

Closes #246