### PR TITLE
fix(scan): exclude virtualenv, vendor, and cache dirs from project scans

### DIFF
--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -66,7 +66,7 @@
         "UV_PROJECT_ENVIRONMENT"
       ]
     },
-    "hint": "Activate a virtual environment using: 'source venv/bin/activate'.",
+    "hint": "Create and activate a virtual environment (e.g. 'python -m venv .venv' then 'source .venv/bin/activate'). Both '.venv' and 'venv' directories are recognized and excluded from project scans.",
     "hint_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices?tabs=python#use-virtual-environments",
     "check_order": 2
   },

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -28,7 +28,30 @@ from azure_functions_doctor.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-EXCLUDED_PROJECT_DIRS = {".venv", "node_modules", "build", "dist", ".pytest_cache", "__pycache__"}
+EXCLUDED_PROJECT_DIRS = {
+    # Python virtual environments
+    ".venv",
+    "venv",
+    "env",
+    ".env",
+    # Installed packages / vendored dependencies
+    "site-packages",
+    "node_modules",
+    # Build / packaging output
+    "build",
+    "dist",
+    # Tooling caches
+    ".pytest_cache",
+    "__pycache__",
+    ".tox",
+    ".nox",
+    ".mypy_cache",
+    ".ruff_cache",
+    # Version control metadata
+    ".git",
+    ".hg",
+    ".svn",
+}
 
 
 class HandlerResult(TypedDict, total=False):

--- a/tests/test_programming_model_detection.py
+++ b/tests/test_programming_model_detection.py
@@ -248,3 +248,49 @@ x = 1
                 ],
             }
         ]
+
+    def test_venv_function_json_does_not_trigger_v1_or_mixed(self) -> None:
+        """A function.json inside a virtualenv must not create false v1/mixed signals."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            # Valid v2 project at the root.
+            (temp_path / "function_app.py").write_text(
+                """
+import azure.functions as func
+
+app = func.FunctionApp()
+
+@app.route(route=\"test\", auth_level=func.AuthLevel.Anonymous)
+def test_function(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(\"Hello\")
+"""
+            )
+
+            # A stray legacy function.json vendored inside a non-dot ``venv`` dir.
+            venv_func = temp_path / "venv" / "lib" / "legacy"
+            venv_func.mkdir(parents=True)
+            (venv_func / "function.json").write_text('{"bindings": []}')
+
+            doctor = Doctor(str(temp_path))
+            # venv-hosted function.json must be ignored: no v1 signal, no mixed model.
+            assert doctor._has_v1_signals() is False
+            assert doctor.programming_model == "v2"
+
+    def test_excluded_dirs_cover_common_venv_and_cache_names(self) -> None:
+        """Guard the exclusion set against regressions for common vendor/cache dirs."""
+        from azure_functions_doctor.handlers._helpers import EXCLUDED_PROJECT_DIRS
+
+        expected = {
+            ".venv",
+            "venv",
+            "env",
+            "site-packages",
+            "node_modules",
+            ".tox",
+            ".nox",
+            ".mypy_cache",
+            ".ruff_cache",
+            ".git",
+        }
+        assert expected <= EXCLUDED_PROJECT_DIRS


### PR DESCRIPTION
## Summary
- Expand `EXCLUDED_PROJECT_DIRS` to cover `venv`/`env`/`site-packages`, `.tox`/`.nox`, `.mypy_cache`/`.ruff_cache`, and VCS metadata (`.git`/`.hg`/`.svn`) in addition to the previous set.
- The mixed-programming-model scan (`rglob("function.json")`) and the `.py` iterator no longer descend into vendored/virtualenv trees, so a stray legacy `function.json` inside `venv/` no longer produces a false **"Mixed programming model detected"** result.
- Reword the `check_venv` hint so it no longer prescribes a `venv/`-only layout — the original source of the exclusion contradiction. Venv **detection** (env-var based) is unchanged.

## Tests
- New regression test: a `function.json` nested in `venv/` yields no v1 signal and the project is still detected as `v2`.
- New guard test asserting the exclusion set covers the common venv/vendor/cache names.
- `make lint`, `make typecheck`, `make test` all green (499 passed, coverage 96.31%).

Closes #285