### PR TITLE
build: auto-sync doc version strings on release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ site/
 
 # Review
 .venv-review/
+
+# Agent orchestration state (oh-my-opencode / Sisyphus)
+.sisyphus/
+.omc/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ When splitting a large piece of work into focused issues, keep the umbrella open
 ## Release Process
 - Version is managed via `hatch` (dynamic from `src/azure_functions_doctor/__init__.py`).
 - **Do NOT manually edit version strings.** Use the Makefile targets below. The public-API test reads `__version__` against `importlib.metadata.version(...)`, so no test changes are needed when bumping.
+- The release targets automatically run `make sync-docs-version` after the `hatch version` bump, which rewrites the canonical version strings in `README.md`, `llms.txt`, `llms-full.txt`, and `docs/deployment.md` so the `test (3.10)` docs-consistency gate stays green. The sync is idempotent and never touches the SARIF schema version (`"version": "2.1.0"`). Run `make sync-docs-version` manually if you ever hand-edit `__version__`.
 
 ### Commands
 - `make release-patch` — bump patch version, update changelog, tag, and push

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ DEMO_TAPE := demo/doctor-demo.tape
 DEMO_IMAGE := azure-functions-doctor-demo-vhs
 DEMO_GIF := docs/assets/doctor-demo.gif
 DEMO_FINAL_PNG := docs/assets/doctor-demo-final.png
+VERSIONED_DOCS := README.md llms.txt llms-full.txt docs/deployment.md
 
 .PHONY: bootstrap
 bootstrap:
@@ -135,7 +136,8 @@ ifndef VERSION
 	$(error VERSION is not set. Usage: make release VERSION=1.0.1)
 endif
 	@$(HATCH) version $(VERSION)
-	@git add "$(PACKAGE_INIT)" && \
+	@$(MAKE) sync-docs-version
+	@git add "$(PACKAGE_INIT)" $(VERSIONED_DOCS) && \
 	 git commit -m "build: bump version to $(VERSION)"
 	@$(MAKE) release-core VERSION=$(VERSION)
 
@@ -151,24 +153,27 @@ endif
 .PHONY: release-patch
 release-patch: ensure-hatch
 	@$(HATCH) version patch
+	@$(MAKE) sync-docs-version
 	@VERSION=$$($(HATCH) version | tail -n1); \
-	 git add "$(PACKAGE_INIT)" && \
+	 git add "$(PACKAGE_INIT)" $(VERSIONED_DOCS) && \
 	 git commit -m "build: bump version to $$VERSION" && \
 	 $(MAKE) release-core VERSION=$$VERSION
 
 .PHONY: release-minor
 release-minor: ensure-hatch
 	@$(HATCH) version minor
+	@$(MAKE) sync-docs-version
 	@VERSION=$$($(HATCH) version | tail -n1); \
-	 git add "$(PACKAGE_INIT)" && \
+	 git add "$(PACKAGE_INIT)" $(VERSIONED_DOCS) && \
 	 git commit -m "build: bump version to $$VERSION" && \
 	 $(MAKE) release-core VERSION=$$VERSION
 
 .PHONY: release-major
 release-major: ensure-hatch
 	@$(HATCH) version major
+	@$(MAKE) sync-docs-version
 	@VERSION=$$($(HATCH) version | tail -n1); \
-	 git add "$(PACKAGE_INIT)" && \
+	 git add "$(PACKAGE_INIT)" $(VERSIONED_DOCS) && \
 	 git commit -m "build: bump version to $$VERSION" && \
 	 $(MAKE) release-core VERSION=$$VERSION
 
@@ -179,6 +184,10 @@ publish-test: ensure-hatch
 .PHONY: publish-pypi
 publish-pypi: ensure-hatch
 	@$(HATCH) publish
+
+.PHONY: sync-docs-version
+sync-docs-version: ensure-hatch
+	@$(HATCH) run python scripts/sync_docs_version.py
 
 .PHONY: version
 version: ensure-hatch

