### PR TITLE
chore(rules): remove unsupported metadata version no-op check

### DIFF
--- a/docs/RULE_POLICY.md
+++ b/docs/RULE_POLICY.md
@@ -98,7 +98,6 @@ Extended rules are included in `--profile full` but excluded from `--profile min
 | `check_openapi_version_mixing` | Heuristic signal detection across OpenAPI 3.0/3.1 usage |
 | `check_scan_before_spec` | Call-order heuristic; naming-based detection may miss custom flows |
 | `check_langgraph_anonymous_auth` | Applies only to LangGraph projects; heuristic auth-level detection |
-| `check_unsupported_metadata_version` | Depends on a configurable supported-version set; advisory only |
 
 ---
 

--- a/docs/rule_inventory.md
+++ b/docs/rule_inventory.md
@@ -37,7 +37,6 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `check_scan_before_spec` | Endpoint scan before spec build | framework | programming_model | `scan_before_spec` | No | full |
 | `check_langgraph_anonymous_auth` | LangGraph route authentication | configuration | security | `langgraph_anonymous_auth` | No | full |
 | `check_durable_nondeterminism` | Orchestrator determinism | framework | durable | `durable_nondeterminism` | Yes | minimal, full |
-| `check_unsupported_metadata_version` | Supported metadata version | configuration | extensions | `unsupported_metadata_version` | No | full |
 | `check_otel_trace_context_activation` | OTel trace-context activation | configuration | observability | `otel_activation` | No | full |
 
 ## Rule Types

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -383,14 +383,7 @@ Found unwanted files: ['tests/', '.venv']
 - **How to fix:** Move nondeterministic work into activity functions.
 - **Severity:** Required (`required: true`).
 
-## 29) `check_unsupported_metadata_version`
-
-- **What it checks:** `host.json` `extensionBundle.version` or a metadata file does not declare a version outside the configured supported set.
-- **Why it matters:** Unsupported metadata versions can fail at load or deploy time.
-- **How to fix:** Use a supported metadata/bundle version.
-- **Severity:** Warning only (`required: false`).
-
-## 30) `check_otel_trace_context_activation`
+## 29) `check_otel_trace_context_activation`
 
 - **What it checks:** In projects that opt into `azure-functions-logging` trace-context activation (`activate_trace_context=True` or `set_default_trace_context_activation`), an `opentelemetry` distribution is declared in `requirements.txt` or `pyproject.toml`.
 - **Why it matters:** `azure-functions-logging` silently degrades activation to a no-op when OpenTelemetry is unavailable, so requested trace context is dropped without any runtime error.

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -481,26 +481,6 @@
     "check_order": 39
   },
   {
-    "id": "check_unsupported_metadata_version",
-    "category": "configuration",
-    "section": "extensions",
-    "label": "Supported metadata version",
-    "description": "Warns when host.json extensionBundle.version or a metadata file declares a version outside the configured supported set.",
-    "type": "unsupported_metadata_version",
-    "required": false,
-    "condition": {
-      "files": ["*.meta.json", "extensions.json"],
-      "fields": ["metadataVersion", "metadata_version"],
-      "supported_versions": []
-    },
-    "hint": "Use a metadata/extension-bundle version supported by the current toolkit.",
-    "source_type": "heuristic",
-    "why_it_matters": "Unsupported metadata versions can be silently ignored or rejected by the runtime, causing bindings or extensions to fail to load.",
-    "symptoms": "Extensions or bindings fail to load; runtime rejects host configuration.",
-    "tags": ["metadata", "version", "extensions"],
-    "check_order": 40
-  },
-  {
     "id": "check_otel_trace_context_activation",
     "category": "configuration",
     "section": "observability",

--- a/tests/test_rule_loading.py
+++ b/tests/test_rule_loading.py
@@ -47,6 +47,9 @@ def test_function(req: func.HttpRequest) -> func.HttpResponse:
             assert "check_programming_model_v2" in rule_ids
             assert "check_http_trigger_bindings" not in rule_ids
             assert "check_timer_cron" not in rule_ids
+            # Removed in #311: shipped as a permanent no-op
+            # (empty supported_versions) with no authoritative version set.
+            assert "check_unsupported_metadata_version" not in rule_ids
 
     def test_rule_loading_uses_v2_rules_only(self) -> None:
         """Test that rule loading no longer branches on legacy programming models."""

--- a/tests/test_toolkit_rule_checks.py
+++ b/tests/test_toolkit_rule_checks.py
@@ -428,7 +428,6 @@ def test_new_rules_present_in_doctor_output(tmp_path: Path) -> None:
         "Endpoint scan before spec build",
         "LangGraph route authentication",
         "Orchestrator determinism",
-        "Supported metadata version",
         "OTel trace-context activation",
     ):
         assert label in labels


### PR DESCRIPTION
## Context
Closes #311.

`check_unsupported_metadata_version` shipped in the built-in ruleset with `condition.supported_versions: []`, so it could never produce a finding — a permanent no-op flagged during the Azure Functions 2026 rule audit.

## Decision: remove
There is no authoritative "supported metadata version" set to configure (the rule is `source_type: heuristic`, and extension-bundle version semantics are handled separately by the `host_json_extension_bundle_version` interval check). Rather than invent an arbitrary supported set, the rule is removed from the built-in `v2.json` ruleset.

The reusable `unsupported_metadata_version` **handler and collector are retained** and remain covered by their direct unit tests, so the mechanism is still available for a future, properly-configured rule.

## Changes
- Remove the `check_unsupported_metadata_version` entry from `assets/rules/v2.json` (built-in ruleset now ships 29 rules).
- Docs: drop the rule from `rule_inventory.md`, remove its per-rule section from `rules.md` (renumbering the OTel section), and remove its Extended-tier row from `RULE_POLICY.md`. `handlers.md` keeps documenting the retained handler mechanism.
- Tests: add a regression assertion in `test_rule_loading.py` that the built-in ruleset no longer ships the rule; drop the stale "Supported metadata version" expectation from `test_new_rules_present_in_doctor_output`. The handler/collector unit tests in `test_toolkit_rule_checks.py` are unchanged and still pass.

## Verification
- `make lint`, `make typecheck`, and the full suite pass; coverage 96.60% (≥95% gate).