### PR TITLE
docs: fix invalid positional path in CLI examples

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ sequenceDiagram
     participant HDLR as handlers.py
     participant TR as target_resolver.py
 
-    Dev->>CLI: fdoctor doctor ./my-project
+    Dev->>CLI: azure-functions-doctor doctor --path ./my-project
     CLI->>DOC: Doctor(path, profile, rules_path)
     DOC->>RULES: load + schema-validate rules
     DOC->>DOC: apply profile filter

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,7 +72,7 @@ This is the core workflow for this repository: diagnose first, deploy second.
 Healthy project check:
 
 ```bash
-azure-functions-doctor doctor examples/v2/http-trigger --profile minimal
+azure-functions-doctor doctor --path examples/v2/http-trigger --profile minimal
 ```
 
 Representative text output:
@@ -98,7 +98,7 @@ Exit code: 0
 Broken project detection (missing `host.json`):
 
 ```bash
-azure-functions-doctor doctor examples/v2/broken-missing-host-json --profile minimal
+azure-functions-doctor doctor --path examples/v2/broken-missing-host-json --profile minimal
 ```
 
 Representative text output:
@@ -125,16 +125,16 @@ Machine-readable output formats:
 
 ```bash
 # JSON
-azure-functions-doctor doctor examples/v2/http-trigger --profile minimal --format json --output doctor-report.json
+azure-functions-doctor doctor --path examples/v2/http-trigger --profile minimal --format json --output doctor-report.json
 
 # SARIF (for code scanning / security tooling)
-azure-functions-doctor doctor examples/v2/http-trigger --profile minimal --format sarif --output doctor-report.sarif
+azure-functions-doctor doctor --path examples/v2/http-trigger --profile minimal --format sarif --output doctor-report.sarif
 
 # JUnit (for CI test dashboards)
-azure-functions-doctor doctor examples/v2/http-trigger --profile minimal --format junit --output doctor-report.xml
+azure-functions-doctor doctor --path examples/v2/http-trigger --profile minimal --format junit --output doctor-report.xml
 
 # Summary JSON sidecar (quick pass/fail counts)
-azure-functions-doctor doctor examples/v2/http-trigger --profile minimal --summary-json doctor-summary.json
+azure-functions-doctor doctor --path examples/v2/http-trigger --profile minimal --summary-json doctor-summary.json
 ```
 
 Representative JSON output (`doctor-report.json`):
@@ -230,7 +230,7 @@ az functionapp list-flexconsumption-locations -o table
 ### Step 4 — Re-run doctor on the healthy sample (deployment gate)
 
 ```bash
-azure-functions-doctor doctor examples/v2/http-trigger --profile minimal
+azure-functions-doctor doctor --path examples/v2/http-trigger --profile minimal
 ```
 
 Proceed only if the command exits with `0`.
@@ -314,19 +314,19 @@ jobs:
           pip install azure-functions-doctor
 
       - name: Run doctor (text)
-        run: azure-functions-doctor doctor . --profile minimal
+        run: azure-functions-doctor doctor --profile minimal
 
       - name: Run doctor (JSON)
-        run: azure-functions-doctor doctor . --profile minimal --format json --output doctor-report.json
+        run: azure-functions-doctor doctor --profile minimal --format json --output doctor-report.json
 
       - name: Run doctor (SARIF)
-        run: azure-functions-doctor doctor . --profile minimal --format sarif --output doctor-report.sarif
+        run: azure-functions-doctor doctor --profile minimal --format sarif --output doctor-report.sarif
 
       - name: Run doctor (JUnit)
-        run: azure-functions-doctor doctor . --profile minimal --format junit --output doctor-report.xml
+        run: azure-functions-doctor doctor --profile minimal --format junit --output doctor-report.xml
 
       - name: Run doctor (summary sidecar)
-        run: azure-functions-doctor doctor . --profile minimal --summary-json doctor-summary.json
+        run: azure-functions-doctor doctor --profile minimal --summary-json doctor-summary.json
 
       - name: Publish
         if: success()
@@ -367,7 +367,7 @@ python3 --version
 az --version
 func --version
 pip show azure-functions-doctor
-azure-functions-doctor doctor . --profile minimal -v
+azure-functions-doctor doctor --profile minimal -v
 ```
 
 ### Before opening an issue
@@ -388,7 +388,7 @@ python --version
 pip show azure-functions-doctor
 
 # 5. Doctor output on your project
-azure-functions-doctor doctor . -v
+azure-functions-doctor doctor -v
 
 # 6. Function App status (if deployed)
 az functionapp show \


### PR DESCRIPTION
## Context

The \`doctor\` CLI declares \`path\` as a Typer **option** with a default of \`.\`:

\`\`\`python
def doctor(path: str = ".", ...):
\`\`\`

In Typer, a bare parameter **with a default** becomes an \`--option\`, not a positional argument. Verified against runtime \`--help\` output — the command exposes \`--path\` and has **no positional arguments**. Positional invocations therefore fail at parse time:

- \`azure-functions-doctor doctor examples/v2/http-trigger\` → **exit code 2** (unexpected argument)
- \`azure-functions-doctor doctor .\` → **exit code 2**
- \`azure-functions-doctor doctor --path examples/v2/http-trigger\` → **exit 0** ✅
- \`azure-functions-doctor doctor\` (relies on default \`.\`) → runs ✅

\`docs/deployment.md\` (15 call sites) and the \`docs/architecture.md\` sequence diagram used the invalid positional form. \`README.md\`, \`scaffold_integration.md\`, \`usage.md\`, and \`configuration.md\` already use the correct \`--path\` form.

## Changes

- \`docs/deployment.md\`: \`doctor <path>\` → \`doctor --path <path>\`; \`doctor . <flags>\` → \`doctor <flags>\` (rely on default).
- \`docs/architecture.md\`: sequence-diagram step \`fdoctor doctor ./my-project\` → \`azure-functions-doctor doctor --path ./my-project\` (also switches the deprecated \`fdoctor\` alias to the canonical command).

## Verification

- Ran the CLI via \`typer.testing.CliRunner\` against the installed package (v0.19.1): positional path exits 2, \`--path\` exits 0, bare \`doctor\` parses.
- \`grep\` confirms no residual positional-path examples remain in the docs.
- No \`docs/\` translations exist and \`README.md\` is untouched, so no translated-file updates are required.