### PR TITLE
docs: sync documentation with v0.19.1 source

### DIFF
--- a/docs/RULE_POLICY.md
+++ b/docs/RULE_POLICY.md
@@ -141,6 +141,7 @@ Core rules must rely on **deterministic, static checks**.
 | `file_exists` | File present at project root |
 | `host_json_version` | JSON property equality |
 | `package_declared` | Package name appears in requirements.txt |
+| `dependency_manifest` | Dependency file (requirements.txt or pyproject.toml) exists |
 | `compare_version` | Version comparison against a fixed minimum |
 
 **Not allowed in Core rules:**

--- a/docs/RULE_POLICY.md
+++ b/docs/RULE_POLICY.md
@@ -43,13 +43,20 @@ Core rules are marked `"required": true` in `v2.json` and are always included in
 | Rule ID | Check Type | MS Learn Reference |
 |---|---|---|
 | `check_python_version` | `compare_version` | [Supported Python versions][py-versions] |
-| `check_requirements_txt` | `file_exists` | [Managing dependencies][req-txt] |
+| `check_requirements_txt` | `dependency_manifest` | [Managing dependencies][req-txt] |
 | `check_azure_functions_library` | `package_declared` | [Python developer reference][az-func-lib] |
 | `check_host_json` | `file_exists` | [host.json reference][host-json] |
 | `check_host_json_version` | `host_json_version` | [host.json reference][host-json] |
+| `check_durable_nondeterminism` | `durable_nondeterminism` | [Durable Functions code constraints][durable-determinism] |
 
 These rules detect **unambiguous misconfiguration** — a project missing any of these
 will fail to deploy or run regardless of environment.
+
+> Note: `check_durable_nondeterminism` is also shipped as required (`"required": true`)
+> because nondeterministic calls in orchestrator/entity functions reliably break Durable
+> Functions replay. Unlike the other Core rules it relies on a specialized source detector
+> (`durable_nondeterminism`) rather than a purely static file/version check, and it only
+> evaluates projects that contain Durable orchestration or entity triggers.
 
 ---
 
