### PR TITLE
feat(rules): add OTel trace-context activation diagnostic rule

### DIFF
--- a/docs/rule_inventory.md
+++ b/docs/rule_inventory.md
@@ -38,6 +38,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `check_langgraph_anonymous_auth` | LangGraph route authentication | configuration | security | `langgraph_anonymous_auth` | No | full |
 | `check_durable_nondeterminism` | Orchestrator determinism | framework | durable | `durable_nondeterminism` | Yes | minimal, full |
 | `check_unsupported_metadata_version` | Supported metadata version | configuration | extensions | `unsupported_metadata_version` | No | full |
+| `check_otel_trace_context_activation` | OTel trace-context activation | configuration | observability | `otel_activation` | No | full |
 
 ## Rule Types
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -59,6 +59,7 @@ The built-in ruleset uses the following handler types:
 - `langgraph_anonymous_auth`
 - `durable_nondeterminism`
 - `unsupported_metadata_version`
+- `otel_activation`
 
 For the authoritative, script-generated list of every built-in rule and its
 type, see the [Rule Inventory](rule_inventory.md).
@@ -381,6 +382,14 @@ Found unwanted files: ['tests/', '.venv']
 - **Why it matters:** Unsupported metadata versions can fail at load or deploy time.
 - **How to fix:** Use a supported metadata/bundle version.
 - **Severity:** Warning only (`required: false`).
+
+## 30) `check_otel_trace_context_activation`
+
+- **What it checks:** In projects that opt into `azure-functions-logging` trace-context activation (`activate_trace_context=True` or `set_default_trace_context_activation`), an `opentelemetry` distribution is declared in `requirements.txt` or `pyproject.toml`.
+- **Why it matters:** `azure-functions-logging` silently degrades activation to a no-op when OpenTelemetry is unavailable, so requested trace context is dropped without any runtime error.
+- **How to fix:** Install the `azure-functions-logging[otel]` extra (or an `opentelemetry-*` package), or disable `activate_trace_context`.
+- **Severity:** Warning only (`required: false`).
+
 
 ## Rule authoring template
 

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -505,5 +505,22 @@
     "symptoms": "Extensions or bindings fail to load; runtime rejects host configuration.",
     "tags": ["metadata", "version", "extensions"],
     "check_order": 40
