### PR TITLE
fix(target): resolve project Python target before falling back to tool interpreter

### DIFF
--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -17,6 +17,7 @@ from azure_functions_doctor.logging_config import (
     log_diagnostic_start,
     setup_logging,
 )
+from azure_functions_doctor.target_resolver import resolve_python_target
 from azure_functions_doctor.utils import format_detail, format_status_icon
 
 cli = typer.Typer()
@@ -356,6 +357,10 @@ def doctor(
     console.print(f"Path: {resolved_path}")
     if target_python is not None:
         console.print(f"Target Python: {target_python} (override)")
+    else:
+        resolved_target, target_source = resolve_python_target(resolved_path)
+        if target_source != "tool-runtime":
+            console.print(f"Target Python: {resolved_target} ({target_source})")
 
     # Print each section with simple title and items
     for section in results:

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -48,7 +48,7 @@ from azure_functions_doctor.handlers._helpers import (
     pyproject_declares_dependencies,
     pyproject_dependency_names,
 )
-from azure_functions_doctor.target_resolver import resolve_target_value
+from azure_functions_doctor.target_resolver import resolve_python_target, resolve_target_value
 
 
 class HandlerRegistry:
@@ -90,7 +90,7 @@ class HandlerRegistry:
 
         if target == "python":
             target_python = context.get("target_python") if context is not None else None
-            current_version = resolve_target_value("python", override=target_python)
+            current_version, source = resolve_python_target(path, override=target_python)
             tool_runtime = (
                 f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
             )
@@ -103,11 +103,17 @@ class HandlerRegistry:
                 ">": current > expected,
                 "<": current < expected,
             }.get(operator, False)
-            detail = (
-                f"Target Python: {current_version} (override) — Tool runtime: {tool_runtime}"
-                if target_python is not None
-                else f"Python {current_version} (tool runtime, {operator}{value})"
-            )
+            if source == "override":
+                detail = (
+                    f"Target Python: {current_version} (override) — Tool runtime: {tool_runtime}"
+                )
+            elif source == "tool-runtime":
+                detail = f"Python {current_version} (tool runtime, {operator}{value})"
+            else:
+                detail = (
+                    f"Target Python: {current_version} ({source}, {operator}{value}) "
+                    f"— Tool runtime: {tool_runtime}"
+                )
             return _create_result(
                 "pass" if passed else "fail",
                 detail,

--- a/src/azure_functions_doctor/target_resolver.py
+++ b/src/azure_functions_doctor/target_resolver.py
@@ -1,7 +1,9 @@
+from pathlib import Path
+import re
 import shutil
 import subprocess  # nosec B404
 import sys
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Tuple
 
 from azure_functions_doctor.logging_config import get_logger
 
@@ -11,6 +13,66 @@ logger = get_logger(__name__)
 def _resolve_python(override: Optional[str] = None) -> str:
     """Resolve the running Python interpreter version."""
     return override if override is not None else sys.version.split()[0]
+
+
+_PYTHON_VERSION_RE = re.compile(r"(\d+\.\d+(?:\.\d+)?)")
+
+
+def _requires_python_floor(pyproject: Path) -> Optional[str]:
+    """Extract the lower version bound from ``[project] requires-python``."""
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = re.search(r'requires-python\s*=\s*["\']([^"\']+)["\']', text)
+    if not match:
+        return None
+    version_match = _PYTHON_VERSION_RE.search(match.group(1))
+    return version_match.group(1) if version_match else None
+
+
+def resolve_python_target(
+    project_path: Optional[Path] = None, override: Optional[str] = None
+) -> Tuple[str, str]:
+    """Resolve the Python version to diagnose against, with provenance.
+
+    Precedence (first match wins):
+
+    1. Explicit ``override`` (e.g. ``--target-python``) -> source ``"override"``.
+    2. ``pyproject.toml`` ``[project] requires-python`` floor ->
+       source ``"pyproject:requires-python"``.
+    3. ``.python-version`` file -> source ``".python-version"``.
+    4. The running interpreter -> source ``"tool-runtime"`` (always resolves).
+
+    Args:
+        project_path: Root of the project under diagnosis. When ``None`` or when
+            no project signal is found, the running interpreter is used.
+        override: Explicit target that short-circuits project detection.
+
+    Returns:
+        A ``(version, source)`` tuple where ``source`` records provenance.
+    """
+    if override is not None:
+        return override, "override"
+
+    if project_path is not None:
+        pyproject = project_path / "pyproject.toml"
+        if pyproject.is_file():
+            version = _requires_python_floor(pyproject)
+            if version is not None:
+                return version, "pyproject:requires-python"
+
+        python_version_file = project_path / ".python-version"
+        if python_version_file.is_file():
+            try:
+                content = python_version_file.read_text(encoding="utf-8").strip()
+            except OSError:
+                content = ""
+            match = _PYTHON_VERSION_RE.search(content)
+            if match:
+                return match.group(1), ".python-version"
+
+    return sys.version.split()[0], "tool-runtime"
 
 
 def _resolve_func_core_tools(override: Optional[str] = None) -> str:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -19,7 +19,7 @@ from azure_functions_doctor.handlers import (
 )
 
 
-def test_compare_python_version_pass() -> None:
+def test_compare_python_version_pass(tmp_path: Path) -> None:
     """Test that the Python version check passes for the current version."""
     rule: Rule = {
         "type": "compare_version",
@@ -29,7 +29,7 @@ def test_compare_python_version_pass() -> None:
             "value": f"{sys.version_info.major}.{sys.version_info.minor}",
         },
     }
