### PR TITLE
refactor: remove unreachable return in _load_pyproject

### DIFF
--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -739,7 +739,6 @@ def _load_pyproject(path: Path) -> Optional[Dict[str, object]]:
         with pyproject_path.open("rb") as handle:
             data: Dict[str, object] = tomllib.load(handle)
             return data
-            return tomllib.load(handle)
     except (OSError, ValueError) as exc:
         logger.debug(f"Skip pyproject.toml at {pyproject_path}: {exc}")
         return None


### PR DESCRIPTION
## Context

Dead-code cleanup surfaced by a static-analysis pass (vulture, 100% confidence). `_load_pyproject` in `handlers/_helpers.py` had two consecutive `return` statements:

```python
with pyproject_path.open("rb") as handle:
    data: Dict[str, object] = tomllib.load(handle)
    return data
    return tomllib.load(handle)   # unreachable
```

The second `return` can never execute. It's a leftover from an earlier refactor.

## Change

Remove the unreachable line. Pure dead-code removal — no behavior change.

## Verification
- `make check-all` — lint/typecheck/security green; 468 tests pass; coverage 96.32% (>=95%).
- The only local test "failure" is the pre-existing stale-editable-install version metadata check (`0.19.1` vs `0.19.0`), unrelated to this change and resolved by refreshing the hatch env.

## Acceptance Checklist
- [x] Unreachable code removed
- [x] No behavior change
- [x] Coverage stays >=95%