### PR TITLE
refactor(rules): model rule identity, severity, and tiers explicitly

### DIFF
--- a/docs/RULE_POLICY.md
+++ b/docs/RULE_POLICY.md
@@ -194,9 +194,36 @@ Rules without a documentation anchor belong in the Experimental tier until a ref
 
 ---
 
-## Proposed Future Metadata
+## Rule Identity, Severity, and Tier Metadata
 
-The following optional fields are reserved for future schema extensions.
+As of the rule-model refactor, the schema and runtime model rule **identity**,
+**severity**, **gate**, and **tier** explicitly instead of overloading `required`.
+Each emitted check result carries a stable `rule_id` (used directly by the SARIF
+reporter — no fragile reverse-mapping from the human-readable label).
+
+```json
+{
+  "id": "check_host_json",
+  "severity": "error",
+  "gate": true,
+  "tier": "core"
+}
+```
+
+| Field | Values | Purpose |
+|---|---|---|
+| `severity` | `error`, `warning`, `info` | Runtime severity of a failing rule. A failing `error` rule maps to `fail`; otherwise it maps to `warn`. |
+| `gate` | `true`, `false` | Whether a failing rule fails its section (gates the run), independent of severity. |
+| `tier` | `core`, `extended`, `experimental` | Explicit maturity/tier classification. |
+
+All three are **optional** and backward compatible: when omitted they are derived
+from `required` (`severity` → `error`/`warning`, `gate` → the `required` value,
+`tier` → `core`/`extended`). This keeps existing `v2.json` entries valid while
+allowing rules to specify the three concerns independently.
+
+### Proposed Future Metadata
+
+The following optional fields remain reserved for future schema extensions.
 They are **not currently enforced** by the schema or handler runtime.
 
 ```json
@@ -204,8 +231,7 @@ They are **not currently enforced** by the schema or handler runtime.
   "id": "check_host_json",
   "source_type": "ms_learn",
   "source_title": "Azure Functions host.json reference",
-  "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-host-json",
-  "tier": "core"
+  "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-host-json"
 }
 ```
 
@@ -214,7 +240,6 @@ They are **not currently enforced** by the schema or handler runtime.
 | `source_type` | `ms_learn`, `derived`, `heuristic` | Classification of rule's documentation basis |
 | `source_title` | String | Human-readable title of the source document |
 | `source_url` | URI | Direct link to the authoritative reference |
-| `tier` | `core`, `extended`, `experimental` | Explicit tier classification |
 
 To adopt these fields, update `rules.schema.json`, the `Rule` TypedDict in `handlers/_helpers.py`,
 and all entries in `v2.json`.

