### PR TITLE
fix(framework): suppress ASGI/WSGI warning for plain FunctionApp projects

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -122,7 +122,7 @@ These checks run only after the repository has been classified as a supported `v
 | Durable Functions configuration | `check_durabletask_config` | `conditional_exists` | Durable usage detected but `$.extensions.durableTask` is missing. |
 | Application Insights configuration | `check_app_insights` | `app_insights_connection` | No connection string set, or only a legacy instrumentation key is configured. |
 | `extensionBundle` | `check_extension_bundle` | `host_json_property` | `$.extensionBundle` key is not present in `host.json`. |
-| ASGI/WSGI compatibility | `check_asgi_wsgi_exposure` | `callable_detection` | No ASGI/WSGI app exposure patterns are detected. |
+| ASGI/WSGI compatibility | `check_asgi_wsgi_exposure` | `callable_detection` | Framework detected but no callable exposed (skips when no framework is present). |
 | Unwanted files | `check_unused_files` | `file_glob_check` | Common deploy-time junk patterns are found. |
 | Decorator order | `check_decorator_order` | `decorator_order` | A handler stacks `@validate_http` outside (above) `@with_context`, so validation/OpenAPI metadata is discarded. |
 | Endpoint metadata coverage | `check_endpoint_metadata` | `endpoint_metadata` | The project depends on `azure-functions-validation` but an HTTP route handler lacks `@validate_http`, so it emits no endpoint OpenAPI metadata. |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -280,14 +280,18 @@ host.json property '$.extensionBundle' not found
 
 ## 16) `check_asgi_wsgi_exposure`
 
-- **What it checks:** Source has ASGI/WSGI exposure patterns.
-- **Why it matters:** Useful signal for framework-host integration readiness.
-- **How to fix:** Ensure framework callable exposure follows expected patterns.
+- **What it checks:** Whether an ASGI/WSGI framework (FastAPI/Flask/Starlette/Quart)
+  is wired into Azure Functions via `AsgiFunctionApp`/`WsgiFunctionApp` (or
+  `AsgiMiddleware`/`WsgiMiddleware`).
+- **Why it matters:** A plain decorator-based `FunctionApp` has no ASGI/WSGI app,
+  so the check **skips** to avoid noise. A detected framework that is not exposed
+  is a real wiring gap.
+- **How to fix:** Expose the framework callable with `AsgiFunctionApp`/`WsgiFunctionApp`.
 
 Example warning detail:
 
 ```text
-No ASGI/WSGI callable detected in project source
+ASGI/WSGI framework detected but no callable is exposed via AsgiFunctionApp/WsgiFunctionApp
 ```
 
 ## 17) `check_unused_files`

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -291,7 +291,7 @@ host.json property '$.extensionBundle' not found
 Example warning detail:
 
 ```text