@@ -71,16 +78,27 @@ Extended rules are included in `--profile full` but excluded from `--profile min
 | Rule ID | Reason for Extended (not Core) tier |
 |---|---|
 | `check_programming_model_v2` | Decorator detection uses AST heuristics; false positives possible in non-standard layouts |
+| `check_blueprint_registration` | Blueprint registration is inferred from source; unusual registration patterns may be missed |
 | `check_venv` | Recommended for local development; not a deployment-time requirement |
 | `check_python_executable` | Interpreter path issues are environment-specific; not caused by project misconfiguration |
+| `check_native_dependency_risk` | Heuristic package list; native builds may still succeed depending on the build environment |
+| `check_azure_functions_worker` | Warns on a discouraged pin; not always fatal |
 | `check_local_settings` | Local development convenience; not required for deployment |
+| `check_funcignore` | Packaging hygiene recommendation; not required for deployment |
+| `check_local_settings_git_tracked` | Secret-hygiene recommendation; depends on git state |
 | `check_func_cli` | Core Tools useful locally; not required by Functions runtime |
 | `check_func_core_tools_version` | Version guidance; not a runtime deployment requirement |
 | `check_extension_bundle` | Binding support recommendation; not universally required |
+| `check_extension_bundle_v4` | Version recommendation; not a hard requirement |
 | `check_app_insights` | Observability recommendation; not required for app to run |
 | `check_durabletask_config` | Conditional on Durable usage; heuristic detection |
 | `check_asgi_wsgi_exposure` | Framework heuristic; non-standard callables may produce false positives |
-| `check_extension_bundle_v4` | Version recommendation; not a hard requirement |
+| `check_decorator_order` | Decorator-stacking heuristic; applies to specific validation/context patterns |
+| `check_endpoint_metadata` | Applies only when `azure-functions-validation` is a dependency; heuristic route detection |
+| `check_openapi_version_mixing` | Heuristic signal detection across OpenAPI 3.0/3.1 usage |
+| `check_scan_before_spec` | Call-order heuristic; naming-based detection may miss custom flows |
+| `check_langgraph_anonymous_auth` | Applies only to LangGraph projects; heuristic auth-level detection |
+| `check_unsupported_metadata_version` | Depends on a configurable supported-version set; advisory only |
 
 ---
 
@@ -242,3 +260,4 @@ The guiding principle for rule design is:
 [req-txt]: https://learn.microsoft.com/azure/azure-functions/functions-reference-python#managing-dependencies
 [az-func-lib]: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
 [host-json]: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+[durable-determinism]: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-code-constraints

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 # API Reference
 
 The public entry point for programmatic usage is
-`azure_functions_doctor.api.run_diagnostics(path, profile, rules_path)`.
+`azure_functions_doctor.api.run_diagnostics(path, profile, rules_path, target_python)`.
 It uses the same diagnostics engine as `azure-functions-doctor doctor`, then returns
 structured results that can be consumed in scripts, CI pipelines, or custom tooling.
 
@@ -9,8 +9,8 @@ structured results that can be consumed in scripts, CI pipelines, or custom tool
 
 | API | Purpose | Typical usage |
 | --- | --- | --- |
-| `run_diagnostics(path, profile, rules_path)` | Run all checks and return section-level results. | CI validation, custom wrappers, pre-commit hooks. |
-| `Doctor(path, profile, rules_path)` | Lower-level runner with explicit lifecycle methods. | Advanced control over rule loading and execution. |
+| `run_diagnostics(path, profile, rules_path, target_python)` | Run all checks and return section-level results. | CI validation, custom wrappers, pre-commit hooks. |
+| `Doctor(path, profile, rules_path, target_python)` | Lower-level runner with explicit lifecycle methods. | Advanced control over rule loading and execution. |
 | `CheckResult` | Result object for one check item. | Output processing and custom reporting. |
 | `SectionResult` | Result object for a group of checks. | Rendering grouped summaries by category. |
 | `HandlerRegistry` | Maps rule `type` to execution handlers. | Handler extension and internal diagnostics flow. |

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,6 +51,7 @@ if __name__ == "__main__":
 | `path` | `str` | Yes | File system path to the Azure Functions app root. |
 | `profile` | `str | None` | No | `"full"` (default behavior) or `"minimal"` (required checks only). |
 | `rules_path` | `pathlib.Path | None` | No | Optional path to a custom rules file matching the rules schema. |
+| `target_python` | `str | None` | No | Override target Python runtime version (e.g. `"3.12"`). Defaults to `None` (use tool runtime). |
 
 ### Return Value
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,9 +16,10 @@ Core options:
 - `--profile <minimal|full>`
 - `--format <table|json|sarif|junit>`
 - `--output <file>`
-- `--verbose`
+- `-v`, `--verbose`
 - `--debug`
 - `--rules <file>`
+- `--target-python <version>`
 
 ## Target path configuration
 
@@ -148,28 +149,17 @@ Behavior:
 
 See [Rules](rules.md) and [Examples: Custom Rules](examples/custom_rules.md).
 
-## Environment-backed config object
+## Environment variables
 
-The package includes `Config` with `FUNC_DOCTOR_*` env support.
-This is currently oriented toward internal and future runtime wiring.
+Runtime behavior is CLI-driven. The only environment variable the tool reads is
+`AZURE_FUNCTIONS_DOCTOR_LOG_LEVEL`, which sets the internal logging verbosity
+(for example `DEBUG`, `INFO`, `WARNING`).
 
-Examples of recognized keys include:
-
-- `FUNC_DOCTOR_LOG_LEVEL`
-- `FUNC_DOCTOR_LOG_FORMAT`
-- `FUNC_DOCTOR_MAX_FILE_SIZE_MB`
-- `FUNC_DOCTOR_SEARCH_TIMEOUT_SECONDS`
-- `FUNC_DOCTOR_OUTPUT_WIDTH`
-
-Programmatic access:
-
-```python
-from azure_functions_doctor.config import get_config
-
-
-def current_config() -> dict:
-    return get_config().to_dict()
+```bash
+AZURE_FUNCTIONS_DOCTOR_LOG_LEVEL=DEBUG azure-functions-doctor doctor
 ```
+
+All other configuration is expressed through the CLI options listed above.
 
 ## Recommended CI configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ azure-functions-doctor doctor [OPTIONS]
 
 Core options:
 
-- `--path <directory>`
+- `<path>` (positional, default `.`)
 - `--profile <minimal|full>`
 - `--format <table|json|sarif|junit>`
 - `--output <file>`
@@ -32,7 +32,7 @@ azure-functions-doctor doctor
 To check another project:
 
 ```bash
-azure-functions-doctor doctor --path ./apps/orders-function
+azure-functions-doctor doctor ./apps/orders-function
 ```
 
 Path validation behavior:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ azure-functions-doctor doctor [OPTIONS]
 
 Core options:
 
-- `<path>` (positional, default `.`)
+- `--path <directory>` (default `.`)
 - `--profile <minimal|full>`
 - `--format <table|json|sarif|junit>`
 - `--output <file>`
