### PR TITLE
fix(telemetry): require Application Insights connection string

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -120,7 +120,7 @@ These checks run only after the repository has been classified as a supported `v
 | Azure Functions Core Tools | `check_func_cli` | `executable_exists` | `func` executable is not available on `PATH`. |
 | Core Tools version | `check_func_core_tools_version` | `compare_version` | Detected Core Tools version is lower than `4.0`. |
 | Durable Functions configuration | `check_durabletask_config` | `conditional_exists` | Durable usage detected but `$.extensions.durableTask` is missing. |
-| Application Insights configuration | `check_app_insights` | `any_of_exists` | No telemetry signal found in env vars or `host.json`. |
+| Application Insights configuration | `check_app_insights` | `app_insights_connection` | No connection string set, or only a legacy instrumentation key is configured. |
 | `extensionBundle` | `check_extension_bundle` | `host_json_property` | `$.extensionBundle` key is not present in `host.json`. |
 | ASGI/WSGI compatibility | `check_asgi_wsgi_exposure` | `callable_detection` | No ASGI/WSGI app exposure patterns are detected. |
 | Unwanted files | `check_unused_files` | `file_glob_check` | Common deploy-time junk patterns are found. |

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -107,6 +107,7 @@ The authoritative dispatch map is `_RULE_DISPATCH` in
 | `callable_detection` | none | Detect ASGI/WSGI callable exposure patterns. |
 | `executable_exists` | `target` | Ensure local binaries exist on `PATH`. |
 | `any_of_exists` | `targets` | Pass when any env/file/host signal is present. |
+| `app_insights_connection` | none | Require an Application Insights connection string; flag legacy instrumentation keys. |
 | `file_glob_check` | `patterns` | Detect junk files and deployment artifacts. |
 | `host_json_property` | `jsonpath` | Validate specific host.json properties. |
 | `host_json_version` | none | Validate `host.json` declares `"version": "2.0"`. |

--- a/docs/rule_inventory.md
+++ b/docs/rule_inventory.md
@@ -24,7 +24,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `check_func_cli` | Azure Functions Core Tools (func) | tooling | tooling | `executable_exists` | No | full |
 | `check_func_core_tools_version` | Azure Functions Core Tools version | tooling | tooling | `compare_version` | No | full |
 | `check_durabletask_config` | Durable Functions configuration | configuration | durable | `conditional_exists` | No | full |
-| `check_app_insights` | Application Insights configuration | telemetry | monitoring | `any_of_exists` | No | full |
+| `check_app_insights` | Application Insights configuration | telemetry | monitoring | `app_insights_connection` | No | full |
 | `check_extension_bundle` | extensionBundle | configuration | extensions | `host_json_property` | No | full |
 | `check_asgi_wsgi_exposure` | ASGI/WSGI compatibility | framework | asgi_wsgi | `callable_detection` | No | full |
 | `check_unused_files` | Detect unused or invalid files | project_health | cleanup | `file_glob_check` | No | full |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -250,17 +250,20 @@ Required host.json property '$.extensions.durableTask' not found
 
 ## 14) `check_app_insights`
 
-- **What it checks:** At least one telemetry signal exists:
-  - `APPLICATIONINSIGHTS_CONNECTION_STRING`
-  - `APPINSIGHTS_INSTRUMENTATIONKEY`
-  - `host.json:instrumentationKey`
-- **Why it matters:** Telemetry is critical for production diagnostics.
-- **How to fix:** Configure one supported telemetry source.
+- **What it checks:** Application Insights uses a **connection string**
+  (`APPLICATIONINSIGHTS_CONNECTION_STRING`). A legacy instrumentation key
+  (`APPINSIGHTS_INSTRUMENTATIONKEY` or `host.json:instrumentationKey`) is
+  treated as stale, and `APPLICATIONINSIGHTS_AUTHENTICATION_STRING` is
+  recognised for Entra (AAD) authentication.
+- **Why it matters:** Instrumentation-key ingestion ended 2025-03-31, so a
+  connection string is required for telemetry to reach Application Insights.
+- **How to fix:** Set `APPLICATIONINSIGHTS_CONNECTION_STRING` and remove any
+  legacy instrumentation key.
 
 Example warning detail:
 
 ```text
