### PR TITLE
fix(extensions): parse extensionBundle version ranges semantically

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -336,7 +336,7 @@ Found unwanted files: ['tests/', '.venv']
 
 ## 22) `check_extension_bundle_v4`
 
-- **What it checks:** `extensionBundle` in `host.json` uses the recommended v4 range `[4.*, 5.0.0)`.
+- **What it checks:** `extensionBundle` in `host.json` uses a documented v4 range. The range is parsed as an interval (not a string prefix): the lower bound must be an inclusive major 4 (`[4.0.0` or `[4.*`) and the upper bound must be an exclusive `5.0.0)`. Over-broad ranges such as `[4.0.0, 6.0.0)` are rejected. The bundle id must be `Microsoft.Azure.Functions.ExtensionBundle`.
 - **Why it matters:** Aligns binding extensions with the current supported bundle.
 - **How to fix:** Update the `extensionBundle.version` range to the v4 range.
 - **Severity:** Warning only (`required: false`).

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -803,31 +803,53 @@ class HandlerRegistry:
                 f"extensionBundle id '{bundle_id}' is not the recommended '{recommended_id}'",
             )
 
-        # Check that the version range starts with [4.
-        version_str = str(bundle_version)
-        if version_str.startswith("[4."):
+        version_str = str(bundle_version).strip()
+        # Parse a NuGet-style range: [lower, upper) with */numeric version parts.
+        range_match = re.match(
+            r"^([\[(])\s*"
+            r"(\d+)(?:\.(\d+|\*))?(?:\.(\d+|\*))?\s*,\s*"
+            r"(\d+)(?:\.(\d+|\*))?(?:\.(\d+|\*))?\s*"
+            r"([\])])$",
+            version_str,
+        )
+        if range_match is None:
+            return _create_result(
+                "fail",
+                f"extensionBundle version '{version_str}' is not a valid range;"
+                " use the recommended [4.0.0, 5.0.0)",
+            )
+
+        lower_bracket = range_match.group(1)
+        lower_major = int(range_match.group(2))
+        upper_major = int(range_match.group(5))
+        upper_bracket = range_match.group(8)
+
+        if lower_major < 4:
+            return _create_result(
+                "fail",
+                f"extensionBundle version '{version_str}' is below"
+                " recommended v4 range — upgrade to [4.0.0, 5.0.0)",
+            )
+
+        # Valid v4: lower bound inclusive starting at major 4, upper bound
+        # exclusive at exactly major 5 (i.e. [4.x, 5.0.0)).
+        is_valid_v4 = (
+            lower_bracket == "["
+            and lower_major == 4
+            and upper_major == 5
+            and upper_bracket == ")"
+        )
+        if is_valid_v4:
             return _create_result(
                 "pass",
                 f"extensionBundle uses recommended v4 range: {version_str}",
             )
 
-        # Detect older major versions
-        import re as _re
-
-        major_match = _re.search(r"\[(\d+)\.", version_str)
-        if major_match:
-            major = int(major_match.group(1))
-            if major < 4:
-                return _create_result(
-                    "fail",
-                    f"extensionBundle version '{version_str}' is below"
-                    " recommended v4 range — upgrade to [4.*, 5.0.0)",
-                )
-
         return _create_result(
             "fail",
-            f"extensionBundle version '{version_str}' does not match"
-            " recommended v4 range [4.*, 5.0.0)",
+            f"extensionBundle version '{version_str}' does not match the"
+            " recommended v4 range [4.0.0, 5.0.0); the upper bound must be an"
+            " exclusive 5.0.0",
         )
 
     @_rule_handler

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -822,6 +822,8 @@ class HandlerRegistry:
         lower_bracket = range_match.group(1)
         lower_major = int(range_match.group(2))
         upper_major = int(range_match.group(5))
+        upper_minor_raw = range_match.group(6)
+        upper_patch_raw = range_match.group(7)
         upper_bracket = range_match.group(8)
 
         if lower_major < 4:
@@ -833,10 +835,17 @@ class HandlerRegistry:
 
         # Valid v4: lower bound inclusive starting at major 4, upper bound
         # exclusive at exactly major 5 (i.e. [4.x, 5.0.0)).
+        # The exclusive upper bound must be exactly 5.0.0. An absent minor/patch
+        # component defaults to 0; a wildcard ('*') or non-zero component (e.g.
+        # 5.1.0) widens the range beyond the recommended bound and must fail.
+        upper_minor_zero = upper_minor_raw in (None, "0")
+        upper_patch_zero = upper_patch_raw in (None, "0")
         is_valid_v4 = (
             lower_bracket == "["
             and lower_major == 4
             and upper_major == 5
+            and upper_minor_zero
+            and upper_patch_zero
             and upper_bracket == ")"
         )
         if is_valid_v4:

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -879,7 +879,60 @@ def test_host_json_extension_bundle_v4_success() -> None:
         }
         result = registry.handle(rule, tmp_path)
         assert result["status"] == "pass"