@@ -32,7 +32,7 @@ azure-functions-doctor doctor
 To check another project:
 
 ```bash
-azure-functions-doctor doctor ./apps/orders-function
+azure-functions-doctor doctor --path ./apps/orders-function
 ```
 
 Path validation behavior:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -46,7 +46,7 @@ In this guide you will:
 | Azure account | [portal.azure.com](https://portal.azure.com) | [Create free account](https://azure.microsoft.com/free/) |
 | Azure CLI | `az --version` | [Install Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) |
 | Azure Functions Core Tools v4 | `func --version` | [Install Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools) |
-| Python 3.10-3.13 | `python3 --version` | [python.org](https://www.python.org/downloads/) |
+| Python 3.10-3.14 | `python3 --version` | [python.org](https://www.python.org/downloads/) |
 | Doctor CLI v0.19.1 | `pip show azure-functions-doctor` | `python3 -m pip install azure-functions-doctor` |
 
 Install doctor if needed:
@@ -143,7 +143,9 @@ Representative JSON output (`doctor-report.json`):
 {
   "metadata": {
     "tool_version": "0.19.1",
-    "target_path": "/data/GitHub/azure-functions-doctor/examples/v2/http-trigger"
+    "target_path": "/data/GitHub/azure-functions-doctor/examples/v2/http-trigger",
+    "programming_model": "v2",
+    "target_python": null
   },
   "results": [
     {

--- a/docs/json_output_contract.md
+++ b/docs/json_output_contract.md
@@ -17,9 +17,11 @@ If `--output` is omitted, JSON is printed to stdout.
 ```json
 {
   "metadata": {
-    "tool_version": "0.15.0",
+    "tool_version": "0.19.1",
     "generated_at": "2026-03-14T10:40:20.731Z",
-    "target_path": "/absolute/path/to/project"
+    "target_path": "/absolute/path/to/project",
+    "programming_model": "v2",
+    "target_python": null
   },
   "results": [
     {
@@ -49,6 +51,8 @@ If `--output` is omitted, JSON is printed to stdout.
 | `tool_version` | string | Installed `azure-functions-doctor` version. |
 | `generated_at` | string | UTC timestamp in ISO 8601 format. |
 | `target_path` | string | Resolved absolute project path used for checks. |
+| `programming_model` | string | Detected Azure Functions programming model (`v2`, `mixed`, `unsupported_v1`, or `unknown`). |
+| `target_python` | string \| null | Target Python version requested via `--target-python`, or `null` when not set. |
 
 ### `results[]`
 
@@ -78,6 +82,8 @@ Use the following contract expectations when writing parsers.
 | `metadata.tool_version` | Stable | Safe for telemetry and compatibility checks. |
 | `metadata.generated_at` | Stable | Safe for run timestamp tracking. |
 | `metadata.target_path` | Stable | Safe for target correlation. |
+| `metadata.programming_model` | Stable | Safe for detecting v1/v2/mixed project state. |
+| `metadata.target_python` | Stable | Safe for correlating requested target Python version. |
 | `results[].category` | Stable | Prefer for machine grouping. |
 | `results[].status` | Stable | Safe for section-level logic. |
 | `results[].items[].label` | Stable | Safe for human-readable matching. |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -123,7 +123,7 @@ Target Python: 3.12 (override) — Tool runtime: 3.13.0
 Example failing detail:
 
 ```text
-No virtual environment detected (VIRTUAL_ENV, CONDA_PREFIX, UV_PROJECT_ENVIRONMENT)
+Targets not found
 ```
 
 ## 5) `check_python_executable`
@@ -147,7 +147,7 @@ Example detail:
 Example failing detail:
 
 ```text
-No dependency manifest found (requirements.txt or pyproject.toml)
+<path>/requirements.txt not found and pyproject.toml declares no dependencies
 ```
 
 ## 7) `check_azure_functions_library`

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -32,21 +32,36 @@ Only required failures produce non-zero process exit code.
 
 ## Built-in rule types
 
+The built-in ruleset uses the following handler types:
+
 - `compare_version`
-- `env_var_exists`
 - `path_exists`
 - `file_exists`
-- `package_installed`
+- `dependency_manifest`
 - `package_declared`
+- `package_forbidden`
 - `native_dependency_risk`
 - `source_code_contains`
+- `blueprint_registration`
 - `conditional_exists`
 - `callable_detection`
 - `executable_exists`
 - `any_of_exists`
 - `file_glob_check`
 - `host_json_property`
-- `blueprint_registration`
+- `host_json_version`
+- `host_json_extension_bundle_version`
+- `local_settings_security`
+- `decorator_order`
+- `endpoint_metadata`
+- `openapi_version_mixing`
+- `scan_before_spec`
+- `langgraph_anonymous_auth`
+- `durable_nondeterminism`
+- `unsupported_metadata_version`
+
+For the authoritative, script-generated list of every built-in rule and its
+type, see the [Rule Inventory](rule_inventory.md).
 
 ## Rule-by-rule reference
 
@@ -101,14 +116,14 @@ Target Python: 3.12 (override) — Tool runtime: 3.13.0
 
 ## 4) `check_venv`
 
-- **What it checks:** Environment variable `VIRTUAL_ENV` exists.
+- **What it checks:** A virtual environment is activated — any of `VIRTUAL_ENV`, `CONDA_PREFIX`, or `UV_PROJECT_ENVIRONMENT` is set (venv, conda, or uv).
 - **Why it matters:** Virtual environments reduce dependency drift and environment pollution.
-- **How to fix:** Create and activate `.venv` before running diagnostics.
+- **How to fix:** Create and activate a virtual environment (`.venv`, conda, or uv) before running diagnostics.
 
 Example failing detail:
 
 ```text
-VIRTUAL_ENV is not set
+No virtual environment detected (VIRTUAL_ENV, CONDA_PREFIX, UV_PROJECT_ENVIRONMENT)
 ```
 
 ## 5) `check_python_executable`
@@ -125,19 +140,19 @@ Example detail:
 
 ## 6) `check_requirements_txt`
 
-- **What it checks:** `requirements.txt` exists at project root.
+- **What it checks:** Dependencies are declared via `requirements.txt` or `pyproject.toml` at the project root.
 - **Why it matters:** Deployability and reproducibility depend on declared dependencies.
-- **How to fix:** Add `requirements.txt` and include runtime dependencies.
+- **How to fix:** Add `requirements.txt` (or declare dependencies in `pyproject.toml`) and include runtime dependencies.
 
 Example failing detail:
 
 ```text
-/workspace/app/requirements.txt not found
+No dependency manifest found (requirements.txt or pyproject.toml)
 ```
 
 ## 7) `check_azure_functions_library`
 
-- **What it checks:** `azure-functions` appears in `requirements.txt`.
+- **What it checks:** `azure-functions` is declared in `requirements.txt` or `pyproject.toml`.
 - **Why it matters:** Function app code depends on Azure Functions Python library.
 - **How to fix:** Add `azure-functions` to dependency declarations.
 
@@ -147,7 +162,7 @@ Example failing detail:
 Package 'azure-functions' not declared in requirements.txt
 ```
 
-## 7) `check_native_dependency_risk`
+## 8) `check_native_dependency_risk`
 
 - **What it checks:** `requirements.txt` for packages with common native-extension deployment risk.
 - **Why it matters:** These packages are valid, but Azure Functions Python deployments often fail when Linux wheels or system libraries do not match the build environment.
@@ -166,7 +181,7 @@ Recommended: use remote build (`func azure functionapp publish --build remote`).
 - pillow: ensure libjpeg/zlib-compatible wheels for Linux deployment
 ```
 
-## 8) `check_host_json`
+## 9) `check_host_json`
 
 - **What it checks:** `host.json` exists at project root.
 - **Why it matters:** Azure Functions host configuration is required for valid app structure.
@@ -178,7 +193,7 @@ Example failing detail:
 /workspace/app/host.json not found
 ```
 
-## 9) `check_local_settings`
+## 10) `check_local_settings`
 
 - **What it checks:** `local.settings.json` exists.
 - **Why it matters:** Local development often needs this file for settings and connection values.
@@ -190,7 +205,7 @@ Example warning detail:
 /workspace/app/local.settings.json not found (optional)
 ```
 
-## 10) `check_func_cli`
+## 11) `check_func_cli`
 
 - **What it checks:** `func` executable is available on `PATH`.
 - **Why it matters:** Core Tools enable local hosting and rich runtime tooling.
@@ -202,7 +217,7 @@ Example warning detail:
 func not found
 ```
 
-## 11) `check_func_core_tools_version`
+## 12) `check_func_core_tools_version`
 
 - **What it checks:** Core Tools version is `>=4.0`.
 - **Why it matters:** Older versions can diverge from current host/runtime expectations.
@@ -214,7 +229,7 @@ Example warning detail:
 func 3.0.3904 (>=4.0)
 ```
 
-## 12) `check_durabletask_config`
+## 13) `check_durabletask_config`
 
 - **What it checks:** If durable usage is detected in source, `$.extensions.durableTask` exists in `host.json`.
 - **Why it matters:** Durable Functions need matching host configuration.
@@ -232,7 +247,7 @@ or
 Required host.json property '$.extensions.durableTask' not found
 ```
 
-## 13) `check_app_insights`
+## 14) `check_app_insights`
 
 - **What it checks:** At least one telemetry signal exists:
   - `APPLICATIONINSIGHTS_CONNECTION_STRING`
@@ -247,7 +262,7 @@ Example warning detail:
 Targets not found
 ```
 
-## 14) `check_extension_bundle`
+## 15) `check_extension_bundle`
 
 - **What it checks:** `$.extensionBundle` exists in `host.json`.
 - **Why it matters:** Extension bundles help ensure binding dependencies are available.
@@ -259,7 +274,7 @@ Example warning detail:
 host.json property '$.extensionBundle' not found
 ```
 
-## 15) `check_asgi_wsgi_exposure`
+## 16) `check_asgi_wsgi_exposure`
 
 - **What it checks:** Source has ASGI/WSGI exposure patterns.
 - **Why it matters:** Useful signal for framework-host integration readiness.
@@ -271,7 +286,7 @@ Example warning detail:
 No ASGI/WSGI callable detected in project source
 ```
 
-## 16) `check_unused_files`
+## 17) `check_unused_files`
 
 - **What it checks:** Presence of unwanted patterns (for example `**/*.pyc`, `**/__pycache__`, `.venv`, `tests/`).
 - **Why it matters:** Reduces deployment package clutter and risk.
@@ -282,6 +297,90 @@ Example warning detail:
 ```text
 Found unwanted files: ['tests/', '.venv']
 ```
+
+## 18) `check_azure_functions_worker`
+
+- **What it checks:** `azure-functions-worker` is **not** declared in `requirements.txt`.
+- **Why it matters:** The Azure Functions platform manages the worker runtime; pinning it can cause deployment failures.
+- **How to fix:** Remove `azure-functions-worker` from your dependency declarations.
+- **Severity:** Warning only (`required: false`).
+
+## 19) `check_host_json_version`
+
+- **What it checks:** `host.json` declares `"version": "2.0"` as required by the v2 runtime.
+- **Why it matters:** An incorrect or missing host version breaks v2 app indexing.
+- **How to fix:** Set `{ "version": "2.0" }` in `host.json`.
+- **Severity:** Required (`required: true`).
+
+## 20) `check_funcignore`
+
+- **What it checks:** A `.funcignore` file is present to control what gets deployed.
+- **Why it matters:** Without it, unnecessary files can bloat the deployment package.
+- **How to fix:** Add a `.funcignore` file excluding local-only paths.
+- **Severity:** Warning only (`required: false`).
+
+## 21) `check_local_settings_git_tracked`
+
+- **What it checks:** `local.settings.json` is **not** tracked by git.
+- **Why it matters:** Tracking it can leak secrets into version control.
+- **How to fix:** Add `local.settings.json` to `.gitignore` and untrack it.
+- **Severity:** Warning only (`required: false`).
+
+## 22) `check_extension_bundle_v4`
+
+- **What it checks:** `extensionBundle` in `host.json` uses the recommended v4 range `[4.*, 5.0.0)`.
+- **Why it matters:** Aligns binding extensions with the current supported bundle.
+- **How to fix:** Update the `extensionBundle.version` range to the v4 range.
+- **Severity:** Warning only (`required: false`).
+
+## 23) `check_decorator_order`
+
+- **What it checks:** `@validate_http` is not stacked outside `@with_context`. The correct order (top to bottom) is `@app.route` → `@with_context` → `@validate_http`.
+- **Why it matters:** Incorrect decorator order changes request handling behavior.
+- **How to fix:** Reorder decorators so `@with_context` wraps `@validate_http`.
+- **Severity:** Warning only (`required: false`).
+
+## 24) `check_endpoint_metadata`
+
+- **What it checks:** In projects depending on `azure-functions-validation`, HTTP route handlers use `@validate_http` so they emit endpoint OpenAPI metadata.
+- **Why it matters:** Handlers without it will not appear in generated OpenAPI specs.
+- **How to fix:** Apply `@validate_http` to route handlers that should emit metadata.
+- **Severity:** Warning only (`required: false`).
+
+## 25) `check_openapi_version_mixing`
+
+- **What it checks:** A project does not mix OpenAPI 3.0 signals (3.0.x version strings or the `nullable` keyword) with OpenAPI 3.1 signals (3.1.x version strings).
+- **Why it matters:** Mixing versions produces inconsistent generated specs.
+- **How to fix:** Standardize on a single OpenAPI version across the project.
+- **Severity:** Warning only (`required: false`).
+
+## 26) `check_scan_before_spec`
+
+- **What it checks:** The OpenAPI spec is not built before endpoints are scanned/registered (and not built without any endpoint scan).
+- **Why it matters:** Building the spec too early yields an empty or incomplete spec.
+- **How to fix:** Scan/register endpoints before building the spec.
+- **Severity:** Warning only (`required: false`).
+
+## 27) `check_langgraph_anonymous_auth`
+
+- **What it checks:** In projects that import `langgraph`, HTTP routes do not use `auth_level` set to `ANONYMOUS`.
+- **Why it matters:** Anonymous auth leaves graph endpoints publicly reachable.
+- **How to fix:** Set a non-anonymous `auth_level` for LangGraph HTTP routes.
+- **Severity:** Warning only (`required: false`).
+
+## 28) `check_durable_nondeterminism`
+
+- **What it checks:** Orchestration or entity trigger functions do not call nondeterministic APIs (`datetime.now`, `random`, `uuid`, `requests`, `open`, `os.getenv`).
+- **Why it matters:** Nondeterministic calls break Durable Functions replay.
+- **How to fix:** Move nondeterministic work into activity functions.
+- **Severity:** Required (`required: true`).
+
+## 29) `check_unsupported_metadata_version`
+
+- **What it checks:** `host.json` `extensionBundle.version` or a metadata file does not declare a version outside the configured supported set.
+- **Why it matters:** Unsupported metadata versions can fail at load or deploy time.
+- **How to fix:** Use a supported metadata/bundle version.
+- **Severity:** Warning only (`required: false`).
 
 ## Rule authoring template
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -66,7 +66,7 @@ To ensure the integrity of our codebase, we employ several automated security sc
 
 - **No Outbound Requests**: The documented diagnostics and version checks do not contact remote servers. The Azure Functions Core Tools version check runs the locally installed `func` CLI as a subprocess and compares the reported version locally.
 - **Privacy**: No telemetry, analytics, or user data is collected or sent to any remote servers.
-- **Resilience**: Checks that depend on external tooling (such as the `func` CLI) are designed to fail gracefully. If the tool is unavailable, the corresponding check shows a "skip" status rather than crashing.
+- **Resilience**: Checks that depend on external tooling (such as the `func` CLI) are designed to fail gracefully. If the tool is unavailable, the handler returns a `fail` result which is then surfaced as a `warn` because the rule is optional — the process does not crash.
 
 > Note: some diagnostic rules scan user project code for risky patterns such as `requests.get(...)` calls. These are string patterns detected in the analyzed project — they are not runtime dependencies or network calls made by `azure-functions-doctor` itself.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -53,9 +53,9 @@ To ensure the integrity of our codebase, we employ several automated security sc
 ### Within Scope
 - **Diagnostic Rule Integrity**: Rules must not execute arbitrary code. The core logic of the doctor is designed to evaluate state, not provide a platform for execution.
 - **Custom Rules Trust Boundary**: When a user specifies a custom `rules.json` path, that file is treated as a trusted input.
-- **Network Requests**: The tool makes outbound HTTP requests exclusively to check for updates to Azure Functions Core Tools using the `requests` library.
+- **Network Behavior**: The documented diagnostics and version checks do not make outbound network requests. The Azure Functions Core Tools version check invokes the locally installed `func` CLI via a subprocess rather than contacting a remote registry.
 - **Input Validation**: Path arguments and user-provided inputs are validated to prevent common vulnerabilities like path traversal.
-- **Dependency Security**: We monitor our five runtime dependencies (jsonschema, packaging, requests, rich, typer) for known vulnerabilities.
+- **Dependency Security**: We monitor our runtime dependencies (jsonschema, packaging, rich, typer, and `tomli` on Python < 3.11) for known vulnerabilities.
 
 ### Out of Scope
 - **Diagnosed Project Security**: The security posture of the Azure Functions projects being analyzed is the responsibility of the project owner.
@@ -64,9 +64,11 @@ To ensure the integrity of our codebase, we employ several automated security sc
 
 ## Network Behavior
 
-- **Update Checks**: The doctor makes outbound HTTP requests to official registries to compare local Azure Functions Core Tools versions with the latest available releases.
+- **No Outbound Requests**: The documented diagnostics and version checks do not contact remote servers. The Azure Functions Core Tools version check runs the locally installed `func` CLI as a subprocess and compares the reported version locally.
 - **Privacy**: No telemetry, analytics, or user data is collected or sent to any remote servers.
-- **Resilience**: Network requests are designed to fail gracefully. If a connection cannot be established, the corresponding check will show a "skip" status rather than crashing the tool.
+- **Resilience**: Checks that depend on external tooling (such as the `func` CLI) are designed to fail gracefully. If the tool is unavailable, the corresponding check shows a "skip" status rather than crashing.
+
+> Note: some diagnostic rules scan user project code for risky patterns such as `requests.get(...)` calls. These are string patterns detected in the analyzed project — they are not runtime dependencies or network calls made by `azure-functions-doctor` itself.
 
 ## Custom Rules Trust Model
 
@@ -84,11 +86,11 @@ To ensure the integrity of our codebase, we employ several automated security sc
 
 ## Dependency Security
 
-The project relies on a minimal set of five runtime dependencies:
+The project relies on a minimal set of runtime dependencies:
 - **jsonschema**: For validating rule files and configurations.
 - **packaging**: For handling version comparisons.
-- **requests**: For secure outbound HTTP communication.
 - **rich**: For formatted terminal output.
 - **typer**: For building the command-line interface.
+- **tomli**: For parsing `pyproject.toml` on Python < 3.11 (the standard-library `tomllib` is used on 3.11+).
 
 We use Dependabot to monitor these dependencies and provide automated updates for security vulnerabilities and version upgrades. All chosen dependencies are widely-used and actively maintained packages.

--- a/docs/supported_versions.md
+++ b/docs/supported_versions.md
@@ -70,7 +70,7 @@ strategy:
 ## CLI and API Compatibility Expectations
 
 - CLI command surface: `azure-functions-doctor doctor` with documented options.
-- Public API surface: `run_diagnostics(path, profile, rules_path)`.
+- Public API surface: `run_diagnostics(path, profile, rules_path, target_python)`.
 - Changes to public behavior should be reflected in tests, docs, and release notes.
 
 Programmatic compatibility check example:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -28,7 +28,7 @@ azure-functions-doctor doctor
 Specific path:
 
 ```bash
-azure-functions-doctor doctor --path ./apps/orders-function
+azure-functions-doctor doctor ./apps/orders-function
 ```
 
 Required-only profile:
@@ -59,7 +59,7 @@ azure-functions-doctor doctor --target-python 3.12
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `--path` | string | `.` | Target project directory. |
+| *(positional)* | string | `.` | Target project directory. |
 | `--format` | enum | `table` | Output format: `table`, `json`, `sarif`, `junit`. |
 | `--output` | path | unset | Write output to file instead of stdout. |
 | `-v`, `--verbose` | flag | `false` | Show fix hints for non-passing checks (table mode). |
@@ -145,13 +145,13 @@ Each diagnostic item is represented as a test case.
 Single app repository:
 
 ```bash
-azure-functions-doctor doctor --path .
+azure-functions-doctor doctor .
 ```
 
 Monorepo app path:
 
 ```bash
-azure-functions-doctor doctor --path ./services/payments-function
+azure-functions-doctor doctor ./services/payments-function
 ```
 
 Use explicit paths in CI to avoid accidental root-level checks.
@@ -177,7 +177,7 @@ tool runtime and table output adds `Target Python: X.Y (override)` near the head
 Example:
 
 ```bash
-azure-functions-doctor doctor --path ./apps/orders-function --target-python 3.12
+azure-functions-doctor doctor ./apps/orders-function --target-python 3.12
 ```
 
 When omitted, doctor keeps checking the current interpreter and labels it as the
@@ -368,7 +368,7 @@ Use JUnit format and publish `doctor-junit.xml` as a test artifact.
 
 Symptom: CLI returns parameter error.
 
-Fix: Ensure `--path` points to an existing readable directory.
+Fix: Ensure the positional path argument points to an existing readable directory.
 
 ### Unknown profile
 
@@ -393,7 +393,7 @@ Fix: validate JSON and schema compatibility.
 - Run `minimal` as hard CI gate
 - Run `full` in local development and scheduled quality checks
 - Keep JSON artifacts for failed CI runs
-- Prefer explicit `--path` in monorepos
+- Prefer explicit path arguments in monorepos
 - Use `--verbose` for faster local remediation
 
 ## Related docs

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,7 +62,7 @@ azure-functions-doctor doctor --target-python 3.12
 | `--path` | string | `.` | Target project directory. |
 | `--format` | enum | `table` | Output format: `table`, `json`, `sarif`, `junit`. |
 | `--output` | path | unset | Write output to file instead of stdout. |
-| `--verbose` | flag | `false` | Show fix hints for non-passing checks (table mode). |
+| `-v`, `--verbose` | flag | `false` | Show fix hints for non-passing checks (table mode). |
 | `--debug` | flag | `false` | Enable debug logging for troubleshooting. |
 | `--profile` | enum | `full` behavior | Rule profile: `minimal` or `full`. |
 | `--rules` | path | unset | Custom rules file path. |
@@ -169,6 +169,7 @@ Supported values:
 - `3.11`
 - `3.12`
 - `3.13`
+- `3.14`
 
 When set, the Python version rule compares the override value instead of the
 tool runtime and table output adds `Target Python: X.Y (override)` near the header.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -28,7 +28,7 @@ azure-functions-doctor doctor
 Specific path:
 
 ```bash
-azure-functions-doctor doctor ./apps/orders-function
+azure-functions-doctor doctor --path ./apps/orders-function
 ```
 
 Required-only profile:
@@ -59,7 +59,7 @@ azure-functions-doctor doctor --target-python 3.12
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| *(positional)* | string | `.` | Target project directory. |
+| `--path` | string | `.` | Target project directory. |
 | `--format` | enum | `table` | Output format: `table`, `json`, `sarif`, `junit`. |
 | `--output` | path | unset | Write output to file instead of stdout. |
 | `-v`, `--verbose` | flag | `false` | Show fix hints for non-passing checks (table mode). |
@@ -145,13 +145,13 @@ Each diagnostic item is represented as a test case.
 Single app repository:
 
 ```bash
-azure-functions-doctor doctor .
+azure-functions-doctor doctor --path .
 ```
 
 Monorepo app path:
 
 ```bash
-azure-functions-doctor doctor ./services/payments-function
+azure-functions-doctor doctor --path ./services/payments-function
 ```
 
 Use explicit paths in CI to avoid accidental root-level checks.
@@ -177,7 +177,7 @@ tool runtime and table output adds `Target Python: X.Y (override)` near the head
 Example:
 
 ```bash
-azure-functions-doctor doctor ./apps/orders-function --target-python 3.12
+azure-functions-doctor doctor --path ./apps/orders-function --target-python 3.12
 ```
 
 When omitted, doctor keeps checking the current interpreter and labels it as the
@@ -368,7 +368,7 @@ Use JUnit format and publish `doctor-junit.xml` as a test artifact.
 
 Symptom: CLI returns parameter error.
 
-Fix: Ensure the positional path argument points to an existing readable directory.
+Fix: Ensure `--path` points to an existing readable directory.
 
 ### Unknown profile
 
@@ -393,7 +393,7 @@ Fix: validate JSON and schema compatibility.
 - Run `minimal` as hard CI gate
 - Run `full` in local development and scheduled quality checks
 - Keep JSON artifacts for failed CI runs
-- Prefer explicit path arguments in monorepos
+- Prefer explicit `--path` in monorepos
 - Use `--verbose` for faster local remediation
 
 ## Related docs


### PR DESCRIPTION
## Summary
Docs-only sync of `docs/` to the actual v0.19.1 CLI/API surface and built-in rule inventory. No source code changes.

- **CLI/API**: add `--target-python` and `-v/--verbose` to `api.md`, `supported_versions.md`, `usage.md`, `configuration.md`; document Python 3.14 as a supported target.
- **configuration.md**: remove the phantom `Config` / `get_config` / `FUNC_DOCTOR_*` environment object (not present in source) and replace it with the real `AZURE_FUNCTIONS_DOCTOR_LOG_LEVEL` variable.
- **security.md**: correct network claims — the documented diagnostics/version checks make no outbound requests; the Core Tools version check runs the local `func` CLI via subprocess. Fix the runtime dependency list (drop `requests`, note conditional `tomli`) and clarify that `requests.*` is a user-code scan pattern, not a runtime dependency.
- **deployment.md / json_output_contract.md**: bump the JSON metadata example to `0.19.1`, add the real `programming_model` / `target_python` fields, and correct the Python range to 3.10-3.14.
- **rules.md / RULE_POLICY.md**: sync the rule inventory with `assets/rules/v2.json` (29 rules, numbered 1-29); fix `check_venv` (`any_of_exists` over `VIRTUAL_ENV`/`CONDA_PREFIX`/`UV_PROJECT_ENVIRONMENT`), `check_requirements_txt` (`dependency_manifest`, incl. `pyproject.toml`), and add `check_durable_nondeterminism` as a required Core rule.

All facts verified against v0.19.1 source (`cli.py`, `api.py`, `doctor.py`, `logging_config.py`, `assets/rules/v2.json`, `pyproject.toml`).

## Notes for reviewers
- Docs-only; touches no `README.md` and no code, so the translation rule and CLI/test-parity rule do not apply.
- Local pre-commit required `SKIP=bandit,forbid-korean` due to two **pre-existing** local blockers unrelated to this change:
  - `bandit` hook can't install under the local hatch env's Python 3.9.6 (needs >=3.10) — tracked in #259.
  - `forbid-korean` hook (`pass_filenames: false`) flags the unmodified `README.md` language switcher (`[한국어]`) — tracked in #258.
- `ruff`/`mypy` ran clean (no Python files in scope).

Closes #257