### PR TITLE
docs: sync minimal-profile check count to 6 after durable rule

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -90,8 +90,11 @@ Project Structure
 [PASS] host.json: found
 [PASS] host.json version: "2.0"
 
+Durable
+[PASS] Orchestrator determinism: No nondeterministic calls detected in orchestrators
+
 Doctor summary (to see all details, run azure-functions-doctor doctor -v):
-  0 fails, 0 warnings, 5 passed
+  0 fails, 0 warnings, 6 passed
 Exit code: 0
 ```
 
@@ -116,8 +119,11 @@ Project Structure
 [FAIL] host.json: file not found (fail)
 [FAIL] host.json version: host.json missing or invalid (fail)
 
+Durable
+[PASS] Orchestrator determinism: No nondeterministic calls detected in orchestrators
+
 Doctor summary (to see all details, run azure-functions-doctor doctor -v):
-  2 fails, 0 warnings, 3 passed
+  2 fails, 0 warnings, 4 passed
 Exit code: 1
 ```
 
@@ -186,7 +192,7 @@ Representative JUnit output (`doctor-report.xml`):
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
-<testsuite name="func-doctor" tests="5" failures="0" skipped="0" time="0.021">
+<testsuite name="func-doctor" tests="6" failures="0" skipped="0" time="0.021">
   <testcase classname="Python Env" name="Python version" />
   <testcase classname="Project Structure" name="host.json" />
 </testsuite>
@@ -195,7 +201,7 @@ Representative JUnit output (`doctor-report.xml`):
 Representative summary sidecar content:
 
 ```json
-{"passed":5,"warned":0,"failed":0}
+{"passed":6,"warned":0,"failed":0}
 ```
 
 When checks fail, doctor exits with code `1`. Use that exit code to block deployment.

--- a/docs/minimal_profile.md
+++ b/docs/minimal_profile.md
@@ -26,13 +26,14 @@ This means `minimal` behavior adapts to your custom rules file if you provide on
 
 ## Built-in minimal rule set (current)
 
-With built-in `v2.json`, minimal includes these 5 checks:
+With built-in `v2.json`, minimal includes these 6 checks:
 
 1. `check_python_version`
 2. `check_requirements_txt`
 3. `check_azure_functions_library`
 4. `check_host_json`
 5. `check_host_json_version`
+6. `check_durable_nondeterminism`
 
 These represent the minimum structural requirements for a valid Azure Functions Python v2 project.
 
@@ -41,10 +42,7 @@ These represent the minimum structural requirements for a valid Azure Functions 
 | Dimension | `full` profile | `minimal` profile |
 | --- | --- | --- |
 | Rule scope | Required + optional | Required only |
-| Built-in count | 20 rules | 5 rules |
-| Warning volume | Higher | Lower |
-| CI suitability | Useful for report artifacts | Best for hard gating |
-| Local guidance depth | High | Baseline only |
+| Built-in count | 29 rules | 6 rules |
 | Warning volume | Higher | Lower |
 | CI suitability | Useful for report artifacts | Best for hard gating |
 | Local guidance depth | High | Baseline only |


### PR DESCRIPTION
## Context

`check_durable_nondeterminism` (Orchestrator determinism) is marked `required: true` in `src/azure_functions_doctor/assets/rules/v2.json`, so the built-in **minimal** profile now runs **6** required checks, not 5, and **full** runs all **29** built-in rules, not 20. The docs still reflected the pre-durable numbers.

Verified against source and runtime:
- `v2.json`: 29 total rules; 6 with `required: true` (`check_python_version`, `check_requirements_txt`, `check_azure_functions_library`, `check_host_json`, `check_host_json_version`, `check_durable_nondeterminism`).
- CLI run of `doctor --path examples/v2/http-trigger --profile minimal` → `0 fails, 0 warnings, 6 passed`.
- CLI run of `doctor --path examples/v2/broken-missing-host-json --profile minimal` → `2 fails, 0 warnings, 4 passed`.
- Both runs emit a **Durable** section (`[✓] Orchestrator determinism`) that the representative outputs omitted.

## Changes

`docs/minimal_profile.md`:
- "these 5 checks" → "these 6 checks"; add `check_durable_nondeterminism` to the list.
- Count table: `20 rules / 5 rules` → `29 rules / 6 rules`.
- Remove duplicated `Warning volume` / `CI suitability` / `Local guidance depth` rows.

`docs/deployment.md` (representative outputs for the two example projects):
- Healthy: add Durable section; `5 passed` → `6 passed`.
- Broken: add Durable section; `3 passed` → `4 passed`.
- JUnit `tests="5"` → `tests="6"`; summary sidecar `{"passed":5,...}` → `{"passed":6,...}`.

## Verification

- Counts cross-checked against `v2.json` and live `CliRunner` output (package v0.19.1).
- `grep` confirms no residual `5 passed` / `3 passed` / `20 rules` / `5 rules` / `tests="5"` in the two files.
- No `docs/` translations exist and `README.md` is untouched → no translated-file updates required.
- Version-string sync (`make sync-docs-version`) only rewrites version numbers in `deployment.md`, so it is unaffected by these edits.