### PR TITLE
docs: sync diagnostics/handlers/testing to current rule set and handlers package

### DIFF
--- a/docs/RULE_POLICY.md
+++ b/docs/RULE_POLICY.md
@@ -216,7 +216,7 @@ They are **not currently enforced** by the schema or handler runtime.
 | `source_url` | URI | Direct link to the authoritative reference |
 | `tier` | `core`, `extended`, `experimental` | Explicit tier classification |
 
-To adopt these fields, update `rules.schema.json`, the `Rule` TypedDict in `handlers.py`,
+To adopt these fields, update `rules.schema.json`, the `Rule` TypedDict in `handlers/_helpers.py`,
 and all entries in `v2.json`.
 
 ---

--- a/docs/RULE_POLICY.md
+++ b/docs/RULE_POLICY.md
@@ -140,7 +140,7 @@ Core rules must rely on **deterministic, static checks**.
 |---|---|
 | `file_exists` | File present at project root |
 | `host_json_version` | JSON property equality |
-| `package_declared` | Package name appears in requirements.txt |
+| `package_declared` | Package name appears in requirements.txt (falls back to pyproject.toml) |
 | `dependency_manifest` | Dependency file (requirements.txt or pyproject.toml) exists |
 | `compare_version` | Version comparison against a fixed minimum |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ Core modules and responsibilities:
 - `__init__.py`: public exports and version string.
 - `cli.py`: Typer-based CLI entrypoint; maps flags to `Doctor` options.
 - `doctor.py`: `Doctor` runner — loads rules, executes handlers, aggregates results.
-- `handlers.py`: `Rule` type, `generic_handler`, type-based rule dispatch via `HandlerRegistry`.
+- `handlers/` package: `Rule` type and shared helpers (`_helpers.py`), plus `generic_handler` and type-based rule dispatch via `HandlerRegistry` (`registry.py`).
 - `config.py`: configuration management (reserved for future use; not yet in the runtime path).
 - `target_resolver.py`: resolves runtime values (Python version, Core Tools version) for version-comparison checks.
 - `logging_config.py`: internal logging setup.
@@ -41,7 +41,7 @@ CLI is the primary consumer. Python import use is for programmatic embedding onl
 flowchart TD
     CLI["cli.py<br/>Typer CLI"]
     DOC["doctor.py<br/>Doctor runner"]
-    HDLR["handlers.py<br/>Rule dispatch + generic_handler"]
+    HDLR["handlers/<br/>Rule dispatch + generic_handler"]
     TR["target_resolver.py<br/>Version resolution"]
     RULES[("assets/<br/>Rule inventory")]
     SCHEMAS[("schemas/<br/>JSON schemas")]
@@ -75,7 +75,7 @@ sequenceDiagram
     participant CLI as cli.py
     participant DOC as Doctor
     participant RULES as assets/v2.json
-    participant HDLR as handlers.py
+    participant HDLR as handlers/
     participant TR as target_resolver.py
 
     Dev->>CLI: azure-functions-doctor doctor --path ./my-project
