### PR TITLE
fix(openapi): align metadata and version checks with OpenAPI 3.2

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -350,14 +350,14 @@ Found unwanted files: ['tests/', '.venv']
 
 ## 24) `check_endpoint_metadata`
 
-- **What it checks:** In projects depending on `azure-functions-validation`, HTTP route handlers use `@validate_http` so they emit endpoint OpenAPI metadata.
+- **What it checks:** In projects depending on `azure-functions-validation`, HTTP route handlers emit endpoint OpenAPI metadata via `@validate_http` **or** another supported metadata decorator (`@openapi`, LangGraph metadata). Routes annotated with those decorators are not flagged even without `@validate_http`.
 - **Why it matters:** Handlers without it will not appear in generated OpenAPI specs.
 - **How to fix:** Apply `@validate_http` to route handlers that should emit metadata.
 - **Severity:** Warning only (`required: false`).
 
 ## 25) `check_openapi_version_mixing`
 
-- **What it checks:** A project does not mix OpenAPI 3.0 signals (3.0.x version strings or the `nullable` keyword) with OpenAPI 3.1 signals (3.1.x version strings).
+- **What it checks:** A project does not mix two or more OpenAPI versions. It recognizes 3.0 signals (3.0.x version strings or the `nullable` keyword), 3.1 signals (3.1.x strings), and **3.2** signals (3.2.x strings). A single-version project — including 3.2-only — never warns.
 - **Why it matters:** Mixing versions produces inconsistent generated specs.
 - **How to fix:** Standardize on a single OpenAPI version across the project.
 - **Severity:** Warning only (`required: false`).

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -352,7 +352,7 @@ Found unwanted files: ['tests/', '.venv']
 
 - **What it checks:** In projects depending on `azure-functions-validation`, HTTP route handlers emit endpoint OpenAPI metadata via `@validate_http` **or** another supported metadata decorator (`@openapi`, LangGraph metadata). Routes annotated with those decorators are not flagged even without `@validate_http`.
 - **Why it matters:** Handlers without it will not appear in generated OpenAPI specs.
