### PR TITLE
docs(policy): extend semver_policy with a behavior-escalation CHANGELOG rule

### DIFF
--- a/docs/semver_policy.md
+++ b/docs/semver_policy.md
@@ -32,6 +32,26 @@ All 29 current built-in rules are **stable**.
 | Fix a false positive in a stable rule | Patch |
 | Add an experimental rule | Minor |
 | Change or remove an experimental rule | Minor |
+| Escalate a rule's behavior (warning to runtime error) | **Minor** (at least) |
+
+## Behavior Escalation Policy
+
+A **behavior escalation** is any change that tightens how existing, previously accepted usage is treated at runtime — most commonly turning a `warning` into a hard runtime error, but also any equivalent tightening (e.g. promoting an advisory into a failing check for input that used to pass).
+
+Such a change **breaks callers whose code ran cleanly before**, so it must never ship in a patch release:
+
+- A behavior escalation requires **at least a minor version bump** — never a patch.
+- It requires a **CHANGELOG migration note** describing the old behavior, the new behavior, and how to adapt (or opt out).
+- This rule applies **toolkit-wide**, not just to Azure Functions Doctor. Doctor owns the toolkit's semver/stability convention, so sibling packages should reference this policy. (Follow-up: link it from the DX hub and sibling `CONTRIBUTING` files.)
+
+**Motivating example.** `azure-functions-validation` **0.11.1** — a *patch* release — escalated a decorator warning into a `RuntimeError`:
+
+- `0.9.0`: *(decorator)* warn when `@validate_http` is applied above `@with_context` (#278).
+- `0.11.1`: *(decorator)* raise `RuntimeError` when `@validate_http` wraps a `FunctionBuilder` (#299).
+
+Code that emitted only a warning under `0.9.0`–`0.11.0` began raising at import/registration time on the `0.11.1` patch, with no migration note. Under this policy that escalation would have required at least a `0.12.0` minor bump and a CHANGELOG migration note.
+
+> Enforcement note: an automated doctor check that flags escalation-on-patch is tracked separately and intentionally out of scope here.
 
 ## Profile Change Policy
 


### PR DESCRIPTION
## Summary
- Add a **Behavior Escalation Policy** section to `docs/semver_policy.md`: turning a warning into a hard runtime error (or any equivalent tightening of previously accepted usage) requires **at least a minor bump** and a **CHANGELOG migration note** — never a patch.
- Add a matching row to the Versioning Impact table.
- Note the policy applies **toolkit-wide** (follow-up: link from the DX hub / sibling CONTRIBUTING).
- Reference the `azure-functions-validation` **0.11.1** patch-release `RuntimeError` escalation (#278 → #299) as the motivating example.

## Acceptance
- [x] Explicit policy line: behavior escalation requires ≥ minor bump + CHANGELOG migration note, never patch.
- [x] Noted as toolkit-wide.
- [x] References the validation 0.11.1 case.
- [x] Automated enforcement check left out of scope (tracked separately).

Closes #262