### PR TITLE
docs(doctor): copy-paste SARIF -> GitHub code scanning recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Use `azure-functions-doctor` as a CI gate to block deployments on required failu
     upload-sarif: "true"
 ```
 
-See [docs/examples/ci_integration.md](docs/examples/ci_integration.md) for Azure DevOps, pre-commit, VS Code, and SARIF upload examples.
+See [docs/examples/ci_integration.md](docs/examples/ci_integration.md) for Azure DevOps, pre-commit, VS Code, and SARIF upload examples — including a [minimal copy-paste SARIF → GitHub code scanning recipe](docs/examples/ci_integration.md#minimal-copy-paste-recipe-official-action).
 
 ## Demo
 

--- a/docs/examples/ci_integration.md
+++ b/docs/examples/ci_integration.md
@@ -289,6 +289,51 @@ Run it with **Terminal → Run Task → Azure Functions Doctor**. The JSON repor
 
 Upload doctor results as SARIF to surface findings in the GitHub Security tab:
 
+### Minimal copy-paste recipe (official Action)
+
+The fastest path is the official composite Action, which runs the doctor,
+produces SARIF, and calls `github/codeql-action/upload-sarif` for you. Copy this
+complete workflow into `.github/workflows/doctor-sarif.yml`:
+
+```yaml
+name: Doctor → Code Scanning
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write  # required for the SARIF upload
+
+jobs:
+  doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run azure-functions-doctor (SARIF → Code Scanning)
+        uses: yeongseon/azure-functions-doctor@v1
+        with:
+          path: .
+          profile: minimal
+          format: sarif
+          output: doctor.sarif
+          upload-sarif: "true"
+```
+
+That is the entire integration: findings appear in the repository's
+**Security → Code scanning** tab on every push and pull request. The Action's
+`format: sarif` + `upload-sarif: "true"` inputs map directly to the doctor CLI
+and the `upload-sarif` step in [`action.yml`](../../action.yml); no separate
+upload step is needed.
+
+If you would rather wire the raw CLI yourself (e.g. to customize the run), use the
+step-level fragment below instead.
+
+
 ```yaml
       - name: Run doctor (SARIF output)
         id: doctor

--- a/docs/examples/ci_integration.md
+++ b/docs/examples/ci_integration.md
@@ -325,10 +325,21 @@ jobs:
 ```
 
 That is the entire integration: findings appear in the repository's
-**Security → Code scanning** tab on every push and pull request. The Action's
+**Security → Code scanning** tab on pushes and on pull requests from
+branches in the same repository. The Action's
 `format: sarif` + `upload-sarif: "true"` inputs map directly to the doctor CLI
 and the `upload-sarif` step in [`action.yml`](../../action.yml); no separate
 upload step is needed.
+
+> **Fork pull requests.** Pull requests opened from a *fork* run with a
+> read-only `GITHUB_TOKEN`, so the SARIF upload step is blocked and findings
+> will not appear in Code scanning for those runs. This affects only
+> fork PRs; pushes and same-repository PRs upload normally.
+
+> **Action pinning.** This copy-paste template uses mutable tags
+> (`actions/checkout@v4`, `yeongseon/azure-functions-doctor@v1`) for readability.
+> For a hardened, immutable setup, pin each `uses:` to a full commit SHA (with a
+> `# vX` comment) so the referenced actions cannot change under you.
 
 If you would rather wire the raw CLI yourself (e.g. to customize the run), use the
 step-level fragment below instead.
@@ -347,7 +358,7 @@ step-level fragment below instead.
 
       - name: Upload SARIF to GitHub Code Scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: doctor.sarif
           category: azure-functions-doctor


### PR DESCRIPTION
## Summary
Tightens the SARIF → GitHub code scanning integration into a **minimal, self-contained, copy-pasteable** recipe.

- Adds a complete `.github/workflows/doctor-sarif.yml` workflow (checkout → official `yeongseon/azure-functions-doctor@v1` composite Action with `format: sarif` + `upload-sarif: "true"`), with `security-events: write` permission inline — findings land in **Security → Code scanning** with no separate upload step.
- Confirms the recipe against the **current action inputs** (`path`, `profile`, `format`, `output`, `upload-sarif`) as defined in `action.yml`.
- Preserves the existing raw-CLI fragment for users who want to wire it manually.
- Links the recipe from the README's CI-integration section.

Closes #324