### PR TITLE
docs: consolidate official documentation URL onto yeongseon.dev

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-doctor-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-doctor-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-doctor-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/doctor/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-doctor-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-doctor-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-doctor-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/doctor/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-doctor-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-doctor-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-doctor-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/doctor/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-doctor-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-doctor-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-doctor-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-doctor-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/doctor/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,22 +5,22 @@
 Part of the **Azure Functions Python DX Toolkit**. A CLI that diagnoses common configuration, environment, and project-structure issues in Azure Functions Python v2 apps, emitting a machine-readable JSON contract for CI. Install from PyPI with `pip install azure-functions-doctor`.
 
 ## Getting Started
-- [Installation](https://yeongseon.github.io/azure-functions-doctor-python/installation/): Install the CLI.
-- [Quickstart](https://yeongseon.github.io/azure-functions-doctor-python/getting-started/): Run your first diagnostic.
-- [Configuration](https://yeongseon.github.io/azure-functions-doctor-python/configuration/): Configure checks and profiles.
+- [Installation](https://yeongseon.dev/azure-functions-python/doctor/installation/): Install the CLI.
+- [Quickstart](https://yeongseon.dev/azure-functions-python/doctor/getting-started/): Run your first diagnostic.
+- [Configuration](https://yeongseon.dev/azure-functions-python/doctor/configuration/): Configure checks and profiles.
 
 ## User Guide
-- [CLI Usage](https://yeongseon.github.io/azure-functions-doctor-python/usage/): Command reference.
-- [Diagnostics](https://yeongseon.github.io/azure-functions-doctor-python/diagnostics/): What gets checked and why.
-- [Rules](https://yeongseon.github.io/azure-functions-doctor-python/rules/): Rule model and inventory.
-- [JSON Output Contract](https://yeongseon.github.io/azure-functions-doctor-python/json_output_contract/): Machine-readable output for CI.
+- [CLI Usage](https://yeongseon.dev/azure-functions-python/doctor/usage/): Command reference.
+- [Diagnostics](https://yeongseon.dev/azure-functions-python/doctor/diagnostics/): What gets checked and why.
+- [Rules](https://yeongseon.dev/azure-functions-python/doctor/rules/): Rule model and inventory.
+- [JSON Output Contract](https://yeongseon.dev/azure-functions-python/doctor/json_output_contract/): Machine-readable output for CI.
 
 ## Reference
-- [API Reference](https://yeongseon.github.io/azure-functions-doctor-python/api/): Public API surface.
-- [Architecture](https://yeongseon.github.io/azure-functions-doctor-python/architecture/): How the rule engine works.
-- [FAQ](https://yeongseon.github.io/azure-functions-doctor-python/faq/): Frequently asked questions.
-- [Troubleshooting](https://yeongseon.github.io/azure-functions-doctor-python/troubleshooting/): Common issues and fixes.
+- [API Reference](https://yeongseon.dev/azure-functions-python/doctor/api/): Public API surface.
+- [Architecture](https://yeongseon.dev/azure-functions-python/doctor/architecture/): How the rule engine works.
+- [FAQ](https://yeongseon.dev/azure-functions-python/doctor/faq/): Frequently asked questions.
+- [Troubleshooting](https://yeongseon.dev/azure-functions-python/doctor/troubleshooting/): Common issues and fixes.
 
 ## Optional
-- [CI Integration](https://yeongseon.github.io/azure-functions-doctor-python/examples/ci_integration/): Use in pipelines.
-- [Changelog](https://yeongseon.github.io/azure-functions-doctor-python/changelog/): Release history.
+- [CI Integration](https://yeongseon.dev/azure-functions-python/doctor/examples/ci_integration/): Use in pipelines.
+- [Changelog](https://yeongseon.dev/azure-functions-python/doctor/changelog/): Release history.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,7 +8,7 @@
 - Version: 0.19.1
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-doctor/
+- Docs: https://yeongseon.dev/azure-functions-python/doctor/
 - Repository: https://github.com/yeongseon/azure-functions-doctor
 - Azure Functions programming model: v2 decorator-based
 
@@ -489,6 +489,6 @@ With `--debug`: +20–50ms overhead for structured logging.
 
 ## Support
 
-- Documentation: https://yeongseon.github.io/azure-functions-doctor/
+- Documentation: https://yeongseon.dev/azure-functions-python/doctor/
 - GitHub Issues: https://github.com/yeongseon/azure-functions-doctor/issues
 - GitHub Discussions: https://github.com/yeongseon/azure-functions-doctor/discussions

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 - Version: 0.19.1
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-doctor/
+- Docs: https://yeongseon.dev/azure-functions-python/doctor/
 - Repository: https://github.com/yeongseon/azure-functions-doctor
 
 ## What It Does
@@ -86,11 +86,11 @@ Rules support two profiles:
 
 ## Documentation
 
-- [Getting Started](https://yeongseon.github.io/azure-functions-doctor/getting-started/)
-- [API Reference](https://yeongseon.github.io/azure-functions-doctor/api/)
-- [Rules Reference](https://yeongseon.github.io/azure-functions-doctor/rules/)
-- [CI Integration](https://yeongseon.github.io/azure-functions-doctor/examples/ci_integration/)
-- [Custom Rules](https://yeongseon.github.io/azure-functions-doctor/custom-rules/)
+- [Getting Started](https://yeongseon.dev/azure-functions-python/doctor/getting-started/)
+- [API Reference](https://yeongseon.dev/azure-functions-python/doctor/api/)
+- [Rules Reference](https://yeongseon.dev/azure-functions-python/doctor/rules/)
+- [CI Integration](https://yeongseon.dev/azure-functions-python/doctor/examples/ci_integration/)
+- [Custom Rules](https://yeongseon.dev/azure-functions-python/doctor/rules/#guidance-for-custom-rules)
 
 ## Ecosystem
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: Azure Functions Doctor
 site_description: A diagnostic tool for Python Azure Functions
 site_author: Yeongseon Choe
-repo_url: https://github.com/yeongseon/azure-functions-doctor
-site_url: https://yeongseon.github.io/azure-functions-doctor-python/
+repo_url: https://github.com/yeongseon/azure-functions-doctor-python
+site_url: https://yeongseon.dev/azure-functions-python/doctor/
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://yeongseon.github.io/azure-functions-doctor-python/"
-Documentation = "https://yeongseon.github.io/azure-functions-doctor-python/"
+Homepage = "https://yeongseon.dev/azure-functions-python/doctor/"
+Documentation = "https://yeongseon.dev/azure-functions-python/doctor/"
 Repository = "https://github.com/yeongseon/azure-functions-doctor-python"
 Issues = "https://github.com/yeongseon/azure-functions-doctor-python/issues"
 


### PR DESCRIPTION
## Summary
Consolidate the official documentation URL onto the new canonical domain `https://yeongseon.dev/azure-functions-python/doctor/`.

- `pyproject.toml`: `Homepage`/`Documentation` → new URL; `Repository`/`Issues` unchanged (GitHub).
- `mkdocs.yml`: `site_url` → new URL; **`repo_url` normalized** from the stale `azure-functions-doctor` alias to the canonical `azure-functions-doctor-python`; `edit_uri` unchanged.
- README (en/ja/ko/zh-CN): docs link + badge updated.
- `llms.txt`, `docs/llms.txt`, `llms-full.txt`: base path updated, preserving subpaths.

## Verification
- All 15 base doc URLs return 200 (curl -L).
- Canonical `repo_url` (`azure-functions-doctor-python`) resolves 200.
- Dead `custom-rules/` link (404 on both old alias and new site) remapped to the valid `rules/#guidance-for-custom-rules` anchor (id present, count=1).
- Stale `github.io/azure-functions-doctor` alias links (incl. non-`-python` variant) normalized to the new route.
- `mkdocs build --strict` passes (INFO-only, no strict abort).
- No stale `github.io/azure-functions-doctor` refs remain in tracked files.

## Notes
Redirect stubs (meta refresh + canonical), not HTTP 301. Repository/Issues GitHub URLs intentionally unchanged.

Closes #279