### PR TITLE
fix(runtime): validate Python target against supported Azure versions

### DIFF
--- a/docs/json_output_contract.md
+++ b/docs/json_output_contract.md
@@ -33,7 +33,7 @@ If `--output` is omitted, JSON is printed to stdout.
           "label": "Python version",
           "value": "Python 3.9.18 (>=3.10)",
           "status": "fail",
-          "hint": "Use Python 3.10 or higher to match Azure Functions Doctor support.",
+          "hint": "Target a Python version supported by Azure Functions: 3.10, 3.11, 3.12, 3.13, or 3.14.",
           "hint_url": "https://learn.microsoft.com/..."
         }
       ]

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -33,7 +33,7 @@
     "category": "environment",
     "section": "python_env",
     "label": "Python version",
-    "description": "Checks if the current Python version is 3.10 or higher.",
+    "description": "Checks that the target Python version is a supported Azure Functions runtime (3.10\u20133.14).",
     "type": "compare_version",
     "required": true,
     "condition": {
@@ -41,13 +41,13 @@
       "operator": ">=",
       "value": "3.10"
     },
-    "hint": "Use Python 3.10 or higher to match Azure Functions Doctor support.",
+    "hint": "Target a Python version supported by Azure Functions: 3.10, 3.11, 3.12, 3.13, or 3.14.",
     "hint_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#supported-python-versions",
     "source_type": "ms_learn",
     "source_title": "Azure Functions Python developer guide — Supported Python versions",
     "source_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#supported-python-versions",
-    "why_it_matters": "Azure Functions only supports Python 3.10+ for v2. Running an older interpreter causes immediate deployment failures and unsupported runtime errors.",
-    "symptoms": "Deployment fails with 'Python version not supported'; functions fail to start; 3.9 or earlier behaviours may cause silent type mismatches.",
+    "why_it_matters": "Azure Functions supports only Python 3.10\u20133.14. Targeting an older interpreter (\u2264 3.9) or a version newer than the runtime supports causes deployment failures and unsupported runtime errors.",
+    "symptoms": "Deployment fails with 'Python version not supported'; functions fail to start; a too-new interpreter is silently downgraded or rejected by the host.",
     "fix_command": "pyenv install 3.10.16",
     "check_order": 1
   },

--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -17,14 +17,17 @@ from azure_functions_doctor.logging_config import (
     log_diagnostic_start,
     setup_logging,
 )
-from azure_functions_doctor.target_resolver import resolve_python_target
+from azure_functions_doctor.target_resolver import (
+    SUPPORTED_PYTHON_VERSIONS,
+    resolve_python_target,
+)
 from azure_functions_doctor.utils import format_detail, format_status_icon
 
 cli = typer.Typer()
 console = Console()
 logger = get_logger(__name__)
 
-SUPPORTED_TARGET_PYTHON_VERSIONS = ("3.10", "3.11", "3.12", "3.13", "3.14")
+SUPPORTED_TARGET_PYTHON_VERSIONS = SUPPORTED_PYTHON_VERSIONS
 
 
 def _validate_inputs(

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -48,7 +48,12 @@ from azure_functions_doctor.handlers._helpers import (
     pyproject_declares_dependencies,
     pyproject_dependency_names,
 )
-from azure_functions_doctor.target_resolver import resolve_python_target, resolve_target_value
+from azure_functions_doctor.target_resolver import (
+    SUPPORTED_PYTHON_VERSIONS,
+is_supported_python_target,
+resolve_python_target,
+resolve_target_value,
+)
 
 
 class HandlerRegistry:
@@ -96,23 +101,32 @@ class HandlerRegistry:
             )
             current = parse_version(current_version)
             expected = parse_version(str(value))
