### PR TITLE
docs: sync doc version strings to 0.19.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ This repository includes `llms.txt` and `llms-full.txt` for LLM-friendly documen
 
 When working with this codebase, LLM assistants should:
 
-1. **Use `llms.txt` for quick reference** — the canonical package version (0.19.1), Python requirements (>=3.10,<3.15), CLI entry points
+1. **Use `llms.txt` for quick reference** — the canonical package version (0.19.2), Python requirements (>=3.10,<3.15), CLI entry points
 2. **Refer to `llms-full.txt` for implementation details** — output contracts, rule structure, custom rule patterns, handler types
 3. **Check `src/azure_functions_doctor/cli.py`** — authoritative source for CLI options and validation
 4. **Review `src/azure_functions_doctor/assets/rules/v2.json`** — complete ruleset with check definitions

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,7 +47,7 @@ In this guide you will:
 | Azure CLI | `az --version` | [Install Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) |
 | Azure Functions Core Tools v4 | `func --version` | [Install Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools) |
 | Python 3.10-3.14 | `python3 --version` | [python.org](https://www.python.org/downloads/) |
-| Doctor CLI v0.19.1 | `pip show azure-functions-doctor` | `python3 -m pip install azure-functions-doctor` |
+| Doctor CLI v0.19.2 | `pip show azure-functions-doctor` | `python3 -m pip install azure-functions-doctor` |
 
 Install doctor if needed:
 
@@ -148,7 +148,7 @@ Representative JSON output (`doctor-report.json`):
 ```json
 {
   "metadata": {
-    "tool_version": "0.19.1",
+    "tool_version": "0.19.2",
     "target_path": "/data/GitHub/azure-functions-doctor/examples/v2/http-trigger",
     "programming_model": "v2",
     "target_python": null
@@ -179,7 +179,7 @@ Representative SARIF output (`doctor-report.sarif`):
       "tool": {
         "driver": {
           "name": "azure-functions-doctor",
-          "version": "0.19.1"
+          "version": "0.19.2"
         }
       },
       "results": []

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5,7 +5,7 @@
 ## Package Info
 
 - PyPI: `pip install azure-functions-doctor`
-- Version: 0.19.1
+- Version: 0.19.2
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.dev/azure-functions-python/doctor/
@@ -185,7 +185,7 @@ Structured output with metadata, results, and rule information:
 ```json
 {
   "metadata": {
-    "tool_version": "0.19.1",
+    "tool_version": "0.19.2",
     "generated_at": "2025-04-07T10:30:00Z",
     "target_path": "/path/to/app"
   },
@@ -223,7 +223,7 @@ Static Analysis Results Format (SARIF 2.1.0) compatible with GitHub Security tab
       "tool": {
         "driver": {
           "name": "azure-functions-doctor",
-          "version": "0.19.1",
+          "version": "0.19.2",
           "informationUri": "https://github.com/yeongseon/azure-functions-doctor",
           "rules": [...]
         }

--- a/llms.txt
+++ b/llms.txt
@@ -5,7 +5,7 @@
 ## Package Info
 
 - PyPI: `pip install azure-functions-doctor`
-- Version: 0.19.1
+- Version: 0.19.2
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.dev/azure-functions-python/doctor/


### PR DESCRIPTION
## Context
`__version__` was bumped to `0.19.2` in d3bc7cd, but the canonical version strings in the AI-assistant/docs surface were left at `0.19.1`. This trips `scripts/check_docs_consistency.py` in CI, so the `test (3.10)` job fails on `main` and on every branch cut from it (currently blocking #292 and #293).

## Changes
- Sync `0.19.1` → `0.19.2` across `llms.txt`, `llms-full.txt`, `docs/deployment.md`, and `README.md` (canonical version strings plus the example JSON `tool_version`/`version` fields).

## Verification
- `python scripts/check_docs_consistency.py` → passes (version 0.19.2, 30 rules).
- `python scripts/gen_rule_inventory.py --check` → up to date.

## Out of scope
- Automating version-string propagation on `hatch version` bumps (tracked separately as release hygiene).