### PR TITLE
fix(handlers): detect @validate_http above binding decorators (dead handler)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ This repository includes `llms.txt` and `llms-full.txt` for LLM-friendly documen
 
 When working with this codebase, LLM assistants should:
 
-1. **Use `llms.txt` for quick reference** — the canonical package version (0.18.0), Python requirements (>=3.10,<3.15), CLI entry points
+1. **Use `llms.txt` for quick reference** — the canonical package version (0.19.0), Python requirements (>=3.10,<3.15), CLI entry points
 2. **Refer to `llms-full.txt` for implementation details** — output contracts, rule structure, custom rule patterns, handler types
 3. **Check `src/azure_functions_doctor/cli.py`** — authoritative source for CLI options and validation
 4. **Review `src/azure_functions_doctor/assets/rules/v2.json`** — complete ruleset with check definitions

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,7 +47,7 @@ In this guide you will:
 | Azure CLI | `az --version` | [Install Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) |
 | Azure Functions Core Tools v4 | `func --version` | [Install Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools) |
 | Python 3.10-3.13 | `python3 --version` | [python.org](https://www.python.org/downloads/) |
-| Doctor CLI v0.18.0 | `pip show azure-functions-doctor` | `python3 -m pip install azure-functions-doctor` |
+| Doctor CLI v0.19.0 | `pip show azure-functions-doctor` | `python3 -m pip install azure-functions-doctor` |
 
 Install doctor if needed:
 
@@ -142,7 +142,7 @@ Representative JSON output (`doctor-report.json`):
 ```json
 {
   "metadata": {
-    "tool_version": "0.18.0",
+    "tool_version": "0.19.0",
     "target_path": "/data/GitHub/azure-functions-doctor/examples/v2/http-trigger"
   },
   "results": [
@@ -171,7 +171,7 @@ Representative SARIF output (`doctor-report.sarif`):
       "tool": {
         "driver": {
           "name": "azure-functions-doctor",
-          "version": "0.18.0"
+          "version": "0.19.0"
         }
       },
       "results": []

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5,7 +5,7 @@
 ## Package Info
 
 - PyPI: `pip install azure-functions-doctor`
-- Version: 0.18.0
+- Version: 0.19.0
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.github.io/azure-functions-doctor/
@@ -185,7 +185,7 @@ Structured output with metadata, results, and rule information:
 ```json
 {
   "metadata": {
-    "tool_version": "0.18.0",
+    "tool_version": "0.19.0",
     "generated_at": "2025-04-07T10:30:00Z",
     "target_path": "/path/to/app"
   },
@@ -223,7 +223,7 @@ Static Analysis Results Format (SARIF 2.1.0) compatible with GitHub Security tab
       "tool": {
         "driver": {
           "name": "azure-functions-doctor",
-          "version": "0.18.0",
+          "version": "0.19.0",
           "informationUri": "https://github.com/yeongseon/azure-functions-doctor",
           "rules": [...]
         }

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,7 @@
 ## Package Info
 
 - PyPI: `pip install azure-functions-doctor`
-- Version: 0.18.0
+- Version: 0.19.0
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.github.io/azure-functions-doctor/

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -209,6 +209,33 @@ def _decorator_simple_name(dec: ast.expr) -> Optional[str]:
         return node.attr
     return None
 
+def _validate_http_above_binding(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, app_aliases: set[str]
+) -> bool:
+    """Return True when ``@validate_http`` sits above an ``@app.<binding>`` decorator.
+
+    ``decorator_list`` index 0 is the topmost/outermost decorator. When
+    ``@validate_http`` has a lower index than any Azure Functions binding
+    decorator (an ``@<app>.<name>`` attribute call on a discovered FunctionApp
+    alias), it wraps the SDK ``FunctionBuilder`` instead of the handler and is
+    therefore inactive.
+    """
+    validate_idx: Optional[int] = None
+    binding_indices: list[int] = []
+    for i, dec in enumerate(node.decorator_list):
+        if validate_idx is None and _decorator_simple_name(dec) == "validate_http":
+            validate_idx = i
+        inner: ast.expr = dec.func if isinstance(dec, ast.Call) else dec
+        if (
+            isinstance(inner, ast.Attribute)
+            and isinstance(inner.value, ast.Name)
+            and inner.value.id in app_aliases
+        ):
+            binding_indices.append(i)
+    if validate_idx is None or not binding_indices:
+        return False
+    return any(validate_idx < binding_idx for binding_idx in binding_indices)
+
 
 def _collect_inverted_decorator_order(
     path: Path, expected_order: list[str]
@@ -222,6 +249,11 @@ def _collect_inverted_decorator_order(
     decorator, so the expected names must appear in the same relative order. A
     function is flagged when two or more of the expected decorators are present
     but their actual relative order does not match *expected_order*.
+    A function is also flagged when ``@validate_http`` appears *above* (outer to)
+    any Azure Functions binding decorator (e.g. ``@app.route``,
+    ``@app.durable_client_input``). In that order ``@validate_http`` receives an
+    SDK ``FunctionBuilder`` instead of the handler, so validation is inactive and
+    no endpoint metadata is emitted -- a silent "dead handler".
     """
     inverted: list[str] = []
     for py_file, content in _iter_project_py_contents(path):
@@ -229,6 +261,7 @@ def _collect_inverted_decorator_order(
             tree = ast.parse(content)
         except SyntaxError:
             continue
+        app_aliases = _discover_functionapp_aliases(content)
         for node in ast.walk(tree):
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
@@ -240,11 +273,14 @@ def _collect_inverted_decorator_order(
                 if name in expected_order and name not in positions:
                     positions[name] = i
             present = [name for name in expected_order if name in positions]
-            if len(present) < 2:
-                continue
-            actual = sorted(present, key=lambda name: positions[name])
-            if actual != present:
-                inverted.append(f"{py_file.relative_to(path)}:{node.name}")
+            label = f"{py_file.relative_to(path)}:{node.name}"
+            if len(present) >= 2:
+                actual = sorted(present, key=lambda name: positions[name])
+                if actual != present:
+                    inverted.append(label)
+                    continue
+            if _validate_http_above_binding(node, app_aliases):
+                inverted.append(label)
     return inverted
 
 
@@ -295,8 +331,13 @@ def _is_spec_serving_handler(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bo
 
 
 def _collect_routes_missing_validate_http(path: Path) -> list[str]:
-    """Return "file:function" labels for HTTP route handlers that lack
-    ``@validate_http`` and therefore emit no endpoint OpenAPI metadata.
+    """Return "file:function" labels for HTTP route handlers that lack an
+    *active* ``@validate_http`` and therefore emit no endpoint OpenAPI metadata.
+
+    ``@validate_http`` only covers a handler when it is applied *below* (inner to)
+    the ``@app.route`` decorator. When it appears above the route decorator it
+    wraps the SDK ``FunctionBuilder``, so validation and endpoint metadata are
+    inactive even though the decorator name is present.
     """
     uncovered: list[str] = []
     for py_file, content in _iter_project_py_contents(path):
@@ -311,8 +352,9 @@ def _collect_routes_missing_validate_http(path: Path) -> list[str]:
             if not node.decorator_list:
                 continue
             is_route = False
-            has_validate_http = False
-            for dec in node.decorator_list:
+            route_idx: Optional[int] = None
+            validate_idx: Optional[int] = None
+            for i, dec in enumerate(node.decorator_list):
                 inner: ast.expr = dec.func if isinstance(dec, ast.Call) else dec
                 if (
                     isinstance(inner, ast.Attribute)
@@ -321,9 +363,16 @@ def _collect_routes_missing_validate_http(path: Path) -> list[str]:
                     and inner.value.id in app_aliases
                 ):
                     is_route = True
-                if _decorator_simple_name(dec) == "validate_http":
-                    has_validate_http = True
-            if is_route and not has_validate_http and not _is_spec_serving_handler(node):
+                    if route_idx is None:
+                        route_idx = i
+                if validate_idx is None and _decorator_simple_name(dec) == "validate_http":
+                    validate_idx = i
+            has_active_validate_http = (
+                validate_idx is not None
+                and route_idx is not None
+                and validate_idx > route_idx
+            )
+            if is_route and not has_active_validate_http and not _is_spec_serving_handler(node):
                 uncovered.append(f"{py_file.relative_to(path)}:{node.name}")
     return uncovered
 

--- a/tests/test_decorator_diagnostics.py
+++ b/tests/test_decorator_diagnostics.py
@@ -202,3 +202,73 @@ def test_collect_routes_missing_validate_http_excludes_spec_serving(tmp_path: Pa
         encoding="utf-8",
     )
     assert helpers._collect_routes_missing_validate_http(tmp_path) == ["function_app.py:items"]
+
+
+# ---------------------------------------------------------------------------
+# Regression: @validate_http above a binding decorator (dead handler)
+# ---------------------------------------------------------------------------
+
+
+def test_collect_inverted_flags_validate_http_above_binding(tmp_path: Path) -> None:
+    # @validate_http above @app.durable_client_input (no @with_context present):
+    # validation receives a FunctionBuilder and is silently inactive.
+    helpers = import_module("azure_functions_doctor.handlers._helpers")
+    (tmp_path / "function_app.py").write_text(
+        "import azure.functions as func\n"
+        "app = func.FunctionApp()\n\n"
+        "@validate_http\n"
+        "@app.durable_client_input(client_name='client')\n"
+        "def handler(req, client):\n"
+        "    return req\n",
+        encoding="utf-8",
+    )
+    assert helpers._collect_inverted_decorator_order(tmp_path, _ORDER) == [
+        "function_app.py:handler"
+    ]
+
+
+def test_collect_inverted_ignores_validate_http_below_binding(tmp_path: Path) -> None:
+    # Correct order: @app.route outermost, @validate_http innermost -> active.
+    helpers = import_module("azure_functions_doctor.handlers._helpers")
+    (tmp_path / "function_app.py").write_text(
+        "import azure.functions as func\n"
+        "app = func.FunctionApp()\n\n"
+        "@app.route(route='x')\n"
+        "@validate_http\n"
+        "def handler(req):\n"
+        "    return req\n",
+        encoding="utf-8",
+    )
+    assert helpers._collect_inverted_decorator_order(tmp_path, _ORDER) == []
+
+
+def test_collect_routes_flags_inactive_validate_http_above_route(tmp_path: Path) -> None:
+    # @validate_http declared but placed ABOVE @app.route -> inactive, so the
+    # route emits no endpoint metadata even though the name is present.
+    helpers = import_module("azure_functions_doctor.handlers._helpers")
+    (tmp_path / "function_app.py").write_text(
+        "import azure.functions as func\n"
+        "app = func.FunctionApp()\n\n"
+        "@validate_http\n"
+        "@app.route(route='x')\n"
+        "def handler(req):\n"
+        "    return req\n",
+        encoding="utf-8",
+    )
+    assert helpers._collect_routes_missing_validate_http(tmp_path) == [
+        "function_app.py:handler"
+    ]
+
+
+def test_collect_routes_passes_active_validate_http_below_route(tmp_path: Path) -> None:
+    helpers = import_module("azure_functions_doctor.handlers._helpers")
+    (tmp_path / "function_app.py").write_text(
+        "import azure.functions as func\n"
+        "app = func.FunctionApp()\n\n"
+        "@app.route(route='x')\n"
+        "@validate_http\n"
+        "def handler(req):\n"
+        "    return req\n",
+        encoding="utf-8",
+    )
+    assert helpers._collect_routes_missing_validate_http(tmp_path) == []


### PR DESCRIPTION
## Summary
Both the `decorator_order` and `endpoint_metadata` checks previously PASSED on a handler that declares `@validate_http` ABOVE a binding decorator (e.g. `@app.route`, `@app.durable_client_input`, `@app.cosmos_db_output`). In that order `@validate_http` wraps the SDK `FunctionBuilder`, so validation is inactive and no endpoint metadata is emitted — a silent "dead handler" — yet neither check flagged it (false-negatives).

- **decorator_order** now flags `@validate_http` positioned above any `@app.<binding>` decorator, not just relative to `@with_context`. This check owns the dead-handler detection since it is fundamentally an ordering problem.
- **endpoint_metadata** route coverage is now position-aware: `@validate_http` only counts as covering an `@app.route` handler when applied BELOW the route decorator. A name-present-but-inactive decorator is treated as uncovered. Scope stays limited to HTTP `@app.route` handlers (non-HTTP triggers are not falsely flagged).
- The #250 spec-serving exclusion is preserved.

## Root-cause note
This gap is **not** caused by #250 (which only added a narrow spec-serving exclusion). The name-presence-only check predates it (introduced in #233); it was never position/activity-aware.

## Tests
- Adds 4 regression tests: `@validate_http` above `@app.durable_client_input` and above `@app.route` (flagged), and correct order below the binding (passes).
- `make test` (468 passed, 96.32% coverage), `make lint`, `make typecheck` all green.