### PR TITLE
chore: bump ruff to 0.16.2 and repair pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
+default_language_version:
+  python: python3.12
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.16.2
     hooks:
       - id: ruff-format
       - id: ruff
@@ -24,6 +27,7 @@ repos:
     rev: 1.9.4
     hooks:
       - id: bandit
+        language_version: python3.12
         args: ["-c", "pyproject.toml"]
         additional_dependencies: ["bandit[toml]"]
         files: "^src/"
@@ -32,7 +36,7 @@ repos:
     hooks:
       - id: forbid-korean
         name: Forbid Korean Characters
-        entry: bash -c 'if grep -RIl --exclude-dir=.venv --exclude-dir=.git -n "[가-힣]" docs src README.md CONTRIBUTING.md AGENTS.md DESIGN.md PRD.md CHANGELOG.md 2>/dev/null; then echo "Korean characters detected. Please use English only."; exit 1; fi'
+        entry: bash -c 'if grep -RIn --exclude-dir=.venv --exclude-dir=.git "[가-힣]" docs src README.md CONTRIBUTING.md AGENTS.md DESIGN.md PRD.md CHANGELOG.md 2>/dev/null | grep -vE "README\.(ko|ja|zh-CN)\.md"; then echo "Korean characters detected. Please use English only."; exit 1; fi'
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/examples/v2/blueprint/http_blueprint.py
+++ b/examples/v2/blueprint/http_blueprint.py
@@ -3,6 +3,7 @@
 Import ``bp`` in ``function_app.py`` and call ``app.register_functions(bp)``
 to attach these routes to the main application.
 """
+
 import azure.functions as func
 
 bp = func.Blueprint()

--- a/examples/v2/multi-trigger/function_app.py
+++ b/examples/v2/multi-trigger/function_app.py
@@ -5,6 +5,7 @@ Demonstrates three common trigger types in a single app:
 - Timer trigger : scheduled execution (every 5 minutes)
 - Queue trigger : event-driven processing from Azure Storage Queue
 """
+
 import json
 import logging
 

--- a/examples/v2/timer-trigger/function_app.py
+++ b/examples/v2/timer-trigger/function_app.py
@@ -3,6 +3,7 @@
 Runs on a cron schedule (every 5 minutes). Logs whether the execution
 is running later than scheduled via the ``past_due`` flag.
 """
+
 import logging
 
 import azure.functions as func

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "ruff==0.16.1",
+    "ruff==0.16.2",
     "requests",
     "types-requests",
 ]

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -20,9 +20,9 @@ Usage:
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 INIT_PY = ROOT / "src" / "azure_functions_doctor" / "__init__.py"

--- a/scripts/gen_rule_inventory.py
+++ b/scripts/gen_rule_inventory.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
+import sys
 
 ROOT = Path(__file__).resolve().parent.parent
 RULES_JSON = ROOT / "src" / "azure_functions_doctor" / "assets" / "rules" / "v2.json"

--- a/scripts/lint_mermaid.py
+++ b/scripts/lint_mermaid.py
@@ -17,9 +17,9 @@ Usage:
 
 from __future__ import annotations
 
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 

--- a/scripts/sync_docs_version.py
+++ b/scripts/sync_docs_version.py
@@ -22,9 +22,9 @@ Usage:
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 INIT_PY = ROOT / "src" / "azure_functions_doctor" / "__init__.py"

--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -428,5 +428,6 @@ def fdoctor_alias() -> None:
     _warn_deprecated_alias("fdoctor")
     cli()
 
+
 if __name__ == "__main__":
     cli()

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -209,6 +209,7 @@ def _decorator_simple_name(dec: ast.expr) -> Optional[str]:
         return node.attr
     return None
 
+
 def _validate_http_above_binding(
     node: ast.FunctionDef | ast.AsyncFunctionDef, app_aliases: set[str]
 ) -> bool:
@@ -237,9 +238,7 @@ def _validate_http_above_binding(
     return any(validate_idx < binding_idx for binding_idx in binding_indices)
 
 
-def _collect_inverted_decorator_order(
-    path: Path, expected_order: list[str]
-) -> list[str]:
+def _collect_inverted_decorator_order(path: Path, expected_order: list[str]) -> list[str]:
     """Return "file:function" labels whose decorators violate *expected_order*.
 
     *expected_order* lists decorator leaf names from **outermost to innermost**
