### PR TITLE
fix(output): report skipped checks with an explicit skip status

### DIFF
--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -189,6 +189,7 @@ def doctor(
     passed_count = 0
     warning_count = 0  # explicit 'warn' statuses
     fail_count = 0  # explicit 'fail' statuses
+    skipped_count = 0  # explicit 'skip' statuses (check not applicable / prerequisite absent)
     for section in results:
         for item in section["items"]:
             s = item.get("status")
@@ -198,6 +199,8 @@ def doctor(
                 warning_count += 1
             elif s == "fail":
                 fail_count += 1
+            elif s == "skip":
+                skipped_count += 1
             else:
                 warning_count += 1  # unknown treated as warning
 
@@ -207,6 +210,7 @@ def doctor(
             "passed": passed_count,
             "warned": warning_count,
             "failed": fail_count,
+            "skipped": skipped_count,
         }
         try:
             summary_json.parent.mkdir(parents=True, exist_ok=True)
@@ -256,7 +260,9 @@ def doctor(
         for section in results:
             for item in section["items"]:
                 status = item.get("status")
-                if status == "pass":
+                # Skipped checks are not findings; exclude them from SARIF output.
+                if status in ("pass", "skip"):
+                    continue
                     continue
                 label = item.get("label", "")
                 matched_rule = label_to_rule.get(label)
@@ -328,7 +334,7 @@ def doctor(
                     failures += 1
                     failure = ET.SubElement(case, "failure", message=item.get("value", ""))
                     failure.text = item.get("hint", "")
-                elif status == "warn":
+                elif status in ("warn", "skip"):
                     skipped += 1
                     skipped_el = ET.SubElement(case, "skipped", message=item.get("value", ""))
                     skipped_el.text = item.get("hint", "")
@@ -391,6 +397,8 @@ def doctor(
     f_label = "fail" if fail_count == 1 else "fails"
     # 'passed' label remains same for singular/plural in current design
     console.print(f"  {fail_count} {f_label}, {warning_count} {w_label}, {passed_count} passed")
+    if skipped_count:
+        console.print(f"  {skipped_count} skipped")
     exit_code = 1 if fail_count > 0 else 0
     console.print(f"Exit code: {exit_code}")
     if exit_code != 0:

--- a/src/azure_functions_doctor/doctor.py
+++ b/src/azure_functions_doctor/doctor.py
@@ -280,15 +280,18 @@ class Doctor:
                 )
 
                 # Simplified canonical mapping:
-                # pass stays pass, otherwise required -> fail and optional -> warn.
+                # pass stays pass, skip stays skip (regardless of required),
+                # otherwise required -> fail and optional -> warn.
                 required = rule.get("required", True)
                 if handler_status == "pass":
                     canonical = "pass"
+                elif handler_status == "skip":
+                    canonical = "skip"
                 else:
                     canonical = "fail" if required else "warn"
 
                 detail = result.get("detail", "")
-                if canonical != "pass" and not required:
+                if canonical == "warn":
                     detail += " (optional)"
 
                 item: CheckResult = {

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -353,7 +353,7 @@ class HandlerRegistry:
         req_file = str(req_file_obj)
         req_path = path / Path(req_file)
         if not req_path.exists():
-            return _create_result("pass", f"{req_file} not found; check skipped")
+            return _create_result("skip", f"{req_file} not found; check skipped")
         try:
             content = req_path.read_text(encoding="utf-8")
         except Exception as exc:
@@ -401,7 +401,7 @@ class HandlerRegistry:
             return _handle_specific_exceptions("scanning for durable usage", exc)
 
         if not uses_durable:
-            return _create_result("pass", "No Durable Functions usage detected; check skipped")
+            return _create_result("skip", "No Durable Functions usage detected; check skipped")
 
         condition = rule.get("condition", {}) or {}
         jsonpath = condition.get("jsonpath")
@@ -590,7 +590,7 @@ class HandlerRegistry:
 
         settings_path = path / "local.settings.json"
         if not settings_path.exists():
-            return _create_result("pass", "local.settings.json not present; check skipped")
+            return _create_result("skip", "local.settings.json not present; check skipped")
 
         # Check if the file is tracked by git
         try:
@@ -603,7 +603,7 @@ class HandlerRegistry:
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             # git not available or not a git repo — skip check
             return _create_result(
-                "pass",
+                "skip",
                 "git not available; local.settings.json git-tracking check skipped",
             )
 
@@ -736,7 +736,7 @@ class HandlerRegistry:
         """Warn when route handlers lack @validate_http in a validation-enabled project."""
         if not _project_declares_validation_dep(path):
             return _create_result(
-                "pass", "azure-functions-validation not declared; endpoint metadata check skipped"
+                "skip", "azure-functions-validation not declared; endpoint metadata check skipped"
             )
         uncovered = _collect_routes_missing_validate_http(path)
         if not uncovered:
@@ -820,7 +820,7 @@ class HandlerRegistry:
     ) -> HandlerResult:
         """Detect when a LangGraph project exposes routes with anonymous auth."""
         if not _project_imports_langgraph(path):
-            return _create_result("pass", "langgraph not imported; anonymous auth check skipped")
+            return _create_result("skip", "langgraph not imported; anonymous auth check skipped")
         condition = rule.get("condition", {}) or {}
         flag_missing = bool(condition.get("flag_missing_auth_level", False))
         flagged = _collect_anonymous_auth_routes(path, flag_missing)
@@ -897,7 +897,7 @@ class HandlerRegistry:
         supported = list(condition.get("supported_versions") or [])
         if not supported:
             return _create_result(
-                "pass", "No supported_versions configured; metadata version check skipped"
+                "skip", "No supported_versions configured; metadata version check skipped"
             )
         found = _collect_unsupported_metadata_versions(path, files, fields, supported)
         if not found:
@@ -925,7 +925,7 @@ class HandlerRegistry:
         activations = _project_activates_trace_context(path)
         if not activations:
             return _create_result(
-                "pass", "No OTel trace-context activation requested; check skipped"
+                "skip", "No OTel trace-context activation requested; check skipped"
             )
         if _project_declares_opentelemetry(path):
             return _create_result(

--- a/src/azure_functions_doctor/utils.py
+++ b/src/azure_functions_doctor/utils.py
@@ -7,6 +7,7 @@ STATUS_ICONS: dict[str, str] = {  # nosec B105
     "pass": "✓",
     "warn": "!",
     "fail": "✗",
+    "skip": "–",
 }
 
 # Status to styled Text (for section headers)
@@ -14,6 +15,7 @@ STATUS_STYLES: dict[str, Style] = {
     "pass": Style(color="green", bold=True),
     "fail": Style(color="red", bold=True),
     "warn": Style(color="yellow", bold=True),
+    "skip": Style(color="bright_black", bold=True),
 }
 
 # Status to plain color strings (for result details)
@@ -21,6 +23,7 @@ DETAIL_COLOR_MAP: dict[str, str] = {  # nosec B105
     "pass": "green",
     "fail": "red",
     "warn": "yellow",
+    "skip": "bright_black",
 }
 
 
@@ -29,7 +32,7 @@ def format_status_icon(status: str) -> str:
     Return a simple icon character based on status.
 
     Args:
-        status: Diagnostic status ("pass", "fail", "warn").
+        status: Diagnostic status ("pass", "fail", "warn", "skip").
 
     Returns:
     A string icon such as ✓, !, or ✗.
@@ -42,7 +45,7 @@ def format_result(status: str) -> Text:
     Return a styled icon Text element based on status.
 
     Args:
-        status: Diagnostic status ("pass", "fail", "warn").
+        status: Diagnostic status ("pass", "fail", "warn", "skip").
 
     Returns:
         A Rich Text object with icon and style for headers.
@@ -57,7 +60,7 @@ def format_detail(status: str, value: str) -> Text:
     Return a colored Text element based on status and value.
 
     Args:
-        status: Diagnostic status ("pass", "fail", "warn").
+        status: Diagnostic status ("pass", "fail", "warn", "skip").
         value: Text to display, typically a description.
 
     Returns:

--- a/tests/test_bugfix_issues.py
+++ b/tests/test_bugfix_issues.py
@@ -38,7 +38,7 @@ def test_rule_typed_literal_includes_package_declared() -> None:
 
 
 def test_summary_json_writes_counts_file(tmp_path: Path) -> None:
-    """Issue #95: --summary-json writes passed/warned/failed keys."""
+    """Issue #95: --summary-json writes passed/warned/failed/skipped keys."""
     runner = CliRunner()
     summary_path = tmp_path / "summary.json"
 
@@ -50,7 +50,7 @@ def test_summary_json_writes_counts_file(tmp_path: Path) -> None:
     assert result.exit_code in (0, 1)
     assert summary_path.exists()
     payload = json.loads(summary_path.read_text(encoding="utf-8"))
-    assert set(payload.keys()) == {"passed", "warned", "failed"}
+    assert set(payload.keys()) == {"passed", "warned", "failed", "skipped"}
 
 
 def test_summary_json_sidecar_created_with_json_format(tmp_path: Path) -> None:

--- a/tests/test_decorator_diagnostics.py
+++ b/tests/test_decorator_diagnostics.py
@@ -45,7 +45,7 @@ def test_endpoint_metadata_missing_warns() -> None:
 
 def test_endpoint_metadata_no_dep_passes() -> None:
     item_map = _item_status_by_label(FIXTURES_DIR / "endpoint_metadata_no_dep")
-    assert item_map["Endpoint metadata coverage"] == "pass"
+    assert item_map["Endpoint metadata coverage"] == "skip"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -310,7 +310,7 @@ def test_conditional_exists_no_durable_usage_pass() -> None:
             "condition": {"jsonpath": "$.extensions.durableTask"},
         }
         result = generic_handler(rule, Path(tmpdir))
-        assert result["status"] == "pass"
+        assert result["status"] == "skip"
 
 
 def test_conditional_exists_durable_missing_host_fail() -> None:
@@ -501,7 +501,7 @@ def test_local_settings_security_not_present(tmp_path: Path) -> None:
     """Test local_settings_security passes when local.settings.json does not exist."""
     rule = _make_rule("local_settings_security", {})
     res = generic_handler(rule, tmp_path)
-    assert res["status"] == "pass"
+    assert res["status"] == "skip"
     assert "not present" in res.get("detail", "").lower()
 
 
@@ -562,7 +562,7 @@ def test_local_settings_security_git_not_available(
     monkeypatch.setattr(_subprocess, "run", fake_run)
     rule = _make_rule("local_settings_security", {})
     res = generic_handler(rule, tmp_path)
-    assert res["status"] == "pass"
+    assert res["status"] == "skip"
     assert "skipped" in res.get("detail", "").lower()
 
 

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -894,7 +894,7 @@ def test_local_settings_security_no_file() -> None:
             "condition": {},
         }
         result = registry.handle(rule, tmp_path)
-        assert result["status"] == "pass"
+        assert result["status"] == "skip"
         assert "not present" in result["detail"]
 
 
@@ -1548,7 +1548,7 @@ def test_conditional_exists_no_durable_detected() -> None:
             },
         }
         result = registry.handle(rule, tmp_path)
-        assert result["status"] == "pass"
+        assert result["status"] == "skip"
         assert "No Durable Functions" in result["detail"]
 
 

--- a/tests/test_handler_registry_extended.py
+++ b/tests/test_handler_registry_extended.py
@@ -679,7 +679,7 @@ def test_local_settings_security_no_file() -> None:
             "condition": {},
         }
         result = registry.handle(rule, tmp_path)
-        assert result["status"] == "pass"
+        assert result["status"] == "skip"
         assert "not present" in result["detail"]
 
 

--- a/tests/test_native_dependency_risk.py
+++ b/tests/test_native_dependency_risk.py
@@ -41,7 +41,7 @@ def test_detect_native_dependency_risks_handles_comments_and_extras() -> None:
 def test_native_dependency_risk_handler_skips_missing_requirements(tmp_path: Path) -> None:
     rule: Rule = {"type": "native_dependency_risk", "condition": {"file": "requirements.txt"}}
     result = generic_handler(rule, tmp_path)
-    assert result["status"] == "pass"
+    assert result["status"] == "skip"
 
 
 def test_native_dependency_risk_handler_passes_for_pure_python_requirements(tmp_path: Path) -> None:

--- a/tests/test_skip_status.py
+++ b/tests/test_skip_status.py
@@ -1,0 +1,153 @@
+"""Tests for the explicit ``skip`` diagnostic status (issue #286).
+
+Previously handlers that could not run a check (missing prerequisite, feature
+not used, file absent) reported ``pass``, so a *skipped* check was
+indistinguishable from a *verified-healthy* one. These tests lock in the new
+``skip`` status across the output contract: styling, the canonical mapping in
+``Doctor.run_all_checks``, JSON summary counts, JUnit, SARIF, exit codes, and
+the human-readable table.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, cast
+import xml.etree.ElementTree as ET
+
+from typer.testing import CliRunner
+
+from azure_functions_doctor.cli import cli as app
+from azure_functions_doctor.handlers._helpers import Rule
+from azure_functions_doctor.handlers.registry import HandlerRegistry
+from azure_functions_doctor.utils import (
+    DETAIL_COLOR_MAP,
+    STATUS_ICONS,
+    STATUS_STYLES,
+    format_status_icon,
+)
+
+runner = CliRunner()
+
+# A valid v2 project that exercises several skip-producing handlers
+# (no Durable Functions, no local.settings.json, etc.).
+V2_FIXTURE_PATH = "examples/v2/http-trigger"
+
+
+def _json_status_counts(path: str) -> dict[str, int]:
+    result = runner.invoke(app, ["doctor", "--path", path, "--format", "json"])
+    data = json.loads(result.output)
+    counts: dict[str, int] = {}
+    for section in data["results"]:
+        for item in section["items"]:
+            counts[item["status"]] = counts.get(item["status"], 0) + 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# utils: skip is a first-class status
+# ---------------------------------------------------------------------------
+
+
+def test_skip_registered_in_status_maps() -> None:
+    assert STATUS_ICONS.get("skip") == "–"
+    assert "skip" in STATUS_STYLES
+    assert DETAIL_COLOR_MAP.get("skip") == "bright_black"
+
+
+def test_format_status_icon_skip() -> None:
+    assert format_status_icon("skip") == "–"
+
+
+# ---------------------------------------------------------------------------
+# handler layer: prerequisite-absent handlers return skip (not pass)
+# ---------------------------------------------------------------------------
+
+
+def test_durable_handler_returns_skip_when_not_used(tmp_path: Path) -> None:
+    registry = HandlerRegistry()
+    rule = cast(
+        Rule,
+        {"type": "conditional_exists", "required": False, "condition": {}},
+    )
+    result = registry.handle(rule, tmp_path)
+    assert result["status"] == "skip"
+
+
+# ---------------------------------------------------------------------------
+# doctor transform + JSON: skip is preserved and never fails a section
+# ---------------------------------------------------------------------------
+
+
+def test_v2_project_reports_skip_items_and_exits_zero() -> None:
+    result = runner.invoke(app, ["doctor", "--path", V2_FIXTURE_PATH, "--format", "json"])
+    assert result.exit_code == 0
+    counts = _json_status_counts(V2_FIXTURE_PATH)
+    assert counts.get("skip", 0) > 0
+    # skip must not be silently folded into pass/warn/fail.
+    assert set(counts).issuperset({"pass", "skip"})
+
+
+# ---------------------------------------------------------------------------
+# summary JSON sidecar exposes the skipped count
+# ---------------------------------------------------------------------------
+
+
+def test_summary_json_includes_skipped_count(tmp_path: Path) -> None:
+    summary_path = tmp_path / "summary.json"
+    result = runner.invoke(
+        app,
+        [
+            "doctor",
+            "--path",
+            V2_FIXTURE_PATH,
+            "--summary-json",
+            str(summary_path),
+        ],
+    )
+    assert result.exit_code in (0, 1)
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert set(payload.keys()) == {"passed", "warned", "failed", "skipped"}
+    counts = _json_status_counts(V2_FIXTURE_PATH)
+    assert payload["skipped"] == counts.get("skip", 0)
+
+
+# ---------------------------------------------------------------------------
+# JUnit: skipped checks map to <skipped>, never <failure>
+# ---------------------------------------------------------------------------
+
+
+def test_junit_skip_items_emit_skipped_element() -> None:
+    result = runner.invoke(app, ["doctor", "--path", V2_FIXTURE_PATH, "--format", "junit"])
+    root = ET.fromstring(result.output)  # noqa: S314 - trusted local output
+    assert root.tag == "testsuite"
+    counts = _json_status_counts(V2_FIXTURE_PATH)
+    expected_skipped = counts.get("skip", 0) + counts.get("warn", 0)
+    assert int(root.attrib.get("skipped", "0")) == expected_skipped
+    # No skip item may be rendered as a failure.
+    for case in root.findall("testcase"):
+        assert not (case.findall("failure") and case.findall("skipped"))
+
+
+# ---------------------------------------------------------------------------
+# SARIF: skipped checks are not findings and must be excluded
+# ---------------------------------------------------------------------------
+
+
+def test_sarif_excludes_skipped_checks() -> None:
+    result = runner.invoke(app, ["doctor", "--path", V2_FIXTURE_PATH, "--format", "sarif"])
+    sarif = json.loads(result.output)
+    sarif_results: list[dict[str, Any]] = sarif["runs"][0]["results"]
+    counts = _json_status_counts(V2_FIXTURE_PATH)
+    # Only fail + warn are findings; pass and skip are excluded.
+    assert len(sarif_results) == counts.get("fail", 0) + counts.get("warn", 0)
+    levels = {r["level"] for r in sarif_results}
+    assert "none" not in levels  # skips are omitted, not emitted as level "none"
+
+
+# ---------------------------------------------------------------------------
+# table output surfaces the skip status to the user
+# ---------------------------------------------------------------------------
+
+
+def test_table_output_renders_skip_status() -> None:
+    result = runner.invoke(app, ["doctor", "--path", V2_FIXTURE_PATH, "--format", "table"])
+    assert "(skip)" in result.output

--- a/tests/test_toolkit_rule_checks.py
+++ b/tests/test_toolkit_rule_checks.py
@@ -247,7 +247,7 @@ def test_langgraph_anonymous_auth_skipped_without_langgraph(tmp_path: Path) -> N
         "def handler(req):\n"
         "    return req\n",
     )
-    assert _status("langgraph_anonymous_auth", tmp_path) == "pass"
+    assert _status("langgraph_anonymous_auth", tmp_path) == "skip"
 
 
 def test_langgraph_anonymous_auth_flag_missing(tmp_path: Path) -> None:
@@ -367,7 +367,7 @@ def test_unsupported_metadata_version_supported_passes(tmp_path: Path) -> None:
 def test_unsupported_metadata_version_no_config_skipped(tmp_path: Path) -> None:
     _write(tmp_path, "host.json", '{"extensionBundle": {"version": "9.9"}}')
     # empty supported_versions -> check is skipped (pass)
-    assert _status("unsupported_metadata_version", tmp_path) == "pass"
+    assert _status("unsupported_metadata_version", tmp_path) == "skip"
 
 
 def test_unsupported_metadata_version_malformed_json_skipped(tmp_path: Path) -> None:
@@ -499,4 +499,4 @@ def test_otel_activation_with_dependency_passes(tmp_path: Path) -> None:
 
 def test_otel_activation_no_activation_passes(tmp_path: Path) -> None:
     _write(tmp_path, "a.py", "import os\n")
-    assert _status("otel_activation", tmp_path) == "pass"
+    assert _status("otel_activation", tmp_path) == "skip"


### PR DESCRIPTION
## Summary
- Add a first-class `skip` diagnostic status so a *skipped* check (feature unused, prerequisite/file absent) is no longer reported as a green `pass`.
- Convert the 8 handlers that returned `_create_result("pass", "...skipped")` to return `skip`.
- Thread `skip` through the entire output contract:
  - `utils`: `STATUS_ICONS` (`–`), `STATUS_STYLES` (`bright_black`), `DETAIL_COLOR_MAP`.
  - `doctor`: canonical mapping preserves `skip` regardless of `required`; skip never fails a section and never gets the `(optional)` suffix.
  - `cli`: `skipped_count` aggregation, `--summary-json` gains a `skipped` key, table renders `(skip)`, JUnit emits `<skipped>` for skip items, SARIF omits skipped checks, and exit codes remain driven solely by `fail_count`.

## Tests
- New `tests/test_skip_status.py` covering styling, handler-level skip, JSON, summary sidecar, JUnit, SARIF exclusion, exit code, and table output.
- Updated 12 existing assertions that described skip scenarios (`no_dep`, `not_present`, `no_file`, `skipped_without_langgraph`, `no_config_skipped`, `no_activation`, …) from `pass` to `skip`, plus the `--summary-json` keys test.
- `make lint`, `make typecheck`, `make test` all green (505 passed, coverage 96.67%).

## Notes
- The JUnit `testsuite` name fix and other public-surface hygiene items are intentionally **out of scope** here (tracked in #291).

Closes #286