@@ -132,7 +132,7 @@ Every diagnostic check is defined as a JSON object in the rule inventory (`asset
 
 ### 2. HandlerRegistry type-based dispatch
 
-`handlers.py` maintains a `HandlerRegistry` that maps rule `type` strings to handler functions. The `Doctor` runner dispatches each rule to its handler by type, enabling extensibility without modifying dispatch logic.
+The `handlers/` package (`registry.py`) maintains a `HandlerRegistry` that maps rule `type` strings to handler functions. The `Doctor` runner dispatches each rule to its handler by type, enabling extensibility without modifying dispatch logic.
 
 ### 3. Exit code contract
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -83,8 +83,8 @@ Use these commands to manage your development environment:
 To add a new diagnostic rule to the doctor:
 
 1. Define the rule metadata in `src/azure_functions_doctor/assets/rules/v2.json`.
-2. Implement the logic for the rule as a handler function in `src/azure_functions_doctor/handlers.py`.
-3. Register the handler type within the `generic_handler` dispatcher.
+2. Implement the logic for the rule as a handler method in `src/azure_functions_doctor/handlers/registry.py`.
+3. Register the handler type in the `_RULE_DISPATCH` map (`src/azure_functions_doctor/handlers/_helpers.py`).
 4. Add unit tests for the new handler in `tests/test_handler.py`.
 5. Update any relevant documentation if the behavior changes user expectations.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -107,16 +107,23 @@ Use this process to introduce a new rule type:
 
 ### Minimal handler example
 
+Add the method inside `HandlerRegistry` (`handlers/registry.py`), decorated with
+`@_rule_handler` so it is registered in `_RULE_DISPATCH`:
+
 ```python
 from pathlib import Path
 
 
-def _handle_sample(self, rule: dict, path: Path) -> dict[str, str]:
-    _ = rule
-    marker = path / ".doctor-marker"
-    if marker.exists():
-        return {"status": "pass", "detail": "Marker exists"}
-    return {"status": "fail", "detail": "Marker missing"}
+class HandlerRegistry:
+    # ... existing handlers ...
+
+    @_rule_handler
+    def _handle_sample(self, rule: dict, path: Path, context=None) -> dict[str, str]:
+        _ = (rule, context)
+        marker = path / ".doctor-marker"
+        if marker.exists():
+            return {"status": "pass", "detail": "Marker exists"}
+        return {"status": "fail", "detail": "Marker missing"}
 ```
 
 ## Debugging Tips

--- a/docs/development.md
+++ b/docs/development.md
@@ -36,7 +36,7 @@ make check-all
 - `src/azure_functions_doctor/api.py`: stable programmatic API (`run_diagnostics`)
 - `src/azure_functions_doctor/cli.py`: Typer-based CLI (`azure-functions-doctor doctor`)
 - `src/azure_functions_doctor/doctor.py`: orchestration, rule loading, section aggregation
-- `src/azure_functions_doctor/handlers.py`: handler implementations and registry dispatch
+- `src/azure_functions_doctor/handlers/`: handler implementations (`registry.py`) and shared helpers/types (`_helpers.py`)
 - `src/azure_functions_doctor/assets/rules/v2.json`: built-in diagnostics rules
 - `src/azure_functions_doctor/schemas/rules.schema.json`: schema for rule validation
 - `tests/`: unit tests, CLI tests, rule/schema tests, integration-style checks
@@ -79,7 +79,7 @@ When adding or modifying a built-in check, keep the rule-first flow:
 
 1. Edit `src/azure_functions_doctor/assets/rules/v2.json`.
 2. Ensure the rule object satisfies `rules.schema.json`.
-3. If needed, extend handler behavior in `handlers.py`.
+3. If needed, extend handler behavior in the `handlers/` package (`registry.py`).
 4. Add tests for both pass and non-pass outcomes.
 5. Update docs (`diagnostics.md`, `rule_inventory.md`, and this guide if needed).
 
@@ -99,9 +99,9 @@ When adding or modifying a built-in check, keep the rule-first flow:
 
 Use this process to introduce a new rule type:
 
-1. Add the new literal to `Rule["type"]` in `handlers.py`.
-2. Implement `_handle_<name>(self, rule, path)`.
-3. Register the handler in `HandlerRegistry.__init__`.
+1. Add the new literal to the `Rule["type"]` definition in `handlers/_helpers.py`.
+2. Implement `_handle_<name>(self, rule, path, context=None)` in `handlers/registry.py`.
+3. Register the type-to-method mapping in `_RULE_DISPATCH` (`handlers/_helpers.py`); `HandlerRegistry.__init__` binds it automatically.
 4. Extend `rules.schema.json` so the new type is schema-valid.
 5. Add tests in `tests/test_handler.py` and registry tests if needed.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -82,7 +82,7 @@ These checks run in both `full` and `minimal` profiles.
 | --- | --- | --- | --- |
 | Python version | `check_python_version` | `compare_version` | Current interpreter is lower than `3.10`. |
 | `requirements.txt` | `check_requirements_txt` | `dependency_manifest` | No dependency manifest found (`requirements.txt` or `pyproject.toml` dependency declarations). |
-| `azure-functions` package | `check_azure_functions_library` | `package_declared` | `azure-functions` is not declared in `requirements.txt`. |
+| `azure-functions` package | `check_azure_functions_library` | `package_declared` | `azure-functions` is not declared in `requirements.txt` or `pyproject.toml`. |
 | `host.json` | `check_host_json` | `file_exists` | `host.json` is missing at project root. |
 | `host.json` version | `check_host_json_version` | `host_json_version` | `host.json` does not declare `"version": "2.0"`. |
 | Orchestrator determinism | `check_durable_nondeterminism` | `durable_nondeterminism` | An orchestration/entity function calls a nondeterministic API (`datetime.now`, `random`, `uuid`, `requests`, `open`, `os.getenv`). |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -81,7 +81,7 @@ These checks run in both `full` and `minimal` profiles.
 | Label | Rule ID | Handler Type | Fails When |
 | --- | --- | --- | --- |
 | Python version | `check_python_version` | `compare_version` | Current interpreter is lower than `3.10`. |
-| `requirements.txt` | `check_requirements_txt` | `file_exists` | `requirements.txt` is missing at project root. |
+| `requirements.txt` | `check_requirements_txt` | `dependency_manifest` | No dependency manifest found (`requirements.txt` or `pyproject.toml` dependency declarations). |
 | `azure-functions` package | `check_azure_functions_library` | `package_declared` | `azure-functions` is not declared in `requirements.txt`. |
 | `host.json` | `check_host_json` | `file_exists` | `host.json` is missing at project root. |
 | `host.json` version | `check_host_json_version` | `host_json_version` | `host.json` does not declare `"version": "2.0"`. |

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -74,6 +74,7 @@ These checks run in both `full` and `minimal` profiles.
 | `azure-functions` package | Ensure the Functions library is declared. |
 | `host.json` | Ensure the project includes host configuration. |
 | `host.json` version | Ensure host.json declares `"version": "2.0"`. |
+| Orchestrator determinism | Ensure orchestrator/entity functions avoid nondeterministic APIs. |
 
 ### Required Check Details
 
@@ -84,6 +85,7 @@ These checks run in both `full` and `minimal` profiles.
 | `azure-functions` package | `check_azure_functions_library` | `package_declared` | `azure-functions` is not declared in `requirements.txt`. |
 | `host.json` | `check_host_json` | `file_exists` | `host.json` is missing at project root. |
 | `host.json` version | `check_host_json_version` | `host_json_version` | `host.json` does not declare `"version": "2.0"`. |
+| Orchestrator determinism | `check_durable_nondeterminism` | `durable_nondeterminism` | An orchestration/entity function calls a nondeterministic API (`datetime.now`, `random`, `uuid`, `requests`, `open`, `os.getenv`). |
 
 ## Optional Checks
 
@@ -111,7 +113,7 @@ These checks run only after the repository has been classified as a supported `v
 | --- | --- | --- | --- |
 | Programming model v2 | `check_programming_model_v2` | `source_code_contains` | Project source does not expose `@app.` decorators in AST mode. |
 | Blueprint registration | `check_blueprint_registration` | `blueprint_registration` | A `func.Blueprint()` alias is used in decorators but never appears in `register_functions(...)` anywhere in the project. |
-| Virtual environment | `check_venv` | `env_var_exists` | `VIRTUAL_ENV` is not set. |
+| Virtual environment | `check_venv` | `any_of_exists` | None of `VIRTUAL_ENV`, `CONDA_PREFIX`, or `UV_PROJECT_ENVIRONMENT` is set. |
 | Python executable | `check_python_executable` | `path_exists` | `sys.executable` is empty or points to a missing path. |
 | azure-functions-worker not pinned | `check_azure_functions_worker` | `package_forbidden` | `azure-functions-worker` is declared in `requirements.txt`. |
 | `local.settings.json` | `check_local_settings` | `file_exists` | Local settings file is absent for local execution scenarios. |

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -240,8 +240,8 @@ class ExtendedRegistry(HandlerRegistry):
         super().__init__()
         self._handlers["always_pass"] = self._handle_always_pass
 
-    def _handle_always_pass(self, rule: dict, path: Path) -> dict[str, str]:
-        _ = (rule, path)
+    def _handle_always_pass(self, rule: dict, path: Path, context=None) -> dict[str, str]:
+        _ = (rule, path, context)
         return {"status": "pass", "detail": "Custom handler executed"}
 
 
@@ -259,7 +259,7 @@ def run_custom_rule(project_path: str) -> dict[str, str]:
 
 When adding a new handler:
 
-1. Extend the `Rule["type"]` literal
-2. Register the handler in `HandlerRegistry`
+1. Extend the `Rule["type"]` literal in `handlers/_helpers.py`
+2. Implement `_handle_<name>(self, rule, path, context=None)` in `handlers/registry.py`, decorated with `@_rule_handler` (which registers it in `_RULE_DISPATCH`; `HandlerRegistry.__init__` binds it automatically)
 3. Update `rules.schema.json`
 4. Add tests in `tests/test_handler.py`

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -3,7 +3,9 @@
 Handlers execute rule definitions from `src/azure_functions_doctor/assets/rules/v2.json`.
 
 Each rule has a `type`, and `HandlerRegistry` routes the rule to the corresponding
-handler implementation in `src/azure_functions_doctor/handlers.py`.
+handler implementation in the `src/azure_functions_doctor/handlers/` package
+(dispatch class in `registry.py`, shared helpers in `_helpers.py`). The public
+import path `azure_functions_doctor.handlers` is preserved.
 
 ## Contract
 
@@ -57,11 +59,14 @@ Dispatch flow:
 ## Built-in Handlers
 
 - `compare_version`
-- `file_exists`
 - `env_var_exists`
 - `path_exists`
+- `file_exists`
+- `dependency_manifest`
 - `package_installed`
 - `package_declared`
+- `package_forbidden`
+- `native_dependency_risk`
 - `source_code_contains`
 - `conditional_exists`
 - `callable_detection`
@@ -69,6 +74,20 @@ Dispatch flow:
 - `any_of_exists`
 - `file_glob_check`
 - `host_json_property`
+- `host_json_version`
+- `host_json_extension_bundle_version`
+- `local_settings_security`
+- `blueprint_registration`
+- `decorator_order`
+- `endpoint_metadata`
+- `openapi_version_mixing`
+- `scan_before_spec`
+- `langgraph_anonymous_auth`
+- `durable_nondeterminism`
+- `unsupported_metadata_version`
+
+The authoritative dispatch map is `_RULE_DISPATCH` in
+`src/azure_functions_doctor/handlers/_helpers.py`.
 
 ### Handler Reference
 
@@ -78,15 +97,29 @@ Dispatch flow:
 | `env_var_exists` | `target` | Environment variable presence checks. |
 | `path_exists` | `target` | Check concrete paths or `sys.executable`. |
 | `file_exists` | `target` | Required project files (`host.json`, `requirements.txt`). |
+| `dependency_manifest` | optional `target` | Pass when dependencies are declared via `requirements.txt` **or** `pyproject.toml`. |
 | `package_installed` | `target` | Validate importable module availability. |
-| `package_declared` | `package`, optional `file` | Confirm package declaration in dependency file. |
-| `source_code_contains` | `keyword`, optional `mode` | Detect decorators or source signals. |
+| `package_declared` | `package`, optional `file` | Confirm package declaration in dependency file (falls back to `pyproject.toml`). |
+| `package_forbidden` | `package`, optional `file` | Warn when a platform-managed package (e.g. `azure-functions-worker`) is pinned. |
+| `native_dependency_risk` | optional `file` | Warn when packages with native-extension deployment risk are declared. |
+| `source_code_contains` | `keyword`, optional `mode` | Detect decorators or source signals (string or `ast` mode). |
 | `conditional_exists` | `jsonpath` | Conditional host checks (for example Durable settings). |
 | `callable_detection` | none | Detect ASGI/WSGI callable exposure patterns. |
 | `executable_exists` | `target` | Ensure local binaries exist on `PATH`. |
 | `any_of_exists` | `targets` | Pass when any env/file/host signal is present. |
 | `file_glob_check` | `patterns` | Detect junk files and deployment artifacts. |
 | `host_json_property` | `jsonpath` | Validate specific host.json properties. |
+| `host_json_version` | none | Validate `host.json` declares `"version": "2.0"`. |
+| `host_json_extension_bundle_version` | none | Validate `extensionBundle` uses the recommended v4 range. |
+| `local_settings_security` | none | Warn when `local.settings.json` is tracked by git. |
+| `blueprint_registration` | none | Warn when decorated Blueprint aliases are never registered. |
+| `decorator_order` | optional `decorators` | Warn when `@validate_http` is stacked outside `@with_context`. |
+| `endpoint_metadata` | none | Warn when route handlers lack `@validate_http` in a validation-enabled project. |
+| `openapi_version_mixing` | none | Warn when OpenAPI 3.0 and 3.1 signals both appear. |
+| `scan_before_spec` | optional `scan_names`, `spec_names` | Warn when the OpenAPI spec is built before endpoints are scanned. |
+| `langgraph_anonymous_auth` | optional `flag_missing_auth_level` | Warn when a LangGraph project exposes anonymous-auth routes. |
+| `durable_nondeterminism` | optional `blocklist`, `decorator_names` | Fail when orchestrator/entity functions call nondeterministic APIs. |
+| `unsupported_metadata_version` | optional `files`, `fields`, `supported_versions` | Warn when metadata declares an unsupported version. |
 
 ## Example Rule JSON by Handler Type
 
@@ -170,7 +203,7 @@ Dispatch flow:
 
 - `source_code_contains` supports a simple string mode and an AST-based mode.
 - `conditional_exists` is used for checks that only matter when a related feature is detected.
-- Handler implementations live in `src/azure_functions_doctor/handlers.py`.
+- Handler implementations live in the `src/azure_functions_doctor/handlers/` package (`registry.py`).
 
 ## Programmatic Usage Examples
 

--- a/docs/scaffold_integration.md
+++ b/docs/scaffold_integration.md
@@ -54,7 +54,7 @@ func new --name HttpTrigger --template "HTTP trigger"
 azure-functions-doctor doctor --profile minimal
 ```
 
-A freshly scaffolded project should pass all five required checks:
+A freshly scaffolded project should pass all six required checks:
 
 | Check | What it confirms |
 | --- | --- |
@@ -63,6 +63,7 @@ A freshly scaffolded project should pass all five required checks:
 | `azure-functions` package | SDK is declared |
 | `host.json` | Host config file exists |
 | `host.json` version | `"version": "2.0"` is set |
+| Orchestrator determinism | No nondeterministic calls in orchestrator/entity functions |
 
 **3. Fix any failures before proceeding:**
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,7 +1,7 @@
 # Testing
 
 ## Overview
-Azure Functions Doctor uses pytest as its primary testing framework. The test suite consists of 15 files with approximately 1,830 lines of code. These tests provide coverage for the CLI, diagnostic handlers, rule registration, configuration management, and error handling.
+Azure Functions Doctor uses pytest as its primary testing framework. The suite spans 20+ test modules covering the CLI, diagnostic handlers, rule registration, configuration management, and error handling.
 
 ## Running Tests
 You can execute the tests using the provided Makefile or by calling pytest directly.
@@ -15,22 +15,31 @@ python -m pytest tests/test_handler.py -v  # Run a specific test file
 ## Test Structure
 The codebase follows a modular test structure to ensure specific components are isolated and verified correctly.
 
-| File | Lines | Description |
-|------|-------|-------------|
-| test_handler.py | 377 | Individual check handler implementations |
-| test_error_handling.py | 244 | Error handling and edge cases |
-| test_handler_registry.py | 214 | Handler dispatch and registration |
-| test_config.py | 155 | Configuration loading and validation |
-| test_programming_model_detection.py | 137 | v1 vs v2 model detection |
-| test_doctor.py | 130 | Core diagnostic engine |
-| test_rule_loading.py | 121 | Rule JSON loading and validation |
-| test_logging_config.py | 106 | Logging configuration |
-| test_cli.py | 104 | CLI command tests |
-| test_rules_schema.py | 77 | Rules schema consistency |
-| test_target_resolver.py | 77 | Version resolution utilities |
-| test_api.py | 40 | Public API surface |
-| test_examples.py | 29 | Example project smoke tests |
-| test_utils.py | 19 | Utility function tests |
+| File | Description |
+|------|-------------|
+| test_handler_registry.py | Handler dispatch and per-type handler behavior |
+| test_handler_registry_extended.py | Extended handler-registry coverage and edge cases |
+| test_handler.py | Individual check handler implementations |
+| test_toolkit_rule_checks.py | DX Toolkit rule handlers (decorator order, endpoint metadata, OpenAPI, LangGraph, durable, metadata version) |
+| test_bugfix_issues.py | Regression tests for previously fixed issues |
+| test_cli.py | CLI command behavior, flags, and exit codes |
+| test_decorator_diagnostics.py | Decorator-order and related diagnostics |
+| test_programming_model_detection.py | v1 vs v2 programming-model detection |
+| test_error_handling.py | Error handling and edge cases |
+| test_doctor.py | Core diagnostic engine (Doctor runner) |
+| test_pyproject_dependency_manifest.py | pyproject.toml dependency-manifest handling |
+| test_blueprint_registration.py | Blueprint registration detection |
+| test_logging_config.py | Logging configuration |
+| test_examples.py | Example project smoke tests |
+| test_rule_loading.py | Rule JSON loading and validation |
+| test_condition_params.py | Condition parameter parsing |
+| test_native_dependency_risk.py | Native dependency risk detection |
+| test_release_workflow_pins.py | Release workflow SHA-pin verification |
+| test_target_resolver.py | Version resolution utilities |
+| test_rules_schema.py | Rules schema consistency |
+| test_api.py | Public API surface (`run_diagnostics`) |
+| test_public_api.py | Public API and version exports |
+| test_utils.py | Utility function tests |
 
 ## Test Patterns
 
@@ -50,7 +59,7 @@ Specific handlers tested include:
 CLI tests use Typer's CliRunner to invoke commands and verify output. They ensure the `doctor` subcommand behaves correctly with different flags such as `--format json`, `--profile minimal`, and `--path`. Exit codes are verified to be 0 for successful checks and 1 when failures occur.
 
 ### Rules Tests
-- **test_rule_loading.py**: Validates the loading of v1.json and v2.json rule files.
+- **test_rule_loading.py**: Validates the loading of the built-in `v2.json` ruleset (and custom rule files).
 - **test_rules_schema.py**: Ensures rule JSON files adhere to the defined schema.
 - Custom rules: Verifies that the `--rules` flag correctly loads external rule files.
 
@@ -65,7 +74,7 @@ Coverage settings are defined in `pyproject.toml`.
 - **Source**: src/azure_functions_doctor
 - **Branch coverage**: Enabled
 - **Reports**: Terminal (missing lines), HTML, and XML
-- **pytest options**: `--cov=src/azure_functions_doctor --cov-report=xml --cov-report=term-missing -ra -q`
+- **pytest options**: `--cov=src/azure_functions_doctor --cov-report=xml --cov-report=term-missing -ra -q -m 'not e2e'`
 
 ## Writing New Tests
 When contributing new features or bug fixes, follow these guidelines:


### PR DESCRIPTION
## Summary
Corrects documentation drift between narrative docs and the current source (rule inventory, handlers package, and test suite). All changes verified against `assets/rules/v2.json`, `handlers/registry.py`, `handlers/_helpers.py`, and `tests/`.

## Changes
- **Sixth required check**: add `Orchestrator determinism` (`check_durable_nondeterminism`, handler `durable_nondeterminism`, `required: true`) to `diagnostics.md` (both required tables) and `scaffold_integration.md` ("five" -> "six").
- **check_venv type fix**: `any_of_exists` (was incorrectly `env_var_exists`); Warns-When updated to `VIRTUAL_ENV` / `CONDA_PREFIX` / `UV_PROJECT_ENVIRONMENT`.
- **handlers.md**: expand Built-in Handlers list and Handler Reference table to all **27** registered dispatch types (verified via runtime `_RULE_DISPATCH`); note authoritative map in `handlers/_helpers.py`; preserve public import path note.
- **handlers.py -> handlers/ package**: fix stale single-file path references across `architecture.md`, `development.md`, `contributing.md`, `RULE_POLICY.md` (dispatch class `registry.py`, `Rule` TypedDict + `_RULE_DISPATCH` in `_helpers.py`).
- **testing.md**: rewrite Test Structure table to the current **23** test modules; drop stale "15 files / 1,830 lines" and non-existent `v1.json`/`test_config.py` references; add `-m 'not e2e'` to documented pytest options.

## Verification
- `_RULE_DISPATCH` runtime keys = 27, exactly matching the documented handler list.
- `tests/test_*.py` = 23 files, exactly matching the rewritten table.
- v2.json required checks = 6, matching the documented required tables.