+  },
+  {
+    "id": "check_otel_trace_context_activation",
+    "category": "configuration",
+    "section": "observability",
+    "label": "OTel trace-context activation",
+    "description": "Warns when a project opts into azure-functions-logging trace-context activation (activate_trace_context=True or set_default_trace_context_activation) but does not declare an opentelemetry dependency, so activation silently no-ops at runtime.",
+    "type": "otel_activation",
+    "required": false,
+    "condition": {},
+    "hint": "Install the azure-functions-logging[otel] extra (or an opentelemetry-* package), or disable activate_trace_context.",
+    "hint_url": "https://github.com/yeongseon/azure-functions-logging-python/blob/main/README.md#opentelemetry-trace-context",
+    "source_type": "heuristic",
+    "why_it_matters": "azure-functions-logging degrades trace-context activation to a no-op when OpenTelemetry is unavailable, so requested distributed tracing is silently dropped without any runtime error.",
+    "symptoms": "Trace context never attaches to logs; spans missing from telemetry despite activation being enabled.",
+    "tags": ["logging", "opentelemetry", "observability", "tracing"],
+    "check_order": 41
   }
 ]

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -534,6 +534,75 @@ def _collect_anonymous_auth_routes(path: Path, flag_missing_auth_level: bool = F
     return flagged
 
 
+def _project_activates_trace_context(path: Path) -> list[str]:
+    """Return "file:location" labels where the project explicitly opts into
+    ``azure-functions-logging`` OTel trace-context activation.
+
+    Two activation signals are detected:
+
+    * a keyword ``activate_trace_context=True`` on any call (e.g.
+      ``setup_logging(activate_trace_context=True)`` or
+      ``logging_context(..., activate_trace_context=True)``); and
+    * a call to ``set_default_trace_context_activation(True)`` (matched by the
+      dotted-call leaf name, with a truthy first positional or keyword arg).
+    """
+    activations: list[str] = []
+    for py_file, content in _iter_project_py_contents(path):
+        try:
+            tree = ast.parse(content)
+        except SyntaxError:
+            continue
+        label_base = str(py_file.relative_to(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for kw in node.keywords:
+                if (
+                    kw.arg == "activate_trace_context"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value is True
+                ):
+                    activations.append(f"{label_base}:{node.lineno}")
+                    break
+            leaf = _dotted_call_name(node.func)
+            if leaf is not None and leaf.rsplit(".", 1)[-1] == (
+                "set_default_trace_context_activation"
+            ):
+                enabled = _first_call_arg_is_true(node)
+                if enabled:
+                    activations.append(f"{label_base}:{node.lineno}")
+    return activations
+
+
+def _first_call_arg_is_true(node: ast.Call) -> bool:
+    """Return True when a call's first positional (or ``enabled`` keyword) arg is the
+    literal ``True``. A bare call with no args is treated as enabling activation.
+    """
+    if node.args:
+        first = node.args[0]
+        return isinstance(first, ast.Constant) and first.value is True
+    for kw in node.keywords:
+        if kw.arg == "enabled":
+            return isinstance(kw.value, ast.Constant) and kw.value.value is True
+    return not node.keywords
+
+
+def _project_declares_opentelemetry(path: Path) -> bool:
+    """Return True when the project declares any ``opentelemetry`` distribution in
+    ``requirements.txt`` or ``pyproject.toml`` (runtime or optional dependencies).
+
+    The ``azure-functions-logging[otel]`` extra pulls in ``opentelemetry-api``, so
+    any declared ``opentelemetry-*`` package satisfies the activation requirement.
+    """
+    declared: set[str] = set(pyproject_dependency_names(path))
+    req_path = path / "requirements.txt"
+    if req_path.exists():
+        content = _read_project_python_file(req_path)
+        if content is not None:
+            declared |= _parse_requirements_names(content)
+    return any(name.startswith("opentelemetry") for name in declared)
+
+
 def _collect_orchestrator_nondeterminism(
     path: Path, blocklist: set[str], decorator_names: set[str]
 ) -> list[str]:

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -31,6 +31,8 @@ from azure_functions_doctor.handlers._helpers import (
     _handle_specific_exceptions,
     _iter_project_py_contents,
     _parse_requirements_names,
+    _project_activates_trace_context,
+    _project_declares_opentelemetry,
     _project_declares_validation_dep,
     _project_imports_langgraph,
     _read_project_python_file,
@@ -906,6 +908,36 @@ class HandlerRegistry:
                 *[f"- {src} = {ver}" for src, ver in found[:10]],
                 "",
                 f"Fix: use a supported version ({', '.join(supported) or 'see docs'}).",
+            ]
+        )
+        return _create_result("fail", detail)
+
+    @_rule_handler
+    def _handle_otel_activation(
+        self, rule: Rule, path: Path, context: Optional[RuleContext] = None
+    ) -> HandlerResult:
+        """Warn when the project opts into logging OTel trace-context activation but
+        does not declare an ``opentelemetry`` distribution.
+
+        ``azure-functions-logging`` stays silent at runtime when activation is
+        requested without OpenTelemetry installed, so doctor surfaces the mismatch.
+        """
+        activations = _project_activates_trace_context(path)
+        if not activations:
+            return _create_result(
+                "pass", "No OTel trace-context activation requested; check skipped"
+            )
+        if _project_declares_opentelemetry(path):
+            return _create_result(
+                "pass", "Trace-context activation requested and opentelemetry is declared"
+            )
+        detail = "\n".join(
+            [
+                "Trace-context activation requested without an opentelemetry dependency:",
+                *[f"- {loc}" for loc in activations[:10]],
+                "",
+                "Fix: install the azure-functions-logging[otel] extra (or an "
+                "opentelemetry-* package), or disable activate_trace_context.",
             ]
         )
         return _create_result("fail", detail)

--- a/src/azure_functions_doctor/schemas/rules.schema.json
+++ b/src/azure_functions_doctor/schemas/rules.schema.json
@@ -74,7 +74,8 @@
           "scan_before_spec",
           "langgraph_anonymous_auth",
           "durable_nondeterminism",
-          "unsupported_metadata_version"
+          "unsupported_metadata_version",
+          "otel_activation"
         ]
       },
       "required": {

--- a/tests/test_toolkit_rule_checks.py
+++ b/tests/test_toolkit_rule_checks.py
@@ -18,6 +18,8 @@ from azure_functions_doctor.handlers._helpers import (
     _collect_scan_before_spec,
     _collect_unsupported_metadata_versions,
     _dotted_call_name,
+    _project_activates_trace_context,
+    _project_declares_opentelemetry,
     _project_imports_langgraph,
 )
 from azure_functions_doctor.handlers.registry import HandlerRegistry
@@ -411,5 +413,90 @@ def test_new_rules_present_in_doctor_output(tmp_path: Path) -> None:
         "LangGraph route authentication",
         "Orchestrator determinism",
         "Supported metadata version",
+        "OTel trace-context activation",
     ):
         assert label in labels
