### PR TITLE
style(handlers): resolve deferred review nits from #313/#314

### DIFF
--- a/docs/json_output_contract.md
+++ b/docs/json_output_contract.md
@@ -33,7 +33,7 @@ If `--output` is omitted, JSON is printed to stdout.
         {
           "rule_id": "check_python_version",
           "label": "Python version",
-          "value": "Python 3.9.18 (>=3.10)",
+          "value": "Python 3.9.18 (tool runtime, >=3.10) — unsupported target; Azure Functions supports Python 3.10–3.14",
           "status": "fail",
           "severity": "error",
           "tier": "core",

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -915,6 +915,7 @@ def is_local_prebuilt_deployment(path: Path, context: Optional["RuleContext"] = 
         return True
     return (path / ".python_packages").is_dir()
 
+
 def _detect_native_dependency_risks(content: str) -> list[tuple[str, str]]:
     """Return matching native-dependency packages in requirements order."""
     matches: list[tuple[str, str]] = []

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -51,9 +51,9 @@ from azure_functions_doctor.handlers._helpers import (
 )
 from azure_functions_doctor.target_resolver import (
     SUPPORTED_PYTHON_VERSIONS,
-is_supported_python_target,
-resolve_python_target,
-resolve_target_value,
+    is_supported_python_target,
+    resolve_python_target,
+    resolve_target_value,
 )
 
 


### PR DESCRIPTION
## Context
PRs #313 and #314 were squash-merged before their minor Copilot review comments were addressed. This PR resolves those deferred nits. No behaviour change.

## Changes
- **#313** — align the multi-line import continuation indentation in `registry.py` (`is_supported_python_target` / `resolve_*` were flush-left).
- **#313** — refresh the `docs/json_output_contract.md` example `value` to the current unsupported-target output shape (`… — unsupported target; Azure Functions supports Python 3.10–3.14`).
- **#314** — restore the two-blank-line PEP8 gap between `is_local_prebuilt_deployment` and `_detect_native_dependency_risks` in `_helpers.py`.

## Validation
- `make lint`, `make typecheck` clean
- full pytest suite green, coverage 96.58% (≥95%)