### PR TITLE
docs: correct built-in rule count (15 -> 29) in semver policy

### DIFF
--- a/docs/semver_policy.md
+++ b/docs/semver_policy.md
@@ -12,7 +12,7 @@ Every built-in rule has one of three stability states:
 | **Experimental** | Under evaluation. May change behavior or be removed in a minor release. False positives are documented as known limitations. |
 | **Deprecated** | Scheduled for removal. Announced in the changelog and removed in the next major release. |
 
-All 15 current built-in rules are **stable**.
+All 29 current built-in rules are **stable**.
 
 ## State Transitions
 
@@ -49,4 +49,4 @@ The `minimal` profile runs only rules marked `required: true`. Because CI pipeli
 
 ## Current Rule Status
 
-All 15 rules in `v2.json` are **stable**. See the [Rule Inventory](rule_inventory.md) for the complete list.
+All 29 rules in `v2.json` are **stable**. See the [Rule Inventory](rule_inventory.md) for the complete list.


### PR DESCRIPTION
## Summary
`docs/semver_policy.md` hardcoded "15 rules" in two places, but the built-in ruleset (`assets/rules/v2.json`) currently ships **29 rules**. Corrected both statements.

## Verification
- `v2.json` rule count = 29 (verified programmatically).
- No rule carries a `stability` / `tier` / `experimental` field in source, so the "all stable" characterization is unchanged — only the count was wrong.

## Changes
- "All 15 current built-in rules are **stable**." -> "All 29 ...".
- "All 15 rules in `v2.json` are **stable**." -> "All 29 ...".