### PR TITLE
fix(dependencies): distinguish remote-build requirements from pyproject metadata

### DIFF
--- a/docs/json_output_contract.md
+++ b/docs/json_output_contract.md
@@ -21,7 +21,8 @@ If `--output` is omitted, JSON is printed to stdout.
     "generated_at": "2026-03-14T10:40:20.731Z",
     "target_path": "/absolute/path/to/project",
     "programming_model": "v2",
-    "target_python": null
+    "target_python": null,
+    "deployment_mode": "remote-build"
   },
   "results": [
     {
@@ -53,6 +54,7 @@ If `--output` is omitted, JSON is printed to stdout.
 | `target_path` | string | Resolved absolute project path used for checks. |
 | `programming_model` | string | Detected Azure Functions programming model (`v2`, `mixed`, `unsupported_v1`, or `unknown`). |
 | `target_python` | string \| null | Target Python version requested via `--target-python`, or `null` when not set. |
+| `deployment_mode` | string | Deployment mode used for dependency checks: `remote-build` (default) or `local`. |
 
 ### `results[]`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,6 +67,7 @@ azure-functions-doctor doctor --target-python 3.12
 | `--profile` | enum | `full` behavior | Rule profile: `minimal` or `full`. |
 | `--rules` | path | unset | Custom rules file path. |
 | `--target-python` | string | unset | Override the Azure Functions target Python runtime: `3.10`, `3.11`, `3.12`, `3.13`, `3.14` (Preview). On the Linux Consumption plan, the maximum supported version is `3.12`. |
+| `--deployment-mode` | enum | `remote-build` | Deployment mode for dependency checks: `remote-build` (Azure installs from `requirements.txt`) or `local` (dependencies prebuilt/vendored locally, e.g. `.python_packages`). |
 
 !!! note
     Supported output formats are currently `table`, `json`, `sarif`, and `junit`.
@@ -115,7 +116,7 @@ azure-functions-doctor doctor --format json --output doctor.json
 
 JSON includes:
 
-- `metadata` (`tool_version`, `generated_at`, `target_path`, `programming_model`, `target_python`)
+- `metadata` (`tool_version`, `generated_at`, `target_path`, `programming_model`, `target_python`, `deployment_mode`)
 - `results` (section + item diagnostics)
 
 Contract details: [JSON Output Contract](json_output_contract.md)

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -90,18 +90,18 @@
     "category": "dependencies",
     "section": "python_env",
     "label": "requirements.txt",
-    "description": "Checks that dependencies are declared via requirements.txt or pyproject.toml.",
+    "description": "Checks that dependencies are declared for the deployment mode: requirements.txt for remote build, or pyproject.toml for a local/prebuilt build.",
     "type": "dependency_manifest",
     "required": true,
     "condition": {
       "target": "requirements.txt"
     },
-    "hint": "Add a requirements.txt file (or declare dependencies in pyproject.toml) to install your packages.",
+    "hint": "Azure remote build installs from requirements.txt, so add one (e.g. 'pip freeze > requirements.txt'). pyproject.toml alone is sufficient only for local/prebuilt deployments (--deployment-mode local).",
     "hint_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#managing-dependencies",
     "source_type": "ms_learn",
     "source_title": "Azure Functions Python developer guide — Managing dependencies",
     "source_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#managing-dependencies",
-    "why_it_matters": "Azure Functions installs from requirements.txt at deployment time. Projects that manage dependencies in pyproject.toml typically generate requirements.txt during packaging, so either manifest satisfies this check.",
+    "why_it_matters": "Azure Functions performs a remote build by default and installs dependencies from requirements.txt; it never reads pyproject.toml. A pyproject-only project passes locally but fails at deploy time unless it uses a local/prebuilt deployment.",
     "symptoms": "ModuleNotFoundError at runtime; deployment pipeline fails with missing package errors; cold start crashes.",
     "fix_command": "pip freeze > requirements.txt",
     "check_order": 4
@@ -111,14 +111,14 @@
     "category": "dependencies",
     "section": "python_env",
     "label": "azure-functions package",
-    "description": "Checks if the azure-functions package is declared in requirements.txt or pyproject.toml.",
+    "description": "Checks that the azure-functions package is installable for the deployment mode (requirements.txt for remote build, pyproject.toml for local/prebuilt).",
     "type": "package_declared",
     "required": true,
     "condition": {
       "package": "azure-functions",
       "file": "requirements.txt"
     },
-    "hint": "Add azure-functions to requirements.txt.",
+    "hint": "Add azure-functions to requirements.txt (Azure remote build installs from it). pyproject.toml alone suffices only for local/prebuilt deployments (--deployment-mode local).",
     "hint_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python",
     "source_type": "ms_learn",
     "source_title": "Azure Functions Python developer guide",

--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -28,6 +28,7 @@ console = Console()
 logger = get_logger(__name__)
 
 SUPPORTED_TARGET_PYTHON_VERSIONS = SUPPORTED_PYTHON_VERSIONS
+SUPPORTED_DEPLOYMENT_MODES = ("remote-build", "local")
 
 
 def _validate_inputs(
@@ -35,6 +36,7 @@ def _validate_inputs(
     format_type: str,
     output: Optional[Path],
     target_python: Optional[str] = None,
+    deployment_mode: Optional[str] = None,
 ) -> None:
     """Validate CLI inputs before processing."""
     try:
@@ -86,6 +88,12 @@ def _validate_inputs(
             f"Invalid target Python: {target_python}. Supported values: {supported}"
         )
 
+    if deployment_mode is not None and deployment_mode not in SUPPORTED_DEPLOYMENT_MODES:
+        supported = ", ".join(SUPPORTED_DEPLOYMENT_MODES)
+        raise typer.BadParameter(
+            f"Invalid deployment mode: {deployment_mode}. Supported values: {supported}"
+        )
+
 
 def _write_output(content: str, output: Optional[Path], label: str) -> None:
     if output:
@@ -133,6 +141,16 @@ def doctor(
     target_python: Annotated[
         Optional[str], typer.Option("--target-python", help="Override target Python runtime")
     ] = None,
+    deployment_mode: Annotated[
+        str,
+        typer.Option(
+            "--deployment-mode",
+            help=(
+                "Deployment mode: 'remote-build' (Azure builds from requirements.txt) "
+                "or 'local' (dependencies prebuilt/vendored locally)."
+            ),
+        ),
+    ] = "remote-build",
 ) -> None:
     """
     Run diagnostics on an Azure Functions application.
@@ -149,7 +167,7 @@ def doctor(
         target_python: Optional target Python runtime override.
     """
     # Validate inputs before proceeding
-    _validate_inputs(path, format, output, target_python)
+    _validate_inputs(path, format, output, target_python, deployment_mode)
 
     if rules is not None and not rules.exists():
         raise typer.BadParameter(f"Rules path does not exist: {rules}")
@@ -162,7 +180,13 @@ def doctor(
         setup_logging(level=None, format_style="simple")
 
     start_time = time.time()
-    doctor = Doctor(path, profile=profile, rules_path=rules, target_python=target_python)
+    doctor = Doctor(
+        path,
+        profile=profile,
+        rules_path=rules,
+        target_python=target_python,
+        deployment_mode=deployment_mode,
+    )
     resolved_path = Path(path).resolve()
     report_properties = doctor.get_report_properties()
 

--- a/src/azure_functions_doctor/doctor.py
+++ b/src/azure_functions_doctor/doctor.py
@@ -57,10 +57,12 @@ class Doctor:
         profile: Optional[str] = None,
         rules_path: Optional[Path] = None,
         target_python: Optional[str] = None,
+        deployment_mode: str = "remote-build",
     ) -> None:
         self.project_path: Path = Path(path).resolve()
         self.profile = profile
         self.target_python: Optional[str] = target_python
+        self.deployment_mode: str = deployment_mode
         self.rules_path: Optional[Path] = None
         if rules_path is not None:
             resolved = rules_path.resolve()
@@ -74,6 +76,7 @@ class Doctor:
         return {
             "programming_model": self.programming_model,
             "target_python": self.target_python,
+            "deployment_mode": self.deployment_mode,
         }
 
     def _detect_programming_model(self) -> ProgrammingModel:
@@ -259,7 +262,10 @@ class Doctor:
             grouped[rule.get("section", "unknown")].append(rule)
 
         results: list[SectionResult] = []
-        context: RuleContext = {"target_python": self.target_python}
+        context: RuleContext = {
+            "target_python": self.target_python,
+            "deployment_mode": self.deployment_mode,
+        }
 
         for section, checks in grouped.items():
             section_result: SectionResult = {

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -66,6 +66,7 @@ class HandlerResult(TypedDict, total=False):
 
 class RuleContext(TypedDict, total=False):
     target_python: Optional[str]
+    deployment_mode: Optional[str]
 
 
 # Platform-aware candidates for executables (for symmetric fallback)
@@ -888,6 +889,19 @@ def pyproject_declares_dependencies(path: Path) -> bool:
     """
     return bool(pyproject_dependency_names(path))
 
+
+def is_local_prebuilt_deployment(path: Path, context: Optional["RuleContext"] = None) -> bool:
+    """Return True when the project targets a local/prebuilt deployment.
+
+    Azure Functions performs a *remote build* by default, installing
+    dependencies from ``requirements.txt`` on the server. A local/prebuilt
+    deployment is assumed when the caller explicitly selects
+    ``deployment_mode='local'`` or when dependencies are vendored into a
+    ``.python_packages`` directory (as produced by a local/prebuilt build).
+    """
+    if context is not None and context.get("deployment_mode") == "local":
+        return True
+    return (path / ".python_packages").is_dir()
 
 def _detect_native_dependency_risks(content: str) -> list[tuple[str, str]]:
     """Return matching native-dependency packages in requirements order."""

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -40,6 +40,7 @@ from azure_functions_doctor.handlers._helpers import (
     _resolve_host_json_pointer,
     _rule_handler,
     _source_contains_ast,
+    is_local_prebuilt_deployment,
     logger,
     parse_compare_version,
     parse_package,
@@ -219,13 +220,13 @@ class HandlerRegistry:
     def _handle_dependency_manifest(
         self, rule: Rule, path: Path, context: Optional[RuleContext] = None
     ) -> HandlerResult:
-        """Pass when the project declares dependencies via requirements.txt OR
-        pyproject.toml.
+        """Validate the dependency manifest against the deployment mode.
 
-        Azure Functions installs from requirements.txt at deploy time, but many
-        modern projects manage dependencies in ``pyproject.toml`` and generate
-        requirements.txt during packaging. Accept either manifest so
-        pyproject-only projects are not reported as broken.
+        Azure Functions performs a *remote build* by default, installing
+        dependencies from ``requirements.txt`` on the server. A pyproject-only
+        project therefore passes only for a local/prebuilt deployment; under
+        remote build a missing ``requirements.txt`` is flagged because the
+        server never reads ``pyproject.toml``.
         """
         condition = rule.get("condition", {}) or {}
         target = parse_target(condition) or "requirements.txt"
@@ -233,10 +234,21 @@ class HandlerRegistry:
         if req_path.is_file():
             return _create_result("pass", f"{req_path} exists")
         if pyproject_declares_dependencies(path):
-            return _create_result(
-                "pass",
-                f"{req_path} not found; dependencies declared in pyproject.toml",
+            if is_local_prebuilt_deployment(path, context):
+                return _create_result(
+                    "pass",
+                    f"{req_path} not found; dependencies declared in pyproject.toml "
+                    "(local/prebuilt deployment)",
+                )
+            detail = (
+                f"{req_path} not found; dependencies are only declared in "
+                "pyproject.toml. Azure remote build installs from requirements.txt, "
+                "so generate one (e.g. 'pip freeze > requirements.txt') or deploy "
+                "with a local/prebuilt build (--deployment-mode local)."
             )
+            if not rule.get("required", True):
+                detail += " (optional)"
+            return _create_result("fail", detail)
         detail = f"{req_path} not found and pyproject.toml declares no dependencies"
         if not rule.get("required", True):
             detail += " (optional)"
@@ -310,12 +322,21 @@ class HandlerRegistry:
         normalized_target = canonicalize_name(package_name)
         req_path = path / Path(req_file)
         if not req_path.exists():
-            # No requirements.txt: fall back to pyproject.toml so pyproject-only
-            # projects can still declare the package.
+            # No requirements.txt: fall back to pyproject.toml. This is valid
+            # only for a local/prebuilt deployment; remote build reads
+            # requirements.txt, never pyproject.toml.
             if normalized_target in pyproject_dependency_names(path):
+                if is_local_prebuilt_deployment(path, context):
+                    return _create_result(
+                        "pass",
+                        f"Package '{package_name}' declared in pyproject.toml "
+                        "(local/prebuilt deployment)",
+                    )
                 return _create_result(
-                    "pass",
-                    f"Package '{package_name}' declared in pyproject.toml",
+                    "fail",
+                    f"Package '{package_name}' is only declared in pyproject.toml; "
+                    "Azure remote build installs from requirements.txt. Add it there "
+                    "or deploy with a local/prebuilt build (--deployment-mode local).",
                 )
             return _create_result(
                 "fail",
@@ -328,9 +349,17 @@ class HandlerRegistry:
         normalized = _parse_requirements_names(content)
         declared = normalized_target in normalized
         if not declared and normalized_target in pyproject_dependency_names(path):
+            if is_local_prebuilt_deployment(path, context):
+                return _create_result(
+                    "pass",
+                    f"Package '{package_name}' declared in pyproject.toml "
+                    "(local/prebuilt deployment)",
+                )
             return _create_result(
-                "pass",
-                f"Package '{package_name}' declared in pyproject.toml",
+                "fail",
+                f"Package '{package_name}' is only declared in pyproject.toml; "
+                "Azure remote build installs from requirements.txt. Add it there "
+                "or deploy with a local/prebuilt build (--deployment-mode local).",
             )
         return _create_result(
             "pass" if declared else "fail",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -197,6 +197,32 @@ def test_cli_target_python_invalid_value() -> None:
         assert version in result.output
 
 
+def test_cli_invalid_deployment_mode() -> None:
+    """Unsupported deployment modes fail with the supported values listed."""
+    result = runner.invoke(app, ["doctor", "--deployment-mode", "bogus"])
+    assert result.exit_code != 0
+    assert "Invalid deployment mode: bogus" in result.output
+    assert "remote-build" in result.output
+    assert "local" in result.output
+
+
+def test_cli_deployment_mode_local_end_to_end() -> None:
+    """A local deployment mode is accepted and recorded in JSON metadata."""
+    result = runner.invoke(
+        app,
+        [
+            "doctor",
+            "--path",
+            V2_FIXTURE_PATH,
+            "--format",
+            "json",
+            "--deployment-mode",
+            "local",
+        ],
+    )
+    data = json.loads(result.output)
+    assert data["metadata"]["deployment_mode"] == "local"
+
 def test_cli_json_output_includes_target_python_override() -> None:
     """Test JSON metadata includes target_python override."""
     result = runner.invoke(
@@ -234,6 +260,7 @@ def test_cli_sarif_output_includes_target_python_override() -> None:
     assert data["runs"][0]["properties"] == {
         "programming_model": "v2",
         "target_python": "3.11",
+        "deployment_mode": "remote-build",
     }
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -120,6 +120,7 @@ def test_get_report_properties_includes_target_python(tmp_path: Path) -> None:
     assert doctor.get_report_properties() == {
         "programming_model": "v2",
         "target_python": "3.12",
+        "deployment_mode": "remote-build",
     }
 
 

--- a/tests/test_pyproject_dependency_manifest.py
+++ b/tests/test_pyproject_dependency_manifest.py
@@ -23,12 +23,17 @@ def _write(path: Path, name: str, content: str) -> None:
     (path / name).write_text(content, encoding="utf-8")
 
 
-def _status(rule_type: str, path: Path, condition: dict[str, Any] | None = None) -> str:
+def _status(
+    rule_type: str,
+    path: Path,
+    condition: dict[str, Any] | None = None,
+    context: dict[str, Any] | None = None,
+) -> str:
     rule = cast(
         Rule,
         {"type": rule_type, "required": True, "condition": condition or {}},
     )
-    return registry.handle(rule, path)["status"]
+    return registry.handle(rule, path, cast(Any, context))["status"]
 
 
 _PYPROJECT_WITH_DEPS = """\
@@ -105,8 +110,29 @@ def test_dependency_manifest_pass_with_requirements(tmp_path: Path) -> None:
     assert _status("dependency_manifest", tmp_path) == "pass"
 
 
-def test_dependency_manifest_pass_with_pyproject_only(tmp_path: Path) -> None:
+def test_dependency_manifest_fail_pyproject_only_remote_build(tmp_path: Path) -> None:
+    """Under the default remote build, pyproject-only is flagged (no requirements.txt)."""
     _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
+    assert _status("dependency_manifest", tmp_path) == "fail"
+
+
+def test_dependency_manifest_pass_pyproject_only_local_mode(tmp_path: Path) -> None:
+    """A declared local/prebuilt deployment accepts pyproject-only."""
+    _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
+    assert (
+        _status(
+            "dependency_manifest",
+            tmp_path,
+            context={"deployment_mode": "local"},
+        )
+        == "pass"
+    )
+
+
+def test_dependency_manifest_pass_pyproject_only_vendored_packages(tmp_path: Path) -> None:
+    """Vendored .python_packages implies a prebuilt deployment."""
+    _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
+    (tmp_path / ".python_packages").mkdir()
     assert _status("dependency_manifest", tmp_path) == "pass"
 
 
@@ -141,17 +167,46 @@ def test_package_declared_requirements_still_wins(tmp_path: Path) -> None:
     assert _status("package_declared", tmp_path, _PKG_CONDITION) == "pass"
 
 
-def test_package_declared_pyproject_fallback_no_requirements(tmp_path: Path) -> None:
+def test_package_declared_pyproject_only_fail_remote_build(tmp_path: Path) -> None:
     _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
-    assert _status("package_declared", tmp_path, _PKG_CONDITION) == "pass"
+    assert _status("package_declared", tmp_path, _PKG_CONDITION) == "fail"
 
 
-def test_package_declared_pyproject_fallback_when_requirements_lacks_it(
+def test_package_declared_pyproject_only_pass_local_mode(tmp_path: Path) -> None:
+    _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
+    assert (
+        _status(
+            "package_declared",
+            tmp_path,
+            _PKG_CONDITION,
+            context={"deployment_mode": "local"},
+        )
+        == "pass"
+    )
+
+
+def test_package_declared_requirements_lacks_it_fail_remote_build(
     tmp_path: Path,
 ) -> None:
     _write(tmp_path, "requirements.txt", "rich\n")
     _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
-    assert _status("package_declared", tmp_path, _PKG_CONDITION) == "pass"
+    assert _status("package_declared", tmp_path, _PKG_CONDITION) == "fail"
+
+
+def test_package_declared_requirements_lacks_it_pass_local_mode(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path, "requirements.txt", "rich\n")
+    _write(tmp_path, "pyproject.toml", _PYPROJECT_WITH_DEPS)
+    assert (
+        _status(
+            "package_declared",
+            tmp_path,
+            _PKG_CONDITION,
+            context={"deployment_mode": "local"},
+        )
+        == "pass"
+    )
 
 
 def test_package_declared_fail_when_missing_everywhere(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Azure Functions performs a **remote build** by default, installing dependencies from `requirements.txt` and never reading `pyproject.toml`. `check_requirements_txt` (`dependency_manifest`) and `check_azure_functions_library` (`package_declared`) previously passed for pyproject-only projects, masking deploy-time failures.
- Introduce a `deployment_mode` (`remote-build` default, or `local`) threaded through the CLI (`--deployment-mode`), `Doctor`, report metadata, and `RuleContext`. A vendored `.python_packages/` directory is also treated as an implicit local/prebuilt signal.
- Both checks now pass for pyproject-only projects **only** under a local/prebuilt deployment; under remote build a missing (or incomplete) `requirements.txt` is flagged with guidance to generate one or switch to `--deployment-mode local`.
- Updated rule copy (`v2.json`), the JSON-output-contract + usage docs, and tests covering: requirements.txt present (pass), pyproject-only + remote build (flag), pyproject-only + local/vendored (pass), and CLI validation of the new flag.

## Verification
- `make lint` ✅
- `make typecheck` ✅
- `hatch run pytest --cov` ✅ — total coverage 96.57% (≥95% gate)

Closes #305