@@ -368,9 +367,7 @@ def _collect_routes_missing_validate_http(path: Path) -> list[str]:
                 if validate_idx is None and _decorator_simple_name(dec) == "validate_http":
                     validate_idx = i
             has_active_validate_http = (
-                validate_idx is not None
-                and route_idx is not None
-                and validate_idx > route_idx
+                validate_idx is not None and route_idx is not None and validate_idx > route_idx
             )
             if is_route and not has_active_validate_http and not _is_spec_serving_handler(node):
                 uncovered.append(f"{py_file.relative_to(path)}:{node.name}")
@@ -425,9 +422,7 @@ def _collect_openapi_version_mixing(path: Path) -> tuple[set[str], set[str]]:
     return v30, v31
 
 
-def _collect_scan_before_spec(
-    path: Path, scan_names: set[str], spec_names: set[str]
-) -> list[str]:
+def _collect_scan_before_spec(path: Path, scan_names: set[str], spec_names: set[str]) -> list[str]:
     """Return "file:spec_call" labels where a spec build precedes endpoint scan.
 
     For each file, records the line numbers of scan-style calls and spec-style
@@ -489,9 +484,7 @@ def _project_imports_langgraph(path: Path) -> bool:
     return False
 
 
-def _collect_anonymous_auth_routes(
-    path: Path, flag_missing_auth_level: bool = False
-) -> list[str]:
+def _collect_anonymous_auth_routes(path: Path, flag_missing_auth_level: bool = False) -> list[str]:
     """Return "file:function" labels for routes using anonymous auth.
 
     A route is flagged when a decorator keyword ``auth_level`` resolves to