-Targets not found
+Application Insights is not configured; set APPLICATIONINSIGHTS_CONNECTION_STRING to enable telemetry. (optional)
 ```
 
 ## 15) `check_extension_bundle`

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -264,18 +264,12 @@
     "category": "telemetry",
     "section": "monitoring",
     "label": "Application Insights configuration",
-    "description": "Checks for Application Insights connection settings via environment variables or host.json.",
-    "type": "any_of_exists",
+    "description": "Checks that Application Insights uses a connection string (instrumentation-key ingestion ended 2025-03-31).",
+    "type": "app_insights_connection",
     "required": false,
-    "condition": {
-      "targets": [
-        "APPLICATIONINSIGHTS_CONNECTION_STRING",
-        "APPINSIGHTS_INSTRUMENTATIONKEY",
-        "host.json:instrumentationKey"
-      ]
-    },
-    "hint": "Configure Application Insights to get telemetry and diagnostics in production.",
-    "hint_url": "https://learn.microsoft.com/azure/azure-monitor/app/azure-functions",
+    "condition": {},
+    "hint": "Set APPLICATIONINSIGHTS_CONNECTION_STRING (instrumentation keys are retired). Optionally set APPLICATIONINSIGHTS_AUTHENTICATION_STRING for Entra (AAD) auth.",
+    "hint_url": "https://learn.microsoft.com/azure/azure-monitor/app/migrate-from-instrumentation-keys-to-connection-strings",
     "check_order": 24
   },
   {

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -565,6 +565,76 @@ class HandlerRegistry:
         return _create_result("fail", "Targets not found")
 
     @_rule_handler
+    def _handle_app_insights_connection(
+        self, rule: Rule, path: Path, context: Optional[RuleContext] = None
+    ) -> HandlerResult:
+        """Validate Application Insights connection configuration.
+
+        Instrumentation-key ingestion ended 2025-03-31, so a connection string
+        (``APPLICATIONINSIGHTS_CONNECTION_STRING``) is now required. A legacy
+        instrumentation key (``APPINSIGHTS_INSTRUMENTATIONKEY`` or
+        ``host.json:instrumentationKey``) is treated as stale, and
+        ``APPLICATIONINSIGHTS_AUTHENTICATION_STRING`` is recognised for Entra
+        (AAD) authentication.
+        """
+        conn = (os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING") or "").strip()
+        auth = (os.getenv("APPLICATIONINSIGHTS_AUTHENTICATION_STRING") or "").strip()
+        ik_env = (os.getenv("APPINSIGHTS_INSTRUMENTATIONKEY") or "").strip()
+
+        ik_host = False
+        host_path = path / "host.json"
+        if host_path.exists():
+            try:
+                data = json.loads(host_path.read_text(encoding="utf-8"))
+                node = _resolve_host_json_pointer(data, ["instrumentationKey"])
+                ik_host = node is not _HOST_JSON_MISSING and node is not None
+            except json.JSONDecodeError as exc:
+                logger.debug(f"Skip invalid host.json while checking App Insights: {exc}")
+
+        has_ik = bool(ik_env) or ik_host
+        auth_note = (
+            " Entra auth via APPLICATIONINSIGHTS_AUTHENTICATION_STRING is configured."
+            if auth
+            else ""
+        )
+
+        if conn:
+            if has_ik:
+                return _create_result(
+                    "fail",
+                    "Connection string is set, but a legacy instrumentation key is "
+                    "also configured; remove it (instrumentation-key ingestion ended "
+                    "2025-03-31)." + auth_note,
+                )
+            return _create_result(
+                "pass",
+                "Application Insights connection string configured." + auth_note,
+            )
+
+        if has_ik:
+            return _create_result(
+                "fail",
+                "Only a legacy Application Insights instrumentation key is configured; "
+                "instrumentation-key ingestion ended 2025-03-31. Set "
+                "APPLICATIONINSIGHTS_CONNECTION_STRING instead." + auth_note,
+            )
+
+        if auth:
+            return _create_result(
+                "fail",
+                "Application Insights Entra authentication "
+                "(APPLICATIONINSIGHTS_AUTHENTICATION_STRING) is configured, but "
+                "APPLICATIONINSIGHTS_CONNECTION_STRING is missing; set the connection "
+                "string to enable telemetry.",
+            )
+
+        return _create_result(
+            "fail",
+            "Application Insights is not configured; set "
+            "APPLICATIONINSIGHTS_CONNECTION_STRING to enable telemetry.",
+        )
+
+    @_rule_handler
     def _handle_file_glob_check(
         self, rule: Rule, path: Path, context: Optional[RuleContext] = None
     ) -> HandlerResult:

--- a/src/azure_functions_doctor/schemas/rules.schema.json
+++ b/src/azure_functions_doctor/schemas/rules.schema.json
@@ -75,7 +75,8 @@
           "langgraph_anonymous_auth",
           "durable_nondeterminism",
           "unsupported_metadata_version",
-          "otel_activation"
+          "otel_activation",
+          "app_insights_connection"
         ]
       },
       "required": {

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -479,6 +479,106 @@ def test_any_of_exists_env_and_file(tmp_path: Path, monkeypatch: MonkeyPatch) ->
     assert res3["status"] == "fail"
 
 
+_APP_INSIGHTS_ENV = (
+    "APPLICATIONINSIGHTS_CONNECTION_STRING",
+    "APPLICATIONINSIGHTS_AUTHENTICATION_STRING",
+    "APPINSIGHTS_INSTRUMENTATIONKEY",
+)
+
+
+def _clear_app_insights_env(monkeypatch: MonkeyPatch) -> None:
+    for name in _APP_INSIGHTS_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_app_insights_connection_string_passes(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    _clear_app_insights_env(monkeypatch)
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=abc")
+    rule = _make_rule("app_insights_connection", {})
+    res = generic_handler(rule, tmp_path)
+    assert res["status"] == "pass"
+    assert "connection string configured" in res["detail"]
+
+
+def test_app_insights_connection_string_with_auth(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    _clear_app_insights_env(monkeypatch)
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=abc")
+    monkeypatch.setenv("APPLICATIONINSIGHTS_AUTHENTICATION_STRING", "Authorization=AAD")
+    rule = _make_rule("app_insights_connection", {})
+    res = generic_handler(rule, tmp_path)
+    assert res["status"] == "pass"
+    assert "Entra auth" in res["detail"]
+
+
+def test_app_insights_conn_and_legacy_key_fails(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    _clear_app_insights_env(monkeypatch)
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "InstrumentationKey=abc")
+    monkeypatch.setenv("APPINSIGHTS_INSTRUMENTATIONKEY", "legacy-key")
+    rule = _make_rule("app_insights_connection", {})
+    res = generic_handler(rule, tmp_path)
+    assert res["status"] == "fail"
+    assert "legacy instrumentation key" in res["detail"]
+
+
+def test_app_insights_legacy_key_only_fails(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    _clear_app_insights_env(monkeypatch)
+    monkeypatch.setenv("APPINSIGHTS_INSTRUMENTATIONKEY", "legacy-key")
+    rule = _make_rule("app_insights_connection", {})
+    res = generic_handler(rule, tmp_path)
+    assert res["status"] == "fail"
+    assert "ingestion ended" in res["detail"]
+
+
+def test_app_insights_host_json_key_only_fails(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    _clear_app_insights_env(monkeypatch)
+    (tmp_path / "host.json").write_text(json.dumps({"instrumentationKey": "host-key"}))
+    rule = _make_rule("app_insights_connection", {})
+    res = generic_handler(rule, tmp_path)
+    assert res["status"] == "fail"
+    assert "instrumentation key" in res["detail"]
+
+
+def test_app_insights_not_configured_fails(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    _clear_app_insights_env(monkeypatch)
+    rule = _make_rule("app_insights_connection", {})
+    res = generic_handler(rule, tmp_path)
+    assert res["status"] == "fail"
+    assert "not configured" in res["detail"]
+
+
+def test_app_insights_empty_conn_string_treated_as_unconfigured(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """An empty/whitespace connection string must not count as configured."""
+    _clear_app_insights_env(monkeypatch)
+    monkeypatch.setenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "   ")
+    rule = _make_rule("app_insights_connection", {})
+    res = generic_handler(rule, tmp_path)
+    assert res["status"] == "fail"
+    assert "not configured" in res["detail"]
+
+
+def test_app_insights_auth_without_conn_string_fails(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Entra auth set but no connection string is a dedicated misconfiguration."""
+    _clear_app_insights_env(monkeypatch)
+    monkeypatch.setenv("APPLICATIONINSIGHTS_AUTHENTICATION_STRING", "Authorization=AAD")
+    rule = _make_rule("app_insights_connection", {})
+    res = generic_handler(rule, tmp_path)
+    assert res["status"] == "fail"
+    assert "APPLICATIONINSIGHTS_CONNECTION_STRING is missing" in res["detail"]
+
+
+def test_app_insights_invalid_host_json_ignored(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    _clear_app_insights_env(monkeypatch)
+    (tmp_path / "host.json").write_text("{ not valid json")
+    rule = _make_rule("app_insights_connection", {})
+    res = generic_handler(rule, tmp_path)
+    assert res["status"] == "fail"
+    assert "not configured" in res["detail"]
+
+
 def test_file_glob_check(tmp_path: Path) -> None:
     # create an unwanted file matching pattern
     bad = tmp_path / "secret.txt"


### PR DESCRIPTION
## Context
Part of the Azure Functions 2026 audit (umbrella #312). Closes #306.

The `check_app_insights` rule previously passed on *any* telemetry signal, including a legacy instrumentation key. Instrumentation-key ingestion ended **2025-03-31**, so a connection string is now required.

## Changes
- New `app_insights_connection` handler in `registry.py`:
  - connection string set, no legacy key → **pass**
  - connection string + legacy key → **warn** (remove the stale key)
  - legacy key only (`APPINSIGHTS_INSTRUMENTATIONKEY` or `host.json:instrumentationKey`) → **warn**
  - nothing configured → **warn**
  - recognises `APPLICATIONINSIGHTS_AUTHENTICATION_STRING` (Entra/AAD auth)
- Retyped `check_app_insights` in `v2.json`; added type to `rules.schema.json`.
- Added 7 handler tests; docs synced (`rules.md`, `rule_inventory.md`, `handlers.md`, `diagnostics.md`).

## Validation
- `make lint` ✅  `make typecheck` ✅
- Full suite ✅ — coverage 96.57% (≥95% gate)