--- a/docs/json_output_contract.md
+++ b/docs/json_output_contract.md
@@ -31,9 +31,12 @@ If `--output` is omitted, JSON is printed to stdout.
       "status": "fail",
       "items": [
         {
+          "rule_id": "check_python_version",
           "label": "Python version",
           "value": "Python 3.9.18 (>=3.10)",
           "status": "fail",
+          "severity": "error",
+          "tier": "core",
           "hint": "Target a Python version supported by Azure Functions: 3.10, 3.11, 3.12, 3.13, or 3.14.",
           "hint_url": "https://learn.microsoft.com/..."
         }
@@ -69,9 +72,12 @@ If `--output` is omitted, JSON is printed to stdout.
 
 | Field | Type | Description |
 | --- | --- | --- |
+| `rule_id` | string | Stable machine-oriented rule identifier (matches the rule `id` in the ruleset). Used directly as the SARIF `ruleId`. |
 | `label` | string | Check display label. |
 | `value` | string | Diagnostic detail text from handler execution. |
 | `status` | `pass` \| `warn` \| `fail` | Canonical item-level status. |
+| `severity` | `error` \| `warning` \| `info` | Runtime severity of the rule. A failing `error` rule maps to `fail`; otherwise it maps to `warn`. |
+| `tier` | `core` \| `extended` \| `experimental` | Rule maturity/tier classification. |
 | `hint` | string (optional) | Human-readable remediation guidance. |
 | `hint_url` | string (optional) | Supporting documentation link. |
 
@@ -88,9 +94,12 @@ Use the following contract expectations when writing parsers.
 | `metadata.target_python` | Stable | Safe for correlating requested target Python version. |
 | `results[].category` | Stable | Prefer for machine grouping. |
 | `results[].status` | Stable | Safe for section-level logic. |
+| `results[].items[].rule_id` | Stable | Prefer for machine matching of specific rules; used as SARIF `ruleId`. |
 | `results[].items[].label` | Stable | Safe for human-readable matching. |
 | `results[].items[].status` | Stable | Primary gate/filter field. |
 | `results[].items[].value` | Stable | Safe for reporting detail text. |
+| `results[].items[].severity` | Stable | Runtime severity classification. |
+| `results[].items[].tier` | Stable | Rule maturity/tier classification. |
 | `results[].title` | Detail | Display-oriented; do not hardcode behavior on casing/format. |
 | `results[].items[].hint` | Detail | Helpful for UX, optional in parsers. |
 | `results[].items[].hint_url` | Detail | Helpful for UX, optional in parsers. |

--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -10,7 +10,7 @@ from rich.text import Text
 import typer
 
 from azure_functions_doctor import __version__
-from azure_functions_doctor.doctor import Doctor
+from azure_functions_doctor.doctor import Doctor, _resolve_severity, _resolve_tier
 from azure_functions_doctor.logging_config import (
     get_logger,
     log_diagnostic_complete,
@@ -262,8 +262,7 @@ def doctor(
         raise typer.Exit(1 if fail_count > 0 else 0)
 
     if format == "sarif":
-        # Build label → rule mapping for enriched ruleId and metadata
-        label_to_rule = {r.get("label", "unknown_rule"): r for r in loaded_rules}
+        # rule_id is emitted on every result, so SARIF uses it directly
 
         # Build driver.rules from the full loaded ruleset
         driver_rules = []
@@ -277,6 +276,8 @@ def doctor(
                 "properties": {
                     "category": rule.get("category", ""),
                     "required": rule.get("required", False),
+                    "tier": _resolve_tier(rule),
+                    "severity": _resolve_severity(rule),
                 },
             }
             hint_url = rule.get("hint_url", "")
@@ -291,9 +292,7 @@ def doctor(
                 # Skipped checks are not findings; exclude them from SARIF output.
                 if status in ("pass", "skip"):
                     continue
-                label = item.get("label", "")
-                matched_rule = label_to_rule.get(label)
-                rule_id = matched_rule.get("id", label) if matched_rule else label
+                rule_id = item.get("rule_id") or item.get("label", "")
                 level = "error" if status == "fail" else "warning"
                 loc_file = item.get("file")
                 if loc_file:

--- a/src/azure_functions_doctor/doctor.py
+++ b/src/azure_functions_doctor/doctor.py
@@ -227,6 +227,8 @@ class Doctor:
                     "label": label,
                     "value": value,
                     "status": "fail",
+                    "severity": "error",
+                    "tier": "core",
                     "hint": hint,
                 }
             ],
@@ -336,8 +338,12 @@ class Doctor:
                 else:
                     canonical = "fail" if severity == "error" else "warn"
 
+                failed = handler_status not in ("pass", "skip")
                 detail = result.get("detail", "")
-                if canonical == "warn":
+                # A failing rule is "optional" when it does not gate the run,
+                # independent of its display severity (a gate rule may still
+                # carry severity "warning"/"info").
+                if failed and not gate:
                     detail += " (optional)"
 
                 item: CheckResult = {
@@ -349,7 +355,7 @@ class Doctor:
                     "tier": tier,
                 }
 
-                if canonical == "fail" and gate:
+                if failed and gate:
                     section_result["status"] = "fail"
 
                 if "hint" in rule:

--- a/src/azure_functions_doctor/doctor.py
+++ b/src/azure_functions_doctor/doctor.py
@@ -23,11 +23,41 @@ logger = get_logger(__name__)
 
 ProgrammingModel = Literal["v2", "unsupported_v1", "mixed", "unknown"]
 
+_VALID_SEVERITIES = ("error", "warning", "info")
+_VALID_TIERS = ("core", "extended", "experimental")
+
+
+def _resolve_severity(rule: Rule) -> str:
+    """Resolve a rule's runtime severity, falling back to ``required``."""
+    severity = rule.get("severity")
+    if severity in _VALID_SEVERITIES:
+        return str(severity)
+    return "error" if rule.get("required", True) else "warning"
+
+
+def _resolve_gate(rule: Rule) -> bool:
+    """Whether a failing rule gates the run, independent of severity."""
+    gate = rule.get("gate")
+    if isinstance(gate, bool):
+        return gate
+    return bool(rule.get("required", True))
+
+
+def _resolve_tier(rule: Rule) -> str:
+    """Resolve a rule's maturity tier, falling back to ``required``."""
+    tier = rule.get("tier")
+    if tier in _VALID_TIERS:
+        return str(tier)
+    return "core" if rule.get("required", True) else "extended"
+
 
 class CheckResult(TypedDict, total=False):
+    rule_id: str
     label: str
     value: str
     status: str
+    severity: str
+    tier: str
     hint: str
     hint_url: str
     file: str
@@ -193,6 +223,7 @@ class Doctor:
             "status": "fail",
             "items": [
                 {
+                    "rule_id": "check_programming_model_v2",
                     "label": label,
                     "value": value,
                     "status": "fail",
@@ -289,28 +320,36 @@ class Doctor:
                     rule_duration_ms,
                 )
 
-                # Simplified canonical mapping:
-                # pass stays pass, skip stays skip (regardless of required),
-                # otherwise required -> fail and optional -> warn.
-                required = rule.get("required", True)
+                # Canonical mapping driven by explicit severity/gate/tier
+                # (each derived from ``required`` when not set on the rule):
+                #   pass -> pass, skip -> skip; a failing handler maps to
+                #   "fail" when severity is "error", otherwise "warn". The
+                #   section is only gated to fail when the rule is a gate.
+                severity = _resolve_severity(rule)
+                gate = _resolve_gate(rule)
+                tier = _resolve_tier(rule)
+                rule_id = rule.get("id", "unknown_rule")
                 if handler_status == "pass":
                     canonical = "pass"
                 elif handler_status == "skip":
                     canonical = "skip"
                 else:
-                    canonical = "fail" if required else "warn"
+                    canonical = "fail" if severity == "error" else "warn"
 
                 detail = result.get("detail", "")
                 if canonical == "warn":
                     detail += " (optional)"
 
                 item: CheckResult = {
-                    "label": rule.get("label", rule.get("id", "unknown_rule")),
+                    "rule_id": rule_id,
+                    "label": rule.get("label", rule_id),
                     "value": detail,
                     "status": canonical,
+                    "severity": severity,
+                    "tier": tier,
                 }
 
-                if canonical == "fail" and required:
+                if canonical == "fail" and gate:
                     section_result["status"] = "fail"
 
                 if "hint" in rule:

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -1070,6 +1070,9 @@ class Rule(TypedDict, total=False):
     section: str
     description: str
     required: bool
+    severity: Literal["error", "warning", "info"]
+    gate: bool
+    tier: Literal["core", "extended", "experimental"]
     condition: Condition
     hint: str
     fix: str

--- a/src/azure_functions_doctor/schemas/rules.schema.json
+++ b/src/azure_functions_doctor/schemas/rules.schema.json
@@ -116,7 +116,17 @@
       },
       "severity": {
         "type": "string",
-        "description": "Severity classification for the rule (optional)."
+        "description": "Severity wired into runtime output: 'error' maps a failing check to fail, 'warning'/'info' map it to warn. When omitted it is derived from 'required'.",
+        "enum": ["error", "warning", "info"]
+      },
+      "gate": {
+        "type": "boolean",
+        "description": "Whether a failing check gates the run (fails its section / non-zero exit). Separate from severity. When omitted it is derived from 'required'."
+      },
+      "tier": {
+        "type": "string",
+        "description": "Maturity tier of the rule. When omitted it is derived from 'required' (required -> core, optional -> extended).",
+        "enum": ["core", "extended", "experimental"]
       },
       "fix": {
         "type": "string",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,19 @@ def test_cli_sarif_output() -> None:
     expected_exit = 1 if has_error else 0
     assert result.exit_code == expected_exit
 
+def test_cli_sarif_ruleid_propagates_from_rule_id() -> None:
+    """SARIF ``ruleId`` comes from the result's ``rule_id``, matching driver rule ids."""
+    result = runner.invoke(app, ["doctor", "--format", "sarif"])
+    data = json.loads(result.output)
+    run = data["runs"][0]
+    driver_ids = {rule["id"] for rule in run["tool"]["driver"]["rules"]}
+    findings = run.get("results", [])
+    # There must be findings to make this assertion meaningful.
+    assert findings
+    for finding in findings:
+        rule_id = finding["ruleId"]
+        assert rule_id, "every SARIF finding must carry a ruleId"
+        assert rule_id in driver_ids, f"ruleId {rule_id!r} must match a driver rule id"
 
 def test_cli_junit_output() -> None:
     """Test CLI outputs JUnit format."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,12 +99,17 @@ def test_cli_sarif_output() -> None:
 
 def test_cli_sarif_ruleid_propagates_from_rule_id() -> None:
     """SARIF ``ruleId`` comes from the result's ``rule_id``, matching driver rule ids."""
-    result = runner.invoke(app, ["doctor", "--format", "sarif"])
+    result = runner.invoke(
+        app,
+        ["doctor", "--path", str(FIXTURES_DIR / "unknown"), "--format", "sarif"],
+    )
     data = json.loads(result.output)
     run = data["runs"][0]
     driver_ids = {rule["id"] for rule in run["tool"]["driver"]["rules"]}
     findings = run.get("results", [])
-    # There must be findings to make this assertion meaningful.
+    # The unknown fixture short-circuits on programming-model detection, which
+    # deterministically yields at least one SARIF finding regardless of the
+    # environment or repository state.
     assert findings
     for finding in findings:
         rule_id = finding["ruleId"]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -174,3 +174,46 @@ def test_load_rules_invalid_schema_raises_value_error(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="Invalid rules file"):
         doctor.load_rules()
+
+
+def test_resolve_severity_gate_tier_fallback_from_required() -> None:
+    """Explicit severity/gate/tier win; otherwise they fall back to ``required``."""
+    from typing import cast
+
+    from azure_functions_doctor.doctor import (
+        _resolve_gate,
+        _resolve_severity,
+        _resolve_tier,
+    )
+    from azure_functions_doctor.handlers import Rule
+
+    def rule(**kwargs: object) -> Rule:
+        return cast(Rule, kwargs)
+
+    # Explicit values are honored.
+    explicit = rule(
+        severity="info",
+        gate=False,
+        tier="experimental",
+        required=True,
+    )
+    assert _resolve_severity(explicit) == "info"
+    assert _resolve_gate(explicit) is False
+    assert _resolve_tier(explicit) == "experimental"
+
+    # Fallbacks derive from ``required=True``.
+    required_true = rule(required=True)
+    assert _resolve_severity(required_true) == "error"
+    assert _resolve_gate(required_true) is True
+    assert _resolve_tier(required_true) == "core"
+
+    # Fallbacks derive from ``required=False``.
+    required_false = rule(required=False)
+    assert _resolve_severity(required_false) == "warning"
+    assert _resolve_gate(required_false) is False
+    assert _resolve_tier(required_false) == "extended"
+
+    # Invalid explicit values are ignored in favor of the fallback.
+    invalid = rule(severity="bogus", tier="bogus", required=False)
+    assert _resolve_severity(invalid) == "warning"
+    assert _resolve_tier(invalid) == "extended"

--- a/tests/test_programming_model_detection.py
+++ b/tests/test_programming_model_detection.py
@@ -216,6 +216,7 @@ x = 1
                 "status": "fail",
                 "items": [
                     {
+                        "rule_id": "check_programming_model_v2",
                         "label": "Unsupported programming model: Python v1",
                         "value": UNSUPPORTED_V1_VALUE,
                         "status": "fail",
@@ -240,6 +241,7 @@ x = 1
                 "status": "fail",
                 "items": [
                     {
+                        "rule_id": "check_programming_model_v2",
                         "label": "Python v2 programming model was not detected",
                         "value": UNKNOWN_VALUE,
                         "status": "fail",

--- a/tests/test_programming_model_detection.py
+++ b/tests/test_programming_model_detection.py
@@ -220,6 +220,8 @@ x = 1
                         "label": "Unsupported programming model: Python v1",
                         "value": UNSUPPORTED_V1_VALUE,
                         "status": "fail",
+                        "severity": "error",
+                        "tier": "core",
                         "hint": UNSUPPORTED_V1_HINT,
                     }
                 ],
@@ -245,6 +247,8 @@ x = 1
                         "label": "Python v2 programming model was not detected",
                         "value": UNKNOWN_VALUE,
                         "status": "fail",
+                        "severity": "error",
+                        "tier": "core",
                         "hint": UNKNOWN_HINT,
                     }
                 ],


### PR DESCRIPTION
## Context
Closes #310.

The rule model under-specified identity, severity, and tiers. `rules.schema.json` carried a freeform `severity` string that the runtime ignored, and a single `required` boolean conflated gate/severity/tier. Docs described Core/Extended/Experimental tiers that were not modeled, and `CheckResult` had no `rule_id`, forcing the SARIF reporter to reverse-map findings from the human-readable `label`.

## Changes
- **`rule_id` on every result → SARIF uses it directly.** `CheckResult` now carries `rule_id`; the SARIF reporter reads it as `ruleId` (no more fragile label reverse-mapping). The programming-model short-circuit result is tagged with the real `check_programming_model_v2` id.
- **Separate gate vs severity vs tier.** New module helpers `_resolve_severity`, `_resolve_gate`, `_resolve_tier` derive each concern independently, each falling back to `required` when unset (fully backward compatible).
- **Severity wired into runtime.** A failing handler maps to `fail` when severity is `error`, otherwise `warn`; a section only fails when the rule is a `gate`. `severity` is now constrained to `error`/`warning`/`info` in the schema.
- **Tier modeled explicitly.** `tier` enum `core`/`extended`/`experimental` added to the schema and emitted on each result.
- Emitted results now include `rule_id`, `severity`, and `tier`.
- Docs updated: `RULE_POLICY.md` (fields now enforced, not "proposed future") and `json_output_contract.md` (new item fields + SARIF `ruleId` semantics).

## Tests
- `test_cli_sarif_ruleid_propagates_from_rule_id` asserts every SARIF `ruleId` matches a driver rule id (round-trip of `rule_id` into SARIF).
- `test_resolve_severity_gate_tier_fallback_from_required` locks explicit-value and `required`-fallback behaviour for all three resolvers.
- Updated programming-model short-circuit expectations for the new `rule_id`.
- `make lint`, `make typecheck`, and the full suite pass; coverage 96.64% (≥95% gate).