--- a/scripts/sync_docs_version.py
+++ b/scripts/sync_docs_version.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Synchronize documentation version strings with the canonical ``__version__``.
+
+The release process bumps ``__version__`` in
+``src/azure_functions_doctor/__init__.py`` but the AI-assistant/docs surface
+(``llms.txt``, ``llms-full.txt``, ``docs/deployment.md`` and ``README.md``)
+carries hard-coded version strings that ``scripts/check_docs_consistency.py``
+enforces on CI. Without this script those files must be edited by hand on every
+release, which repeatedly turned the ``test (3.10)`` leg red.
+
+This script rewrites every package-version reference in those files to match the
+current ``__version__`` and is safe to run repeatedly (idempotent). It never
+touches the unrelated SARIF schema version (``"version": "2.1.0"``): the SARIF
+driver's package version is matched only when anchored to the
+``"name": "azure-functions-doctor"`` line.
+
+Usage:
+    python scripts/sync_docs_version.py           # rewrite docs in place
+    python scripts/sync_docs_version.py --check    # exit 1 if any file is stale
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+INIT_PY = ROOT / "src" / "azure_functions_doctor" / "__init__.py"
+
+_SEMVER = r"\d+\.\d+\.\d+"
+
+
+def _read_version() -> str:
+    text = INIT_PY.read_text(encoding="utf-8")
+    match = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']', text, re.MULTILINE)
+    if not match:
+        raise SystemExit(f"Could not find __version__ in {INIT_PY}")
+    return match.group(1)
+
+
+def _substitutions(version: str) -> dict[str, list[tuple[str, str]]]:
+    """Map each doc file to its ``(pattern, replacement)`` rewrite rules."""
+    return {
+        "llms.txt": [
+            (rf"(?m)^- Version: {_SEMVER}$", f"- Version: {version}"),
+        ],
+        "llms-full.txt": [
+            (rf"(?m)^- Version: {_SEMVER}$", f"- Version: {version}"),
+            (rf'"tool_version": "{_SEMVER}"', f'"tool_version": "{version}"'),
+            (
+                rf'("name": "azure-functions-doctor",\s*"version": ")({_SEMVER})(")',
+                rf"\g<1>{version}\g<3>",
+            ),
+        ],
+        "docs/deployment.md": [
+            (rf"Doctor CLI v{_SEMVER}", f"Doctor CLI v{version}"),
+            (rf'"tool_version": "{_SEMVER}"', f'"tool_version": "{version}"'),
+            (
+                rf'("name": "azure-functions-doctor",\s*"version": ")({_SEMVER})(")',
+                rf"\g<1>{version}\g<3>",
+            ),
+        ],
+        "README.md": [
+            (rf"package version \({_SEMVER}\)", f"package version ({version})"),
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not write; exit 1 if any doc file would change.",
+    )
+    args = parser.parse_args()
+
+    version = _read_version()
+    stale: list[str] = []
+
+    for rel_path, rules in _substitutions(version).items():
+        path = ROOT / rel_path
+        original = path.read_text(encoding="utf-8")
+        updated = original
+        for pattern, replacement in rules:
+            updated = re.sub(pattern, replacement, updated)
+        if updated != original:
+            stale.append(rel_path)
+            if not args.check:
+                path.write_text(updated, encoding="utf-8")
+
+    if args.check:
+        if stale:
+            print("Documentation version references are stale:")
+            for rel_path in stale:
+                print(f"  - {rel_path}")
+            print(f"Fix with: python scripts/sync_docs_version.py (target {version})")
+            return 1
+        print(f"Documentation version references already match {version}.")
+        return 0
+
+    if stale:
+        print(f"Synced version references to {version} in: " + ", ".join(stale))
+    else:
+        print(f"Version references already match {version}; nothing to do.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Context

Every release (`make release-patch/minor/major`) bumped `__version__` but left the hard-coded version strings in `README.md`, `llms.txt`, `llms-full.txt`, and `docs/deployment.md` stale. `scripts/check_docs_consistency.py` enforces those needles on the **`test (3.10)`** CI leg, so the gate went red after every release until someone fixed the docs by hand (this is exactly what blocked PR #252's 3.10 leg).

## What this does

- Adds **`scripts/sync_docs_version.py`** — idempotent script that rewrites the 4 canonical version needles to match `__version__`. Has `--check` mode (exit 1 on drift) for CI use.
- Adds a **`sync-docs-version`** Make target and wires `@$(MAKE) sync-docs-version` into all four release targets right after the `hatch version` bump, adding `$(VERSIONED_DOCS)` to the version-bump commit's `git add`.
- Updates the **AGENTS.md Release Process** section to document the auto-sync.
- Ignores agent orchestration state (`.sisyphus/`, `.omc/`).

## SARIF safety

`llms-full.txt` and `docs/deployment.md` contain `"version": "2.1.0"` = the **SARIF schema version**, which must never change. The script only rewrites the SARIF driver's *package* version by anchoring the regex to the preceding `"name": "azure-functions-doctor",` line, plus the safe `"tool_version"` field.

## Verification

- `sync_docs_version.py --check` — passes at 0.19.1.
- **Integration test**: simulated `hatch version 0.20.0` → sync rewrote all 4 docs → `check_docs_consistency.py` passed at 0.20.0 → SARIF `2.1.0` confirmed untouched → clean restore.
- `make check` (lint + typecheck) — green.

## Acceptance Checklist
- [x] Release targets auto-sync doc version strings
- [x] SARIF schema version never rewritten
- [x] `--check` mode available for CI
- [x] AGENTS.md documents the behavior

No release is needed for this PR itself.