@@ -571,9 +564,7 @@ def _collect_orchestrator_nondeterminism(
                     continue
                 for entry in blocklist:
                     if dotted == entry or dotted.endswith("." + entry):
-                        flagged.append(
-                            f"{py_file.relative_to(path)}:{node.name} -> {dotted}"
-                        )
+                        flagged.append(f"{py_file.relative_to(path)}:{node.name} -> {dotted}")
                         break
     return flagged
 
@@ -610,9 +601,7 @@ def _collect_unsupported_metadata_versions(
     seen: set[Path] = set()
     for pattern in files:
         for match in path.rglob(pattern):
-            if match in seen or any(
-                part in EXCLUDED_PROJECT_DIRS for part in match.parts
-            ):
+            if match in seen or any(part in EXCLUDED_PROJECT_DIRS for part in match.parts):
                 continue
             seen.add(match)
             data = _load(match)
@@ -1031,7 +1020,6 @@ def _resolve_host_json_path(data: object, jsonpath: str) -> object:
     return _resolve_host_json_pointer(data, parts)
 
 
-
 _HandlerFn = TypeVar("_HandlerFn", bound=Callable[..., "HandlerResult"])
 
 # Populated at class-definition time by the @_rule_handler decorator:
@@ -1047,6 +1035,3 @@ def _rule_handler(func: _HandlerFn) -> _HandlerFn:
     """
     _RULE_DISPATCH[func.__name__.removeprefix("_handle_")] = func.__name__
     return func
-
-
-

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -53,9 +53,7 @@ class HandlerRegistry:
     """Registry for diagnostic check handlers with individual handler methods."""
 
     def __init__(self) -> None:
-        self._handlers: Dict[
-            str, Callable[[Rule, Path, Optional[RuleContext]], HandlerResult]
-        ] = {
+        self._handlers: Dict[str, Callable[[Rule, Path, Optional[RuleContext]], HandlerResult]] = {
             check_type: getattr(self, method_name)
             for check_type, method_name in _RULE_DISPATCH.items()
         }
@@ -700,7 +698,6 @@ class HandlerRegistry:
         )
         return _create_result("fail", detail)
 
-
     @_rule_handler
     def _handle_decorator_order(
         self, rule: Rule, path: Path, context: Optional[RuleContext] = None
@@ -726,7 +723,6 @@ class HandlerRegistry:
                 "Fix: reorder to @app.route -> "
                 + " -> ".join(f"@{name}" for name in expected_order)
                 + f" ({expected_order[-1]} innermost).",
-
             ]
         )
         return _create_result("fail", detail)
@@ -873,8 +869,7 @@ class HandlerRegistry:
             ]
         )
         decorator_names = set(
-            condition.get("decorator_names")
-            or ["orchestration_trigger", "entity_trigger"]
+            condition.get("decorator_names") or ["orchestration_trigger", "entity_trigger"]
         )
         flagged = _collect_orchestrator_nondeterminism(path, blocklist, decorator_names)
         if not flagged:
@@ -920,9 +915,7 @@ class HandlerRegistry:
 _registry = HandlerRegistry()
 
 
-def generic_handler(
-    rule: Rule, path: Path, context: Optional[RuleContext] = None
-) -> HandlerResult:
+def generic_handler(rule: Rule, path: Path, context: Optional[RuleContext] = None) -> HandlerResult:
     """
     Execute a diagnostic rule based on its type and condition.
 

--- a/tests/test_condition_params.py
+++ b/tests/test_condition_params.py
@@ -38,6 +38,7 @@ class TestParseCompareVersion:
 
     def test_returns_none_when_missing_value(self) -> None:
         assert parse_compare_version({"target": "python", "operator": ">="}) is None
+
     def test_accepts_numeric_zero_value(self) -> None:
         # 0 / 0.0 are valid scalars and must not be treated as missing.
         assert parse_compare_version(
@@ -53,9 +54,7 @@ class TestParseCompareVersion:
         )
 
     def test_returns_none_when_target_empty(self) -> None:
-        assert (
-            parse_compare_version({"target": "", "operator": ">=", "value": "3.10"}) is None
-        )
+        assert parse_compare_version({"target": "", "operator": ">=", "value": "3.10"}) is None
 
     def test_returns_none_when_value_not_scalar(self) -> None:
         assert (
@@ -80,6 +79,7 @@ class TestParseSourceCode:
 
     def test_returns_none_when_keyword_not_str(self) -> None:
         assert parse_source_code({"keyword": 5}) is None  # type: ignore[typeddict-item]
+
     def test_coerces_unknown_mode_to_string(self) -> None:
         assert parse_source_code(
             {"keyword": "@app.", "mode": "bogus"}  # type: ignore[typeddict-item]
@@ -104,6 +104,7 @@ class TestParsePackage:
 
     def test_returns_none_when_absent(self) -> None:
         assert parse_package({}) is None
+
     def test_returns_none_when_package_empty(self) -> None:
         assert parse_package({"package": ""}) is None
 

--- a/tests/test_decorator_diagnostics.py
+++ b/tests/test_decorator_diagnostics.py
@@ -143,9 +143,7 @@ def test_collect_inverted_decorator_order_honors_custom_order(tmp_path: Path) ->
         "@a\n@b\ndef f():\n    return None\n", encoding="utf-8"
     )
     assert helpers._collect_inverted_decorator_order(tmp_path, ["a", "b"]) == []
-    assert helpers._collect_inverted_decorator_order(tmp_path, ["b", "a"]) == [
-        "function_app.py:f"
-    ]
+    assert helpers._collect_inverted_decorator_order(tmp_path, ["b", "a"]) == ["function_app.py:f"]
 
 
 # ---------------------------------------------------------------------------
@@ -255,9 +253,7 @@ def test_collect_routes_flags_inactive_validate_http_above_route(tmp_path: Path)
         "    return req\n",
         encoding="utf-8",
     )
-    assert helpers._collect_routes_missing_validate_http(tmp_path) == [
-        "function_app.py:handler"
-    ]
+    assert helpers._collect_routes_missing_validate_http(tmp_path) == ["function_app.py:handler"]
 
 
 def test_collect_routes_passes_active_validate_http_below_route(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Bump pinned `ruff` dev dependency **0.16.1 → 0.16.2** and apply the resulting formatter changes (blank-line-after-function normalization, single-line signature collapsing) across `src`, `tests`, `examples`, and `scripts`.
- Bump `ruff-pre-commit` rev **v0.15.6 → v0.16.2** so the hook formats identically to the pinned tool.
- Repair pre-commit env: pin the `bandit` hook (and default python-language version) to **python3.12** — the default env was resolving to system Python 3.9.6, which modern bandit rejects (`requires >=3.10`), crashing every commit.
- Narrow the `forbid-korean` hook so the README language-selector nav links (`README.ko/ja/zh-CN.md`) no longer trip the Hangul check (it previously failed on `main`).

## Verification
- `pre-commit run --all-files` → ruff-format, ruff, mypy, bandit, forbid-korean all **Passed**.
- `ruff check src tests` and `ruff format --check src tests` → clean.

## Scope
- Dev tooling + pre-commit config only. No runtime dependency or logic changes.
- `mypy`/`bandit` version pins left untouched (already at/above the highest versions available on the active package index).