-- **How to fix:** Apply `@validate_http` to route handlers that should emit metadata.
+- **How to fix:** Apply `@validate_http` — or another supported endpoint-metadata decorator (`@openapi` or the LangGraph metadata decorators) — to route handlers that should emit metadata.
 - **Severity:** Warning only (`required: false`).
 
 ## 25) `check_openapi_version_mixing`

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -366,8 +366,12 @@ _ENDPOINT_METADATA_DECORATORS = frozenset({"openapi", "openapi_metadata", "langg
 def _collect_routes_missing_validate_http_locations(
     path: Path,
 ) -> list[tuple[str, int, Optional[int], int]]:
-    """Return ``(label, lineno)`` pairs for HTTP route handlers that lack an
-    *active* ``@validate_http`` and therefore emit no endpoint OpenAPI metadata.
+    """Return ``(label, lineno)`` pairs for HTTP route handlers that expose no
+    endpoint OpenAPI metadata.
+
+    A handler is considered *covered* when it carries an *active* ``@validate_http``
+    or any other supported endpoint-metadata decorator (e.g. ``@openapi`` or the
+    LangGraph metadata decorators); such handlers are omitted from the result.
 
     ``label`` is ``"file:function"`` and ``lineno`` is the 1-based source line of
     the offending function definition.

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -357,6 +357,12 @@ def _is_spec_serving_handler(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bo
     return False
 
 
+# Decorators that emit OpenAPI endpoint metadata other than ``@validate_http``.
+# A route carrying any of these is considered metadata-covered and is not
+# flagged for missing endpoint metadata.
+_ENDPOINT_METADATA_DECORATORS = frozenset({"openapi", "openapi_metadata", "langgraph_metadata"})
+
+
 def _collect_routes_missing_validate_http_locations(
     path: Path,
 ) -> list[tuple[str, int, Optional[int], int]]:
@@ -386,6 +392,7 @@ def _collect_routes_missing_validate_http_locations(
             is_route = False
             route_idx: Optional[int] = None
             validate_idx: Optional[int] = None
+            has_other_metadata = False
             for i, dec in enumerate(node.decorator_list):
                 inner: ast.expr = dec.func if isinstance(dec, ast.Call) else dec
                 if (
@@ -399,10 +406,13 @@ def _collect_routes_missing_validate_http_locations(
                         route_idx = i
                 if validate_idx is None and _decorator_simple_name(dec) == "validate_http":
                     validate_idx = i
+                if _decorator_simple_name(dec) in _ENDPOINT_METADATA_DECORATORS:
+                    has_other_metadata = True
             has_active_validate_http = (
                 validate_idx is not None and route_idx is not None and validate_idx > route_idx
             )
-            if is_route and not has_active_validate_http and not _is_spec_serving_handler(node):
+            covered = has_active_validate_http or has_other_metadata
+            if is_route and not covered and not _is_spec_serving_handler(node):
                 uncovered.append(
                     (
                         f"{py_file.relative_to(path)}:{node.name}",
@@ -444,18 +454,17 @@ def _dotted_call_name(func: ast.expr) -> Optional[str]:
     return None
 
 
-def _collect_openapi_version_mixing(path: Path) -> tuple[set[str], set[str]]:
-    """Return (v30_signals, v31_signals) found across the project.
+def _collect_openapi_version_mixing(path: Path) -> dict[str, set[str]]:
+    """Return a mapping of OpenAPI ``major.minor`` version -> signals found.
 
-    OpenAPI 3.0 signals: a string constant like ``3.0.N`` or a
-    keyword argument named ``nullable``. OpenAPI 3.1 signals: a string constant
-    like ``3.1.N``. Callers treat a non-empty intersection of both
-    sets as a version-mixing warning.
+    Recognised keys are ``"3.0"``, ``"3.1"`` and ``"3.2"``. Signals are string
+    constants like ``3.0.N`` / ``3.1.N`` / ``3.2.N``; a ``nullable`` keyword
+    argument is a 3.0-only signal (``nullable`` was removed in OpenAPI 3.1+).
+    Callers treat two or more populated version keys as a version-mixing warning,
+    so a single-version project (including 3.2-only) never warns.
     """
-    v30: set[str] = set()
-    v31: set[str] = set()
-    v30_re = re.compile(r"^3\.0\.\d+$")
-    v31_re = re.compile(r"^3\.1\.\d+$")
+    signals: dict[str, set[str]] = {"3.0": set(), "3.1": set(), "3.2": set()}
+    version_re = re.compile(r"^3\.(0|1|2)\.\d+$")
     for _py_file, content in _iter_project_py_contents(path):
         try:
             tree = ast.parse(content)
@@ -463,13 +472,12 @@ def _collect_openapi_version_mixing(path: Path) -> tuple[set[str], set[str]]:
             continue
         for node in ast.walk(tree):
             if isinstance(node, ast.Constant) and isinstance(node.value, str):
-                if v30_re.match(node.value):
-                    v30.add(node.value)
-                elif v31_re.match(node.value):
-                    v31.add(node.value)
+                match = version_re.match(node.value)
+                if match is not None:
+                    signals[f"3.{match.group(1)}"].add(node.value)
             elif isinstance(node, ast.keyword) and node.arg == "nullable":
-                v30.add("nullable")
-    return v30, v31
+                signals["3.0"].add("nullable")
+    return signals
 
 
 def _collect_scan_before_spec(path: Path, scan_names: set[str], spec_names: set[str]) -> list[str]:

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -949,15 +949,18 @@ class HandlerRegistry:
     def _handle_openapi_version_mixing(
         self, rule: Rule, path: Path, context: Optional[RuleContext] = None
     ) -> HandlerResult:
-        """Detect when both OpenAPI 3.0 and 3.1 signals appear in one project."""
-        v30, v31 = _collect_openapi_version_mixing(path)
-        if not (v30 and v31):
+        """Detect when two or more OpenAPI versions (3.0/3.1/3.2) appear together."""
+        signals = _collect_openapi_version_mixing(path)
+        present = {version: sigs for version, sigs in signals.items() if sigs}
+        if len(present) < 2:
             return _create_result("pass", "No OpenAPI version mixing detected")
         detail = "\n".join(
             [
                 "Mixed OpenAPI version signals detected:",
-                f"- 3.0 signals: {', '.join(sorted(v30))}",
-                f"- 3.1 signals: {', '.join(sorted(v31))}",
+                *[
+                    f"- {version} signals: {', '.join(sorted(sigs))}"
+                    for version, sigs in sorted(present.items())
+                ],
                 "",
                 "Fix: standardise on a single OpenAPI version across the project.",
             ]

--- a/tests/test_decorator_diagnostics.py
+++ b/tests/test_decorator_diagnostics.py
@@ -202,6 +202,23 @@ def test_collect_routes_missing_validate_http_excludes_spec_serving(tmp_path: Pa
     assert helpers._collect_routes_missing_validate_http(tmp_path) == ["function_app.py:items"]
 
 
+def test_collect_routes_openapi_decorator_covers_metadata(tmp_path: Path) -> None:
+    # A route carrying @openapi already emits endpoint metadata, so it must not
+    # be flagged even without @validate_http.
+    helpers = import_module("azure_functions_doctor.handlers._helpers")
+    (tmp_path / "function_app.py").write_text(
+        "import azure.functions as func\n"
+        "from azure_functions_openapi import openapi\n"
+        "fa = func.FunctionApp()\n\n"
+        "@fa.route(route='items')\n"
+        "@openapi(summary='List items')\n"
+        "def items(req):\n"
+        "    return req\n",
+        encoding="utf-8",
+    )
+    assert helpers._collect_routes_missing_validate_http(tmp_path) == []
+
+
 # ---------------------------------------------------------------------------
 # Regression: @validate_http above a binding decorator (dead handler)
 # ---------------------------------------------------------------------------

--- a/tests/test_toolkit_rule_checks.py
+++ b/tests/test_toolkit_rule_checks.py
@@ -70,7 +70,11 @@ def test_openapi_version_mixing_both_signals_fails(tmp_path: Path) -> None:
         "app.py",
         "V30 = '3.0.3'\nV31 = '3.1.0'\n",
     )
-    assert _collect_openapi_version_mixing(tmp_path) == ({"3.0.3"}, {"3.1.0"})
+    assert _collect_openapi_version_mixing(tmp_path) == {
+        "3.0": {"3.0.3"},
+        "3.1": {"3.1.0"},
+        "3.2": set(),
+    }
     assert _status("openapi_version_mixing", tmp_path) == "fail"
 
 
@@ -80,8 +84,9 @@ def test_openapi_version_mixing_nullable_counts_as_v30(tmp_path: Path) -> None:
         "app.py",
         "def f():\n    schema(nullable=True)\n    return '3.1.0'\n",
     )
-    v30, v31 = _collect_openapi_version_mixing(tmp_path)
-    assert "nullable" in v30 and "3.1.0" in v31
+    signals = _collect_openapi_version_mixing(tmp_path)
+    assert "nullable" in signals["3.0"] and "3.1.0" in signals["3.1"]
+
     assert _status("openapi_version_mixing", tmp_path) == "fail"
 
 
@@ -90,9 +95,20 @@ def test_openapi_version_mixing_single_version_passes(tmp_path: Path) -> None:
     assert _status("openapi_version_mixing", tmp_path) == "pass"
 
 
+def test_openapi_version_mixing_32_only_passes(tmp_path: Path) -> None:
+    _write(tmp_path, "app.py", "V = '3.2.0'\n")
+    assert _collect_openapi_version_mixing(tmp_path)["3.2"] == {"3.2.0"}
+    assert _status("openapi_version_mixing", tmp_path) == "pass"
+
+
+def test_openapi_version_mixing_31_and_32_fails(tmp_path: Path) -> None:
+    _write(tmp_path, "app.py", "V31 = '3.1.0'\nV32 = '3.2.0'\n")
+    assert _status("openapi_version_mixing", tmp_path) == "fail"
+
+
 def test_openapi_version_mixing_skips_syntax_error(tmp_path: Path) -> None:
     _write(tmp_path, "broken.py", "def f(:\n")
-    assert _collect_openapi_version_mixing(tmp_path) == (set(), set())
+    assert _collect_openapi_version_mixing(tmp_path) == {"3.0": set(), "3.1": set(), "3.2": set()}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context
Part of the Azure Functions 2026 audit (umbrella #312). Closes #309.

Two OpenAPI rules were stale: `check_endpoint_metadata` flagged routes carrying `@openapi` (not just `@validate_http`), and `check_openapi_version_mixing` had no awareness of OpenAPI 3.2.

## Changes
- `_collect_routes_missing_validate_http_locations` now treats a route as metadata-covered when it carries `@openapi` / LangGraph metadata decorators (`_ENDPOINT_METADATA_DECORATORS`), not only an active `@validate_http`.
- `_collect_openapi_version_mixing` returns a version-keyed dict (`3.0`/`3.1`/`3.2`); the handler warns only when 2+ distinct versions are present. A 3.2-only project passes; a 3.1+3.2 mix warns.
- Updated existing tests for the new signature and added coverage for `@openapi`-only routes, 3.2-only, and 3.1+3.2 mixing; docs synced (`rules.md`).

## Validation
- `make lint` ✅  `make typecheck` ✅
- Full suite ✅ — coverage 96.61% (≥95% gate)