-        assert "v4" in result["detail"]
+
+
+def _bundle_host(version: str) -> str:
+    return (
+        '{"extensionBundle": {"id": "Microsoft.Azure.Functions.ExtensionBundle",'
+        f' "version": "{version}"}}}}'
+    )
+
+
+def test_extension_bundle_v4_wildcard_passes() -> None:
+    """[4.*, 5.0.0) is a documented v4 range and should pass."""
+    registry = HandlerRegistry()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        (tmp_path / "host.json").write_text(_bundle_host("[4.*, 5.0.0)"))
+        rule: Rule = {"type": "host_json_extension_bundle_version", "condition": {}}
+        result = registry.handle(rule, tmp_path)
+        assert result["status"] == "pass"
+
+
+def test_extension_bundle_overbroad_upper_fails() -> None:
+    """[4.0.0, 6.0.0) is over-broad (wrong upper bound) and must fail."""
+    registry = HandlerRegistry()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        (tmp_path / "host.json").write_text(_bundle_host("[4.0.0, 6.0.0)"))
+        rule: Rule = {"type": "host_json_extension_bundle_version", "condition": {}}
+        result = registry.handle(rule, tmp_path)
+        assert result["status"] == "fail"
+        assert "does not match" in result["detail"]
+
+
+def test_extension_bundle_inclusive_upper_fails() -> None:
+    """[4.0.0, 5.0.0] with an inclusive upper bound must fail."""
+    registry = HandlerRegistry()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        (tmp_path / "host.json").write_text(_bundle_host("[4.0.0, 5.0.0]"))
+        rule: Rule = {"type": "host_json_extension_bundle_version", "condition": {}}
+        result = registry.handle(rule, tmp_path)
+        assert result["status"] == "fail"
+
+
+def test_extension_bundle_malformed_range_fails() -> None:
+    """A non-range version string must fail as invalid."""
+    registry = HandlerRegistry()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        (tmp_path / "host.json").write_text(_bundle_host("4.0.0"))
+        rule: Rule = {"type": "host_json_extension_bundle_version", "condition": {}}
+        result = registry.handle(rule, tmp_path)
+        assert result["status"] == "fail"
+        assert "not a valid range" in result["detail"]
+
 
 
 def test_local_settings_security_no_file() -> None:

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -910,6 +910,17 @@ def test_extension_bundle_overbroad_upper_fails() -> None:
         assert result["status"] == "fail"
         assert "does not match" in result["detail"]
 
+def test_extension_bundle_nonzero_upper_minor_fails() -> None:
+    """[4.0.0, 5.1.0) widens past the exclusive 5.0.0 bound and must fail."""
+    registry = HandlerRegistry()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        (tmp_path / "host.json").write_text(_bundle_host("[4.0.0, 5.1.0)"))
+        rule: Rule = {"type": "host_json_extension_bundle_version", "condition": {}}
+        result = registry.handle(rule, tmp_path)
+        assert result["status"] == "fail"
+        assert "does not match" in result["detail"]
+
 
 def test_extension_bundle_inclusive_upper_fails() -> None:
     """[4.0.0, 5.0.0] with an inclusive upper bound must fail."""


### PR DESCRIPTION
## Context
Part of the Azure Functions 2026 audit (umbrella #312). Closes #308.

`check_extension_bundle_v4` validated the range with `version.startswith("[4.")`, so over-broad ranges like `[4.0.0, 6.0.0)` passed incorrectly.

## Changes
- `_handle_host_json_extension_bundle_version` now parses the NuGet-style range as an interval:
  - lower bound inclusive major 4 (`[4.0.0` or `[4.*`)
  - upper bound exclusive `5.0.0)`
  - rejects over-broad (`[4.0.0, 6.0.0)`), inclusive-upper (`[4.0.0, 5.0.0]`), and malformed values
  - bundle id still validated as `Microsoft.Azure.Functions.ExtensionBundle`
- Added tests for valid v4 (`[4.0.0, 5.0.0)`, `[4.*, 5.0.0)`), over-broad, inclusive-upper, and malformed ranges; docs synced (`rules.md`).

## Validation
- `make lint` ✅  `make typecheck` ✅
- Full suite ✅ — coverage 96.65% (≥95% gate)