-            passed = {
+            operator_passed = {
                 ">=": current >= expected,
                 "<=": current <= expected,
                 "==": current == expected,
                 ">": current > expected,
                 "<": current < expected,
             }.get(operator, False)
+            supported = is_supported_python_target(current_version)
+            passed = operator_passed and supported
+            supported_range = f"{SUPPORTED_PYTHON_VERSIONS[0]}\u2013{SUPPORTED_PYTHON_VERSIONS[-1]}"
             if source == "override":
                 detail = (
-                    f"Target Python: {current_version} (override) — Tool runtime: {tool_runtime}"
+                    f"Target Python: {current_version} (override) "
+                    f"\u2014 Tool runtime: {tool_runtime}"
                 )
             elif source == "tool-runtime":
                 detail = f"Python {current_version} (tool runtime, {operator}{value})"
             else:
                 detail = (
                     f"Target Python: {current_version} ({source}, {operator}{value}) "
-                    f"— Tool runtime: {tool_runtime}"
+                    f"\u2014 Tool runtime: {tool_runtime}"
+                )
+            if not supported:
+                detail += (
+                    f" \u2014 unsupported target; Azure Functions supports "
+                    f"Python {supported_range}"
                 )
             return _create_result(
                 "pass" if passed else "fail",

--- a/src/azure_functions_doctor/target_resolver.py
+++ b/src/azure_functions_doctor/target_resolver.py
@@ -9,6 +9,35 @@ from azure_functions_doctor.logging_config import get_logger
 
 logger = get_logger(__name__)
 
+# Python versions supported by Azure Functions (2026). Anything outside this
+# inclusive major.minor set is unsupported and should fail diagnostics.
+SUPPORTED_PYTHON_VERSIONS: Tuple[str, ...] = ("3.10", "3.11", "3.12", "3.13", "3.14")
+
+
+def _major_minor(version: str) -> Optional[Tuple[int, int]]:
+    """Return the ``(major, minor)`` pair for a version string, or ``None``."""
+    match = _PYTHON_VERSION_RE.search(version)
+    if not match:
+        return None
+    parts = match.group(1).split(".")
+    try:
+        return int(parts[0]), int(parts[1])
+    except (IndexError, ValueError):
+        return None
+
+
+def is_supported_python_target(version: str) -> bool:
+    """Return ``True`` when ``version``'s major.minor is a supported Azure target.
+
+    Only the major and minor components are considered, so patch releases such
+    as ``"3.14.2"`` are supported while ``"3.15.0"`` and ``"3.9.1"`` are not.
+    """
+    parsed = _major_minor(version)
+    if parsed is None:
+        return False
+    supported = {_major_minor(v) for v in SUPPORTED_PYTHON_VERSIONS}
+    return parsed in supported
+
 
 def _resolve_python(override: Optional[str] = None) -> str:
     """Resolve the running Python interpreter version."""
@@ -16,19 +45,6 @@ def _resolve_python(override: Optional[str] = None) -> str:
 
 
 _PYTHON_VERSION_RE = re.compile(r"(\d+\.\d+(?:\.\d+)?)")
-
-
-def _requires_python_floor(pyproject: Path) -> Optional[str]:
-    """Extract the lower version bound from ``[project] requires-python``."""
-    try:
-        text = pyproject.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    match = re.search(r'requires-python\s*=\s*["\']([^"\']+)["\']', text)
-    if not match:
-        return None
-    version_match = _PYTHON_VERSION_RE.search(match.group(1))
-    return version_match.group(1) if version_match else None
 
 
 def resolve_python_target(
@@ -39,10 +55,13 @@ def resolve_python_target(
     Precedence (first match wins):
 
     1. Explicit ``override`` (e.g. ``--target-python``) -> source ``"override"``.
-    2. ``pyproject.toml`` ``[project] requires-python`` floor ->
-       source ``"pyproject:requires-python"``.
-    3. ``.python-version`` file -> source ``".python-version"``.
-    4. The running interpreter -> source ``"tool-runtime"`` (always resolves).
+    2. ``.python-version`` file -> source ``".python-version"``.
+    3. The running interpreter -> source ``"tool-runtime"`` (always resolves).
+
+    The ``[project] requires-python`` value in ``pyproject.toml`` is deliberately
+    NOT used as the target: it declares a compatibility *floor*, not the
+    interpreter the app will actually be deployed against, so treating it as the
+    target masks unsupported runtimes.
 
     Args:
         project_path: Root of the project under diagnosis. When ``None`` or when
@@ -56,12 +75,6 @@ def resolve_python_target(
         return override, "override"
 
     if project_path is not None:
-        pyproject = project_path / "pyproject.toml"
-        if pyproject.is_file():
-            version = _requires_python_floor(pyproject)
-            if version is not None:
-                return version, "pyproject:requires-python"
-
         python_version_file = project_path / ".python-version"
         if python_version_file.is_file():
             try:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -78,8 +78,8 @@ def test_compare_python_version_override_fail() -> None:
     assert "Tool runtime:" in result["detail"]
 
 
-def test_compare_python_version_uses_pyproject_target(tmp_path: Path) -> None:
-    """A project's requires-python floor drives the comparison, not the runtime."""
+def test_compare_python_version_ignores_pyproject_target(tmp_path: Path) -> None:
+    """requires-python is a floor, not a target: it must not drive the comparison."""
     (tmp_path / "pyproject.toml").write_text(
         '[project]\nrequires-python = ">=3.11"\n', encoding="utf-8"
     )
@@ -88,14 +88,76 @@ def test_compare_python_version_uses_pyproject_target(tmp_path: Path) -> None:
         "condition": {
             "target": "python",
             "operator": ">=",
-            "value": "3.12",
+            "value": "3.10",
         },
     }
     result = generic_handler(rule, tmp_path)
-    assert result["status"] == "fail"
-    assert "pyproject:requires-python" in result["detail"]
-    assert "Target Python: 3.11" in result["detail"]
+    # Falls back to the tool runtime, never pyproject:requires-python.
+    assert "pyproject:requires-python" not in result["detail"]
+    assert "tool runtime" in result["detail"]
 
+
+def test_compare_python_version_unsupported_target_fails() -> None:
+    """A too-new Python target fails even when the operator condition holds."""
+    rule: Rule = {
+        "type": "compare_version",
+        "condition": {
+            "target": "python",
+            "operator": ">=",
+            "value": "3.10",
+        },
+    }
+    result = generic_handler(rule, Path("."), {"target_python": "3.15"})
+    assert result["status"] == "fail"
+    assert "unsupported target" in result["detail"]
+    assert "3.10\u20133.14" in result["detail"]
+
+
+def test_compare_python_version_too_old_target_fails() -> None:
+    """A too-old Python target fails and reports the supported range."""
+    rule: Rule = {
+        "type": "compare_version",
+        "condition": {
+            "target": "python",
+            "operator": "<=",
+            "value": "3.14",
+        },
+    }
+    result = generic_handler(rule, Path("."), {"target_python": "3.9"})
+    assert result["status"] == "fail"
+    assert "unsupported target" in result["detail"]
+
+
+def test_compare_python_version_supported_target_passes() -> None:
+    """A supported target that satisfies the operator passes."""
+    rule: Rule = {
+        "type": "compare_version",
+        "condition": {
+            "target": "python",
+            "operator": ">=",
+            "value": "3.10",
+        },
+    }
+    result = generic_handler(rule, Path("."), {"target_python": "3.12"})
+    assert result["status"] == "pass"
+    assert "unsupported target" not in result["detail"]
+
+
+def test_compare_python_version_from_python_version_file(tmp_path: Path) -> None:
+    """A supported .python-version target drives the comparison and provenance."""
+    (tmp_path / ".python-version").write_text("3.12\n", encoding="utf-8")
+    rule: Rule = {
+        "type": "compare_version",
+        "condition": {
+            "target": "python",
+            "operator": ">=",
+            "value": "3.10",
+        },
+    }
+    result = generic_handler(rule, tmp_path)
+    assert result["status"] == "pass"
+    assert ".python-version" in result["detail"]
+    assert "unsupported target" not in result["detail"]
 
 def test_compare_func_core_tools_version_pass(monkeypatch: MonkeyPatch) -> None:
     """Test that the func Core Tools version check passes when version meets minimum."""

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -92,12 +92,13 @@ def test_resolve_python_target_override_short_circuits(tmp_path: Path) -> None:
     assert (version, source) == ("3.12", "override")
 
 
-def test_resolve_python_target_from_pyproject_floor(tmp_path: Path) -> None:
+def test_resolve_python_target_ignores_pyproject_requires_python(tmp_path: Path) -> None:
+    """``requires-python`` is a floor, not a target, so it must be ignored."""
     (tmp_path / "pyproject.toml").write_text(
         '[project]\nname = "x"\nrequires-python = ">=3.11,<3.15"\n', encoding="utf-8"
     )
     version, source = target_resolver.resolve_python_target(tmp_path)
-    assert (version, source) == ("3.11", "pyproject:requires-python")
+    assert (version, source) == (sys.version.split()[0], "tool-runtime")
 
 
 def test_resolve_python_target_from_python_version_file(tmp_path: Path) -> None:
@@ -106,13 +107,14 @@ def test_resolve_python_target_from_python_version_file(tmp_path: Path) -> None:
     assert (version, source) == ("3.12.4", ".python-version")
 
 
-def test_resolve_python_target_pyproject_precedes_python_version(tmp_path: Path) -> None:
+def test_resolve_python_target_python_version_precedes_pyproject(tmp_path: Path) -> None:
+    """.python-version wins; pyproject requires-python is never a target."""
     (tmp_path / "pyproject.toml").write_text(
         '[project]\nrequires-python = ">=3.10"\n', encoding="utf-8"
     )
     (tmp_path / ".python-version").write_text("3.13\n", encoding="utf-8")
     version, source = target_resolver.resolve_python_target(tmp_path)
-    assert (version, source) == ("3.10", "pyproject:requires-python")
+    assert (version, source) == ("3.13", ".python-version")
 
 
 def test_resolve_python_target_pyproject_without_requires_python(tmp_path: Path) -> None:
@@ -136,3 +138,26 @@ def test_resolve_python_target_falls_back_to_tool_runtime(tmp_path: Path) -> Non
 def test_resolve_python_target_no_project_path(tmp_path: Path) -> None:
     version, source = target_resolver.resolve_python_target(None)
     assert (version, source) == (sys.version.split()[0], "tool-runtime")
+
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        ("3.10", True),
+        ("3.11", True),
+        ("3.12", True),
+        ("3.13", True),
+        ("3.14", True),
+        ("3.14.7", True),
+        ("3.12.4", True),
+        ("3.9", False),
+        ("3.9.18", False),
+        ("3.15", False),
+        ("3.15.0", False),
+        ("2.7", False),
+        ("not-a-version", False),
+    ],
+)
+def test_is_supported_python_target(version: str, expected: bool) -> None:
+    assert target_resolver.is_supported_python_target(version) is expected


### PR DESCRIPTION
## Summary
- Resolve the Python diagnostic target from an explicit override → `.python-version` → tool runtime, and stop treating `pyproject`'s `requires-python` as the target (it is a compatibility *floor*, not the deployed interpreter).
- Fail `check_python_version` when the resolved target's major.minor falls outside Azure Functions' supported **3.10–3.14** range — catching both too-old (≤3.9) and too-new (≥3.15) targets — with a clear "unsupported target" message listing the supported range.
- Add `SUPPORTED_PYTHON_VERSIONS` + `is_supported_python_target()` to `target_resolver`, and have the CLI validator reuse that canonical tuple instead of duplicating it.
- Refresh the `v2.json` rule copy and the JSON-output-contract doc example, and add unit + handler tests (supported/unsupported/too-old/`.python-version` provenance).

## Verification
- `make lint` ✅
- `make typecheck` ✅
- `hatch run pytest --cov` ✅ — total coverage 96.53% (≥95% gate)

Closes #304