+
+
+# ---------------------------------------------------------------------------
+# otel_activation
+# ---------------------------------------------------------------------------
+
+
+def test_project_activates_trace_context_keyword(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "a.py",
+        "from azure_functions_logging import setup_logging\n"
+        "setup_logging(activate_trace_context=True)\n",
+    )
+    assert _project_activates_trace_context(tmp_path)
+
+
+def test_project_activates_trace_context_setter_call(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "a.py",
+        "from azure_functions_logging import set_default_trace_context_activation\n"
+        "set_default_trace_context_activation(True)\n",
+    )
+    assert _project_activates_trace_context(tmp_path)
+
+
+def test_project_activates_trace_context_setter_bare_call(tmp_path: Path) -> None:
+    _write(tmp_path, "a.py", "set_default_trace_context_activation()\n")
+    assert _project_activates_trace_context(tmp_path)
+
+
+def test_project_activates_trace_context_setter_enabled_keyword(tmp_path: Path) -> None:
+    _write(tmp_path, "a.py", "set_default_trace_context_activation(enabled=True)\n")
+    assert _project_activates_trace_context(tmp_path)
+
+
+def test_project_activates_trace_context_false_ignored(tmp_path: Path) -> None:
+    _write(tmp_path, "a.py", "setup_logging(activate_trace_context=False)\n")
+    assert not _project_activates_trace_context(tmp_path)
+    _write(tmp_path, "b.py", "set_default_trace_context_activation(False)\n")
+    assert not _project_activates_trace_context(tmp_path)
+
+
+def test_project_activates_trace_context_skips_syntax_error(tmp_path: Path) -> None:
+    _write(tmp_path, "a.py", "def broken(:\n")
+    assert not _project_activates_trace_context(tmp_path)
+
+
+def test_project_declares_opentelemetry_requirements(tmp_path: Path) -> None:
+    _write(tmp_path, "requirements.txt", "opentelemetry-api>=1.24\n")
+    assert _project_declares_opentelemetry(tmp_path)
+
+
+def test_project_declares_opentelemetry_pyproject(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "pyproject.toml",
+        '[project]\nname = "x"\nversion = "0"\n'
+        'dependencies = ["opentelemetry-sdk>=1.24"]\n',
+    )
+    assert _project_declares_opentelemetry(tmp_path)
+
+
+def test_project_declares_opentelemetry_absent(tmp_path: Path) -> None:
+    _write(tmp_path, "requirements.txt", "azure-functions\n")
+    assert not _project_declares_opentelemetry(tmp_path)
+
+
+def test_otel_activation_without_dependency_fails(tmp_path: Path) -> None:
+    _write(tmp_path, "a.py", "setup_logging(activate_trace_context=True)\n")
+    _write(tmp_path, "requirements.txt", "azure-functions\n")
+    assert _status("otel_activation", tmp_path) == "fail"
+
+
+def test_otel_activation_with_dependency_passes(tmp_path: Path) -> None:
+    _write(tmp_path, "a.py", "setup_logging(activate_trace_context=True)\n")
+    _write(tmp_path, "requirements.txt", "azure-functions\nopentelemetry-api>=1.24\n")
+    assert _status("otel_activation", tmp_path) == "pass"
+
+
+def test_otel_activation_no_activation_passes(tmp_path: Path) -> None:
+    _write(tmp_path, "a.py", "import os\n")
+    assert _status("otel_activation", tmp_path) == "pass"


### PR DESCRIPTION
## Summary
- Adds an optional `otel_activation` rule that warns when a project opts into `azure-functions-logging` trace-context activation (`activate_trace_context=True` or `set_default_trace_context_activation`) but declares no `opentelemetry` dependency. The logging runtime silently degrades activation to a no-op when OpenTelemetry is unavailable, so doctor is the right place to surface the mismatch.
- New helpers `_project_activates_trace_context` / `_project_declares_opentelemetry`; new `_handle_otel_activation` handler registered via `@_rule_handler`.
- Rule entry in `assets/rules/v2.json`, schema enum update, `docs/rules.md`, and regenerated `docs/rule_inventory.md`.

## Tests
- Detection-helper and handler-status tests added to `tests/test_toolkit_rule_checks.py`.
- `make lint`, `make typecheck` clean; full suite coverage 96.35% (gate ≥95%).

Closes #261