### PR TITLE
feat(sarif): emit per-file and per-line locations in SARIF output

### DIFF
--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -264,25 +264,43 @@ def doctor(
                 # Skipped checks are not findings; exclude them from SARIF output.
                 if status in ("pass", "skip"):
                     continue
-                    continue
                 label = item.get("label", "")
                 matched_rule = label_to_rule.get(label)
                 rule_id = matched_rule.get("id", label) if matched_rule else label
                 level = "error" if status == "fail" else "warning"
+                loc_file = item.get("file")
+                if loc_file:
+                    artifact_uri = str(loc_file).replace("\\", "/")
+                    if artifact_uri.startswith("./"):
+                        artifact_uri = artifact_uri[2:]
+                    physical_location: dict[str, object] = {
+                        "artifactLocation": {
+                            "uri": artifact_uri,
+                            "uriBaseId": "%SRCROOT%",
+                        }
+                    }
+                    loc_line = item.get("line")
+                    if isinstance(loc_line, int) and loc_line > 0:
+                        region: dict[str, object] = {"startLine": loc_line}
+                        loc_end_line = item.get("end_line")
+                        if isinstance(loc_end_line, int) and loc_end_line > 0:
+                            region["endLine"] = loc_end_line
+                        loc_column = item.get("column")
+                        if isinstance(loc_column, int) and loc_column > 0:
+                            region["startColumn"] = loc_column
+                        physical_location["region"] = region
+                else:
+                    physical_location = {
+                        "artifactLocation": {
+                            "uri": path.replace("\\", "/").rstrip("/") + "/",
+                            "uriBaseId": "%SRCROOT%",
+                        }
+                    }
                 sarif_result: dict[str, object] = {
                     "ruleId": rule_id,
                     "message": {"text": item.get("value", "")},
                     "level": level,
-                    "locations": [
-                        {
-                            "physicalLocation": {
-                                "artifactLocation": {
-                                    "uri": path.replace("\\", "/").rstrip("/") + "/",
-                                    "uriBaseId": "%SRCROOT%",
-                                }
-                            }
-                        }
-                    ],
+                    "locations": [{"physicalLocation": physical_location}],
                 }
                 if item.get("hint"):
                     sarif_result["properties"] = {"hint": item.get("hint", "")}

--- a/src/azure_functions_doctor/doctor.py
+++ b/src/azure_functions_doctor/doctor.py
@@ -30,6 +30,10 @@ class CheckResult(TypedDict, total=False):
     status: str
     hint: str
     hint_url: str
+    file: str
+    line: int
+    end_line: int
+    column: int
 
 
 class SectionResult(TypedDict):
@@ -308,6 +312,15 @@ class Doctor:
 
                 if "hint_url" in rule and rule["hint_url"]:
                     item["hint_url"] = rule["hint_url"]
+
+                if "file" in result:
+                    item["file"] = result["file"]
+                if "line" in result:
+                    item["line"] = result["line"]
+                if "end_line" in result:
+                    item["end_line"] = result["end_line"]
+                if "column" in result:
+                    item["column"] = result["column"]
 
                 section_result["items"].append(item)
 

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -58,6 +58,10 @@ class HandlerResult(TypedDict, total=False):
     status: str
     detail: str
     internal_error: str
+    file: str
+    line: int
+    end_line: int
+    column: int
 
 
 class RuleContext(TypedDict, total=False):
@@ -352,16 +356,21 @@ def _is_spec_serving_handler(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bo
     return False
 
 
-def _collect_routes_missing_validate_http(path: Path) -> list[str]:
-    """Return "file:function" labels for HTTP route handlers that lack an
+def _collect_routes_missing_validate_http_locations(
+    path: Path,
+) -> list[tuple[str, int, Optional[int], int]]:
+    """Return ``(label, lineno)`` pairs for HTTP route handlers that lack an
     *active* ``@validate_http`` and therefore emit no endpoint OpenAPI metadata.
+
+    ``label`` is ``"file:function"`` and ``lineno`` is the 1-based source line of
+    the offending function definition.
 
     ``@validate_http`` only covers a handler when it is applied *below* (inner to)
     the ``@app.route`` decorator. When it appears above the route decorator it
     wraps the SDK ``FunctionBuilder``, so validation and endpoint metadata are
     inactive even though the decorator name is present.
     """
-    uncovered: list[str] = []
+    uncovered: list[tuple[str, int, Optional[int], int]] = []
     for py_file, content in _iter_project_py_contents(path):
         try:
             tree = ast.parse(content)
@@ -393,8 +402,25 @@ def _collect_routes_missing_validate_http(path: Path) -> list[str]:
                 validate_idx is not None and route_idx is not None and validate_idx > route_idx
             )
             if is_route and not has_active_validate_http and not _is_spec_serving_handler(node):
-                uncovered.append(f"{py_file.relative_to(path)}:{node.name}")
+                uncovered.append(
+                    (
+                        f"{py_file.relative_to(path)}:{node.name}",
+                        node.lineno,
+                        node.end_lineno,
+                        node.col_offset + 1,
+                    )
+                )
     return uncovered
+
+
+def _collect_routes_missing_validate_http(path: Path) -> list[str]:
+    """Return "file:function" labels for HTTP route handlers that lack an
+    *active* ``@validate_http`` and therefore emit no endpoint OpenAPI metadata.
+
+    Thin string-only wrapper over
+    :func:`_collect_routes_missing_validate_http_locations`.
+    """
+    return [lbl for lbl, _ln, _end, _col in _collect_routes_missing_validate_http_locations(path)]
 
 
 def _dotted_call_name(func: ast.expr) -> Optional[str]:
@@ -905,11 +931,27 @@ def _detect_native_dependency_risks(content: str) -> list[tuple[str, str]]:
     return matches
 
 
-def _create_result(status: str, detail: str, internal_error: bool = False) -> HandlerResult:
+def _create_result(
+    status: str,
+    detail: str,
+    internal_error: bool = False,
+    file: Optional[str] = None,
+    line: Optional[int] = None,
+    end_line: Optional[int] = None,
+    column: Optional[int] = None,
+) -> HandlerResult:
     """Create a standardized result dictionary (status limited to 'pass'/'fail')."""
     res: HandlerResult = {"status": status, "detail": detail}
     if internal_error:
         res["internal_error"] = "true"
+    if file is not None:
+        res["file"] = file
+    if line is not None:
+        res["line"] = line
+    if end_line is not None:
+        res["end_line"] = end_line
+    if column is not None:
+        res["column"] = column
     return res
 
 

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -22,7 +22,7 @@ from azure_functions_doctor.handlers._helpers import (
     _collect_inverted_decorator_order,
     _collect_openapi_version_mixing,
     _collect_orchestrator_nondeterminism,
-    _collect_routes_missing_validate_http,
+    _collect_routes_missing_validate_http_locations,
     _collect_scan_before_spec,
     _collect_unregistered_blueprint_aliases,
     _collect_unsupported_metadata_versions,
@@ -194,11 +194,12 @@ class HandlerRegistry:
         if not target:
             return _create_result("fail", "Missing file path")
         file_path = path / target
+        rel_target = target.replace("\\", "/")
         exists = file_path.is_file()
         detail = f"{file_path} {'exists' if exists else 'not found'}"
         if not exists and not rule.get("required", True):
             detail += " (optional)"
-        return _create_result("pass" if exists else "fail", detail)
+        return _create_result("pass" if exists else "fail", detail, file=rel_target)
 
     @_rule_handler
     def _handle_dependency_manifest(
@@ -744,18 +745,27 @@ class HandlerRegistry:
             return _create_result(
                 "skip", "azure-functions-validation not declared; endpoint metadata check skipped"
             )
-        uncovered = _collect_routes_missing_validate_http(path)
+        uncovered = _collect_routes_missing_validate_http_locations(path)
         if not uncovered:
             return _create_result("pass", "All route handlers expose endpoint metadata")
         detail = "\n".join(
             [
                 "Route handlers missing @validate_http (no endpoint metadata):",
-                *[f"- {fn}" for fn in uncovered[:10]],
+                *[f"- {label}" for label, _ln, _end, _col in uncovered[:10]],
                 "",
                 "Fix: add @validate_http so the route emits OpenAPI endpoint metadata.",
             ]
         )
-        return _create_result("fail", detail)
+        first_label, first_line, first_end_line, first_column = uncovered[0]
+        first_file = first_label.rsplit(":", 1)[0]
+        return _create_result(
+            "fail",
+            detail,
+            file=first_file,
+            line=first_line,
+            end_line=first_end_line,
+            column=first_column,
+        )
 
     @_rule_handler
     def _handle_openapi_version_mixing(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 import re
+from typing import Any
 from unittest.mock import Mock
 import xml.etree.ElementTree as ET
 
@@ -307,3 +308,74 @@ def test_fdoctor_alias_warns_and_delegates(
     err = capsys.readouterr().err
     assert "deprecated" in err
     assert "v1.0.0" in err
+
+
+def _write_sarif_location_fixture(root: Path) -> int:
+    """Create a v2 project that triggers a file-based failure (missing host.json)
+    and an AST-based failure (route missing an active @validate_http).
+
+    Returns the 1-based source line of the offending ``handler`` definition.
+    """
+    (root / "requirements.txt").write_text(
+        "azure-functions\nazure-functions-validation\n", encoding="utf-8"
+    )
+    # @validate_http placed ABOVE @app.route is inactive, so the route emits no
+    # endpoint metadata and is flagged by the endpoint_metadata rule.
+    source = (
+        "import azure.functions as func\n"
+        "\n"
+        "app = func.FunctionApp()\n"
+        "\n"
+        "\n"
+        "@validate_http\n"
+        "@app.route(route='x')\n"
+        "def handler(req):\n"
+        "    return req\n"
+    )
+    (root / "function_app.py").write_text(source, encoding="utf-8")
+    # 1-based line of `def handler` within the source above.
+    return source.splitlines().index("def handler(req):") + 1
+
+
+def test_cli_sarif_output_emits_per_file_and_per_line_locations(tmp_path: Path) -> None:
+    """SARIF results carry per-file locations for a file-based rule and per-line
+    locations (with region) for an AST-based rule."""
+    handler_line = _write_sarif_location_fixture(tmp_path)
+
+    result = runner.invoke(app, ["doctor", "--path", str(tmp_path), "--format", "sarif"])
+    data = json.loads(result.output)
+    sarif_results = data["runs"][0]["results"]
+
+    def _uri(res: Any) -> str:
+        return str(res["locations"][0]["physicalLocation"]["artifactLocation"]["uri"])
+
+    # File-based rule: missing host.json is reported against the offending file.
+    host_json_results = [r for r in sarif_results if _uri(r) == "host.json"]
+    assert host_json_results, "expected a SARIF result located at host.json"
+    assert "region" not in host_json_results[0]["locations"][0]["physicalLocation"]
+
+    # AST-based rule: the flagged route carries a per-line region.
+    ast_results = [r for r in sarif_results if _uri(r) == "function_app.py"]
+    assert ast_results, "expected a SARIF result located at function_app.py"
+    region = next(
+        r["locations"][0]["physicalLocation"]["region"]
+        for r in ast_results
+        if "region" in r["locations"][0]["physicalLocation"]
+    )
+    assert region["startLine"] == handler_line
+    assert region["endLine"] >= region["startLine"]
+    assert region["startColumn"] >= 1
+
+
+def test_create_result_populates_optional_location_fields() -> None:
+    """_create_result threads optional file/line/end_line/column when provided."""
+    from azure_functions_doctor.handlers._helpers import _create_result
+
+    res = _create_result("fail", "detail", file="function_app.py", line=8, end_line=9, column=1)
+    assert res["file"] == "function_app.py"
+    assert res["line"] == 8
+    assert res["end_line"] == 9
+    assert res["column"] == 1
+
+    bare = _create_result("pass", "ok")
+    assert "file" not in bare and "line" not in bare


### PR DESCRIPTION
## Context
SARIF output previously emitted a single repo-root artifact URI with `uriBaseId: "%SRCROOT%"` and no per-result physical locations, so code-scanning consumers (GitHub Advanced Security, etc.) could not annotate specific files/lines. The result models carried no location fields even though AST-based rules already have `node.lineno`/`node.end_lineno`/`node.col_offset` at detection time.

Closes #288.

## Changes
- Add optional `file` / `line` / `end_line` / `column` fields to `HandlerResult` (`handlers/_helpers.py`) and `CheckResult` (`doctor.py`), and thread them through `_create_result`.
- **AST rule** (`_handle_endpoint_metadata`): populate `file`, `line`, `end_line`, and `column` for the first route missing an active `@validate_http`. Added `_collect_routes_missing_validate_http_locations()` returning `(label, lineno, end_lineno, column)`; the existing string-only `_collect_routes_missing_validate_http()` is now a thin wrapper (unchanged public behavior).
- **File-based rule** (`_handle_file_exists`): populate `file` with the offending/expected project-relative path.
- `doctor.py` copies any present location keys from the handler result into the `CheckResult`.
- `cli.py` SARIF emitter now builds a per-file `artifactLocation.uri` (forward-slashed, repo-relative) with `region.startLine` (+ `endLine`/`startColumn` when known), falling back to the previous repo-root behavior when no location is known. Also removed a pre-existing duplicate `continue`.

## Out of scope
- Adding the `skip` SARIF level (handled separately).

## Testing
- New tests assert SARIF contains a per-file location for a file-based rule (`host.json`) and a per-line region for an AST rule (route missing `@validate_http`), plus `_create_result` location threading.
- `make lint`, `make typecheck`, `make test` all green; coverage 96.60% (≥95%). `scripts/check_docs_consistency.py` passes.