### PR TITLE
chore(surface): fix JUnit name, README count, action alias, and SHA pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Deploying a broken Azure Functions app is expensive — the worker starts, the h
 
 ## What it does
 
-- **14+ diagnostic checks** — Python version, dependencies, host.json, Core Tools, Durable Functions, and more
+- **30 diagnostic checks** — Python version, dependencies, host.json, Core Tools, Durable Functions, and more
 - **Multiple output formats** — table, JSON, SARIF, JUnit for CI integration
 - **Profile support** — `minimal` or `full` rulesets depending on your needs
 - **Official GitHub Action** — `yeongseon/azure-functions-doctor@v1` for CI gates

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -109,7 +109,7 @@ runs:
       run: |
         set +e
         SUMMARY_FILE=$(mktemp /tmp/doctor-summary-XXXXXX.json)
-        azure-functions doctor \
+        azure-functions-doctor doctor \
           --path "${{ inputs.path }}" \
           --profile "${{ inputs.profile }}" \
           --format "${{ inputs.format }}" \
@@ -143,7 +143,7 @@ runs:
 
     - name: Upload report artifact
       if: inputs.upload-artifact == 'true' && always()
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.output }}

--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -317,7 +317,7 @@ def doctor(
         skipped = 0
         suite = ET.Element(
             "testsuite",
-            name="func-doctor",
+            name="azure-functions-doctor",
             tests="0",
             failures="0",
             skipped="0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,7 +103,7 @@ def test_cli_junit_output() -> None:
     assert result.output.startswith("<?xml")
     root = ET.fromstring(result.output)
     assert root.tag == "testsuite"
-    assert root.attrib.get("name") == "func-doctor"
+    assert root.attrib.get("name") == "azure-functions-doctor"
     tests = int(root.attrib.get("tests", "0"))
     failures = int(root.attrib.get("failures", "0"))
     skipped = int(root.attrib.get("skipped", "0"))


### PR DESCRIPTION
## Context
A batch of small, user-visible public-surface and CI-hygiene defects (findings P2-9/10/11/13 from the external review), cheap to fix and safe to ship together.

## Changes
- **JUnit name (P2-9):** testsuite `name` `func-doctor` → `azure-functions-doctor` (`cli.py`); test assertion updated.
- **README count (P2-10):** "14+ diagnostic checks" → "30 diagnostic checks" to match the shipped ruleset (verified via `scripts/check_docs_consistency.py` / `gen_rule_inventory.py`).
- **Action alias (P2-11):** `action.yml` now invokes the canonical `azure-functions-doctor doctor` instead of the deprecated `azure-functions` alias (which prints a deprecation warning and collides with Core Tools' binary name).
- **SHA pinning (P2-13):** `action.yml` pins `setup-python` and `upload-artifact` to the same commit SHAs used across the repo's workflows.

## Acceptance Checklist
- [x] JUnit testsuite name renamed.
- [x] README rule count corrected to the shipped ruleset.
- [x] `action.yml` uses the canonical command, not the deprecated alias.
- [x] `setup-python` / `upload-artifact` SHA-pinned.
- [x] Test asserting the JUnit name updated.
- [x] `make lint`, `make typecheck`, docs-consistency, and `test_cli.py` green.

## Out of scope
- Removing the deprecated `azure-functions` / `fdoctor` console aliases (breaking; targeted for v1.0.0).

Closes #291