-ASGI/WSGI framework detected but no callable is exposed via AsgiFunctionApp/WsgiFunctionApp
+ASGI/WSGI framework detected but no callable is exposed via AsgiFunctionApp/WsgiFunctionApp (or AsgiMiddleware/WsgiMiddleware); wire it into Azure Functions: ['main.py:\bFastAPI\s*\('] (optional)
 ```
 
 ## 17) `check_unused_files`

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -491,7 +491,9 @@ class HandlerRegistry:
         A plain decorator-based ``FunctionApp`` project has no ASGI/WSGI app and
         should not be warned, so the check **skips** when there is no framework
         signal at all. When a framework is present but its callable is not wired
-        into Azure Functions it warns; a correctly exposed callable passes.
+        into Azure Functions it returns ``fail`` (surfaced as a warning by the
+        doctor only because this rule is optional); a correctly exposed callable
+        passes.
         """
         # Azure Functions wiring that actually exposes an ASGI/WSGI callable.
         exposure_patterns = [

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -486,31 +486,63 @@ class HandlerRegistry:
     def _handle_callable_detection(
         self, rule: Rule, path: Path, context: Optional[RuleContext] = None
     ) -> HandlerResult:
-        """Detect ASGI/WSGI callable exposure in source files (basic heuristics)."""
-        patterns = [
-            r"\bAsgiMiddleware\s*\(|\bWsgiMiddleware\s*\(",
-            r"\bAsgiFunctionApp\s*\(|\bWsgiFunctionApp\s*\(",
+        """Detect ASGI/WSGI callable exposure in source files (basic heuristics).
+
+        A plain decorator-based ``FunctionApp`` project has no ASGI/WSGI app and
+        should not be warned, so the check **skips** when there is no framework
+        signal at all. When a framework is present but its callable is not wired
+        into Azure Functions it warns; a correctly exposed callable passes.
+        """
+        # Azure Functions wiring that actually exposes an ASGI/WSGI callable.
+        exposure_patterns = [
+            r"\bAsgiFunctionApp\s*\(",
+            r"\bWsgiFunctionApp\s*\(",
+            r"\bAsgiMiddleware\s*\(",
+            r"\bWsgiMiddleware\s*\(",
+        ]
+        # Presence of an ASGI/WSGI framework (import or instantiation).
+        framework_patterns = [
             r"\bFastAPI\s*\(|\bStarlette\s*\(|\bFlask\s*\(|\bQuart\s*\(",
+            r"\b(?:import|from)\s+(?:fastapi|starlette|flask|quart)\b",
             r"ASGIApp|WSGIApp|asgi_app|wsgi_app",
         ]
 
-        found_items: List[str] = []
+        exposure_hits: List[str] = []
+        framework_hits: List[str] = []
         try:
             for py_file in path.rglob("*.py"):
                 content = _read_project_python_file(py_file)
                 if content is None:
                     continue
-                for pat in patterns:
+                rel = py_file.relative_to(path)
+                for pat in exposure_patterns:
                     if re.search(pat, content):
-                        found_items.append(f"{py_file.relative_to(path)}:{pat}")
+                        exposure_hits.append(f"{rel}:{pat}")
+                        break
+                for pat in framework_patterns:
+                    if re.search(pat, content):
+                        framework_hits.append(f"{rel}:{pat}")
                         break
         except Exception as exc:
             return _handle_specific_exceptions("scanning for ASGI/WSGI callables", exc)
 
-        if found_items:
-            return _create_result("pass", f"Detected ASGI/WSGI-related patterns: {found_items[:3]}")
+        if exposure_hits:
+            return _create_result(
+                "pass", f"Detected ASGI/WSGI callable exposure: {exposure_hits[:3]}"
+            )
 
-        return _create_result("fail", "No ASGI/WSGI callable detected in project source")
+        if framework_hits:
+            return _create_result(
+                "fail",
+                "ASGI/WSGI framework detected but no callable is exposed via "
+                "AsgiFunctionApp/WsgiFunctionApp (or AsgiMiddleware/WsgiMiddleware); "
+                f"wire it into Azure Functions: {framework_hits[:3]}",
+            )
+
+        return _create_result(
+            "skip",
+            "No ASGI/WSGI framework detected; plain FunctionApp project.",
+        )
 
     # --- adapters / additional handlers ---
 

--- a/tests/test_bugfix_issues.py
+++ b/tests/test_bugfix_issues.py
@@ -137,7 +137,7 @@ def test_callable_detection_asgi_function_app_passes(tmp_path: Path) -> None:
     assert result["status"] == "pass"
 
 
-def test_callable_detection_fastapi_passes(tmp_path: Path) -> None:
+def test_callable_detection_fastapi_unexposed_fails(tmp_path: Path) -> None:
     """#307: FastAPI present but no exposure => warn (fail)."""
     (tmp_path / "main.py").write_text(
         "from fastapi import FastAPI\napp = FastAPI()\n",
@@ -150,7 +150,7 @@ def test_callable_detection_fastapi_passes(tmp_path: Path) -> None:
     assert result["status"] == "fail"
 
 
-def test_callable_detection_flask_passes(tmp_path: Path) -> None:
+def test_callable_detection_flask_unexposed_fails(tmp_path: Path) -> None:
     """#307: Flask present but no exposure => warn (fail)."""
     (tmp_path / "main.py").write_text(
         "from flask import Flask\napp = Flask(__name__)\n",

--- a/tests/test_bugfix_issues.py
+++ b/tests/test_bugfix_issues.py
@@ -104,7 +104,7 @@ def test_callable_detection_no_false_positive_for_functionapp_only() -> None:
 
         result = generic_handler(rule, tmp_path)
 
-        assert result["status"] == "fail"
+        assert result["status"] == "skip"
 
 
 def test_callable_detection_asgi_middleware_passes(tmp_path: Path) -> None:
@@ -138,7 +138,7 @@ def test_callable_detection_asgi_function_app_passes(tmp_path: Path) -> None:
 
 
 def test_callable_detection_fastapi_passes(tmp_path: Path) -> None:
-    """Issue #97: FastAPI usage triggers callable detection pass."""
+    """#307: FastAPI present but no exposure => warn (fail)."""
     (tmp_path / "main.py").write_text(
         "from fastapi import FastAPI\napp = FastAPI()\n",
         encoding="utf-8",
@@ -147,11 +147,11 @@ def test_callable_detection_fastapi_passes(tmp_path: Path) -> None:
 
     result = generic_handler(rule, tmp_path)
 
-    assert result["status"] == "pass"
+    assert result["status"] == "fail"
 
 
 def test_callable_detection_flask_passes(tmp_path: Path) -> None:
-    """Issue #97: Flask usage triggers callable detection pass."""
+    """#307: Flask present but no exposure => warn (fail)."""
     (tmp_path / "main.py").write_text(
         "from flask import Flask\napp = Flask(__name__)\n",
         encoding="utf-8",
@@ -160,7 +160,7 @@ def test_callable_detection_flask_passes(tmp_path: Path) -> None:
 
     result = generic_handler(rule, tmp_path)
 
-    assert result["status"] == "pass"
+    assert result["status"] == "fail"
 
 
 def test_setup_logging_reinvocation_updates_log_level() -> None:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -429,7 +429,7 @@ def test_conditional_exists_durable_present_pass() -> None:
         assert result["status"] == "pass"
 
 
-def test_callable_detection_pass_and_fail() -> None:
+def test_callable_detection_skip_fail_pass() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         # No ASGI/WSGI framework => skip (plain FunctionApp)
         rule: Rule = {"type": "callable_detection"}

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -431,16 +431,26 @@ def test_conditional_exists_durable_present_pass() -> None:
 
 def test_callable_detection_pass_and_fail() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
-        # No ASGI/WSGI files => fail
+        # No ASGI/WSGI framework => skip (plain FunctionApp)
         rule: Rule = {"type": "callable_detection"}
         result = generic_handler(rule, Path(tmpdir))
-        assert result["status"] == "fail"
+        assert result["status"] == "skip"
 
-        # Add a FastAPI example => pass
+        # FastAPI present but no exposure => warn (fail)
         file_path = Path(tmpdir) / "app.py"
         file_path.write_text("from fastapi import FastAPI\napp = FastAPI()")
         result2 = generic_handler(rule, Path(tmpdir))
-        assert result2["status"] == "pass"
+        assert result2["status"] == "fail"
+
+        # Exposed via AsgiFunctionApp => pass
+        file_path.write_text(
+            "import azure.functions as func\n"
+            "from fastapi import FastAPI\n"
+            "fastapi_app = FastAPI()\n"
+            "app = func.AsgiFunctionApp(app=fastapi_app)\n"
+        )
+        result3 = generic_handler(rule, Path(tmpdir))
+        assert result3["status"] == "pass"
 
 
 def _make_rule(rule_type: str, condition: Condition) -> Rule:

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -2305,8 +2305,8 @@ def test_local_settings_json_exists() -> None:
         assert result["status"] in ("pass", "fail")  # pass if not git-tracked or git unavailable
 
 
-def test_executable_detection() -> None:
-    """Test _handle_callable_detection doesn't find executable pattern."""
+def test_callable_detection_skip_without_framework() -> None:
+    """callable_detection returns skip when no framework signal is present."""
     registry = HandlerRegistry()
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -1365,12 +1365,10 @@ def test_callable_detection_found() -> None:
         tmp_path = Path(tmpdir)
         py_file = tmp_path / "main.py"
         py_file.write_text(
-            """from fastapi import FastAPI
-app = FastAPI()
-
-@app.get("/")
-def read_root():
-    return {"Hello": "World"}
+            """import azure.functions as func
+from fastapi import FastAPI
+fastapi_app = FastAPI()
+app = func.AsgiFunctionApp(app=fastapi_app)
 """
         )
 
@@ -1398,7 +1396,7 @@ def test_callable_detection_not_found() -> None:
             "condition": {},
         }
         result = registry.handle(rule, tmp_path)
-        assert result["status"] == "fail"
+        assert result["status"] == "skip"
         assert "No ASGI/WSGI" in result["detail"]
 
 
@@ -2288,7 +2286,7 @@ def test_callable_detection_finds_fastapi() -> None:
             "condition": {},
         }
         result = registry.handle(rule, tmp_path)
-        assert result["status"] == "pass"  # Finding callable is good
+        assert result["status"] == "fail"  # framework present but callable not exposed
 
 
 def test_local_settings_json_exists() -> None:
@@ -2320,7 +2318,7 @@ def test_executable_detection() -> None:
             "condition": {},
         }
         result = registry.handle(rule, tmp_path)
-        assert result["status"] == "fail"  # No callable found is bad
+        assert result["status"] == "skip"  # No framework => plain FunctionApp, skip
 
 
 # Tests for exception branches in package handlers


### PR DESCRIPTION
## Context
Part of the Azure Functions 2026 audit (umbrella #312). Closes #307.

`check_asgi_wsgi_exposure` warned whenever no ASGI/WSGI callable was found — noisy for the common decorator-based `FunctionApp` project that has no ASGI/WSGI app at all.

## Changes
- `_handle_callable_detection` now distinguishes **framework signal** from **exposure wiring**:
  - no framework (FastAPI/Flask/Starlette/Quart or Asgi/Wsgi wrappers) → **skip**
  - framework present but not exposed via `AsgiFunctionApp`/`WsgiFunctionApp` (or `AsgiMiddleware`/`WsgiMiddleware`) → **warn**
  - callable correctly exposed → **pass**
- Updated existing tests and added coverage for skip/warn/pass; docs synced (`rules.md`, `diagnostics.md`).

## Validation
- `make lint` ✅  `make typecheck` ✅
- Full suite ✅ — coverage 96.63% (≥95% gate)