### PR TITLE
docs(i18n): adopt best-effort translation policy with staleness banners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,9 @@
 - Preserve Python 3.10+ compatibility declared in `pyproject.toml`.
 
 ### Documentation & Translations
-- When a change touches `README.md` or any English documentation, update the translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) **in the same PR** so translations never drift from the English source.
-- This applies to any code change that alters documented behavior, CLI output, or the ecosystem/package table — not just direct edits to prose.
-- If a full translation cannot land in the same PR, add a short "translation pending" note to the affected translated file and open a tracking issue before merging.
+- English (`README.md`) is the **canonical** source of truth for all documentation. Translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) are **best-effort**, community-maintained, and may lag the English source.
+- Translation sync is **not** required in the same PR as an English change, and a PR is **never** blocked by translation drift. Update translations opportunistically; when you do, keep them faithful to the current English source.
+- Each translated README carries a staleness banner linking back to the canonical English README. Keep that banner in place so readers always know the translation may be out of date.
 
 ### Action Pinning
 - All external `uses:` references in `.github/workflows/` must be SHA-pinned per `CONTRIBUTING.md` § "GitHub Actions Pinning". The PyPA publish action, local composite actions (`uses: ./...`), and the end-user `azure-functions-preflight.yml` template are the only documented exceptions and must carry an inline comment at the call site.

--- a/README.ja.md
+++ b/README.ja.md
@@ -13,6 +13,8 @@
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 
+> ℹ️ この翻訳はコミュニティによる参考用であり、最新の [English README](README.md) より古い場合があります。正確な最新情報は英語版を参照してください。
+
 Azure Functions Doctor は、**Azure Functions Python v2 プログラミングモデル**で構築されたプロジェクトのための診断 CLI ツールです。
 
 このツールは、ローカルプロジェクトにおける以下のような一般的な問題をチェックします：

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,6 +13,8 @@
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
+> ℹ️ 이 번역은 커뮤니티가 관리하는 참고용 문서로, 최신 [English README](README.md)보다 뒤처질 수 있습니다. 정확한 최신 정보는 영어 원문을 기준으로 하세요.
+
 Azure Functions Doctor는 **Azure Functions Python v2 프로그래밍 모델**로 구축된 프로젝트를 위한 진단 CLI 도구입니다.
 
 이 도구는 로컬 프로젝트에서 다음과 같은 일반적인 문제들을 점검합니다:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,8 @@
 
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
 
+> ℹ️ 本翻译由社区维护，仅供参考，可能落后于最新的 [English README](README.md)。请以英文版为准。
+
 Azure Functions Doctor 是一个用于诊断基于 **Azure Functions Python v2 编程模型** 构建的项目的 CLI 工具。
 
 它会检查本地项目中存在的常见问题，例如：


### PR DESCRIPTION
## Context
Closes #267. Fleet rollout of the best-effort translation policy from azure-functions-validation#314 (Option B): English README is canonical, translations are best-effort and may lag, and a PR is never blocked by translation drift. No translations are deleted.

## Changes
- AGENTS.md: rewrite Documentation & Translations to the best-effort policy.
- README.ko.md / README.ja.md / README.zh-CN.md: add a localized staleness banner linking to the canonical README.md.