-    result = generic_handler(rule, Path("."))
+    result = generic_handler(rule, tmp_path)
     assert result["status"] == "pass"
     assert "tool runtime" in result["detail"]
 
@@ -76,6 +76,25 @@ def test_compare_python_version_override_fail() -> None:
     result = generic_handler(rule, Path("."), {"target_python": "3.10"})
     assert result["status"] == "fail"
     assert "Tool runtime:" in result["detail"]
+
+
+def test_compare_python_version_uses_pyproject_target(tmp_path: Path) -> None:
+    """A project's requires-python floor drives the comparison, not the runtime."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nrequires-python = ">=3.11"\n', encoding="utf-8"
+    )
+    rule: Rule = {
+        "type": "compare_version",
+        "condition": {
+            "target": "python",
+            "operator": ">=",
+            "value": "3.12",
+        },
+    }
+    result = generic_handler(rule, tmp_path)
+    assert result["status"] == "fail"
+    assert "pyproject:requires-python" in result["detail"]
+    assert "Target Python: 3.11" in result["detail"]
 
 
 def test_compare_func_core_tools_version_pass(monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -47,7 +47,7 @@ def test_handler_registry_unknown_type() -> None:
     assert "Unknown check type" in result["detail"]
 
 
-def test_handler_registry_compare_version() -> None:
+def test_handler_registry_compare_version(tmp_path: Path) -> None:
     """Test version comparison through registry."""
     registry = HandlerRegistry()
 
@@ -61,7 +61,7 @@ def test_handler_registry_compare_version() -> None:
         },
     }
 
-    result = registry.handle(rule, Path("."))
+    result = registry.handle(rule, tmp_path)
 
     assert result["status"] == "pass"
     # Detail now clarifies that the local interpreter is the tool runtime.
@@ -1710,7 +1710,7 @@ def test_compare_version_python_fail() -> None:
     assert result["status"] == "fail"
 
 
-def test_compare_version_python_equal() -> None:
+def test_compare_version_python_equal(tmp_path: Path) -> None:
     """Test _handle_compare_version with Python version == operator."""
     registry = HandlerRegistry()
     rule: Rule = {
@@ -1722,7 +1722,7 @@ def test_compare_version_python_equal() -> None:
             "value": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
         },
     }
-    result = registry.handle(rule, Path("."))
+    result = registry.handle(rule, tmp_path)
     assert result["status"] == "pass"
 
 

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import subprocess
 import sys
 from typing import Optional
@@ -81,3 +82,57 @@ def test_resolve_func_core_tools_called_process_error(monkeypatch: pytest.Monkey
     monkeypatch.setattr(subprocess, "check_output", mock_check_output)
     result = target_resolver.resolve_target_value("func_core_tools")
     assert result == "error_2"
+
+
+def test_resolve_python_target_override_short_circuits(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nrequires-python = ">=3.10"\n', encoding="utf-8"
+    )
+    version, source = target_resolver.resolve_python_target(tmp_path, override="3.12")
+    assert (version, source) == ("3.12", "override")
+
+
+def test_resolve_python_target_from_pyproject_floor(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "x"\nrequires-python = ">=3.11,<3.15"\n', encoding="utf-8"
+    )
+    version, source = target_resolver.resolve_python_target(tmp_path)
+    assert (version, source) == ("3.11", "pyproject:requires-python")
+
+
+def test_resolve_python_target_from_python_version_file(tmp_path: Path) -> None:
+    (tmp_path / ".python-version").write_text("3.12.4\n", encoding="utf-8")
+    version, source = target_resolver.resolve_python_target(tmp_path)
+    assert (version, source) == ("3.12.4", ".python-version")
+
+
+def test_resolve_python_target_pyproject_precedes_python_version(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nrequires-python = ">=3.10"\n', encoding="utf-8"
+    )
+    (tmp_path / ".python-version").write_text("3.13\n", encoding="utf-8")
+    version, source = target_resolver.resolve_python_target(tmp_path)
+    assert (version, source) == ("3.10", "pyproject:requires-python")
+
+
+def test_resolve_python_target_pyproject_without_requires_python(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n', encoding="utf-8")
+    (tmp_path / ".python-version").write_text("3.13\n", encoding="utf-8")
+    version, source = target_resolver.resolve_python_target(tmp_path)
+    assert (version, source) == ("3.13", ".python-version")
+
+
+def test_resolve_python_target_ignores_unparseable_python_version(tmp_path: Path) -> None:
+    (tmp_path / ".python-version").write_text("not-a-version\n", encoding="utf-8")
+    version, source = target_resolver.resolve_python_target(tmp_path)
+    assert (version, source) == (sys.version.split()[0], "tool-runtime")
+
+
+def test_resolve_python_target_falls_back_to_tool_runtime(tmp_path: Path) -> None:
+    version, source = target_resolver.resolve_python_target(tmp_path)
+    assert (version, source) == (sys.version.split()[0], "tool-runtime")
+
+
+def test_resolve_python_target_no_project_path(tmp_path: Path) -> None:
+    version, source = target_resolver.resolve_python_target(None)
+    assert (version, source) == (sys.version.split()[0], "tool-runtime")

--- a/tests/test_toolkit_rule_checks.py
+++ b/tests/test_toolkit_rule_checks.py
@@ -474,8 +474,7 @@ def test_project_declares_opentelemetry_pyproject(tmp_path: Path) -> None:
     _write(
         tmp_path,
         "pyproject.toml",
-        '[project]\nname = "x"\nversion = "0"\n'
-        'dependencies = ["opentelemetry-sdk>=1.24"]\n',
+        '[project]\nname = "x"\nversion = "0"\ndependencies = ["opentelemetry-sdk>=1.24"]\n',
     )
     assert _project_declares_opentelemetry(tmp_path)
 


### PR DESCRIPTION
## Context
`compare_version` checks for `python` always compared against the interpreter running Doctor (`sys.version`), ignoring the Python version the project under diagnosis actually targets. A project pinned to 3.11 diagnosed with a 3.12 interpreter was silently checked against 3.12.

## Changes
- Add `resolve_python_target(project_path, override) -> (version, source)` to `target_resolver.py` with deterministic precedence:
  1. `--target-python` override → `override`
  2. `pyproject.toml` `[project] requires-python` floor → `pyproject:requires-python`
  3. `.python-version` file → `.python-version`
  4. running interpreter → `tool-runtime`
- Wire it into `_handle_compare_version`; diagnostic detail now records provenance and keeps the tool runtime visible for context.
- CLI header surfaces a project-derived target when no override is supplied (override output unchanged).

## Acceptance Checklist
- [x] Project `requires-python` floor drives the comparison when present.
- [x] `.python-version` used when no `requires-python`.
- [x] Falls back to the running interpreter with `tool-runtime` provenance.
- [x] `--target-python` override still short-circuits detection.
- [x] New unit tests for `resolve_python_target` + handler-level project-target test.
- [x] `make lint`, `make typecheck`, `make test` green (coverage 96.27%).

## Notes
- Existing `compare_version` tests that implicitly relied on cwd (`Path(".")`) were isolated to `tmp_path` so they test the intended tool-runtime path deterministically.
- Includes a pre-existing ruff implicit-string-concat auto-fix in `tests/test_toolkit_rule_checks.py`.

Closes #287