### PR TITLE
docs: repoint rule hints to central hub pages

### DIFF
--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -372,7 +372,7 @@
       "decorators": ["with_context", "validate_http"]
     },
     "hint": "Move @validate_http below (closer to def) @with_context so it wraps first.",
-    "hint_url": "https://github.com/yeongseon/azure-functions-validation-python/blob/main/README.md#decorator-order",
+    "hint_url": "https://yeongseon.dev/azure-functions-python/platform/how-the-worker-binds-handlers/",
     "source_type": "heuristic",
     "why_it_matters": "Inverted decorator order lets @with_context wrap last, discarding the endpoint metadata attached by @validate_http and breaking OpenAPI generation.",
     "symptoms": "Missing or empty endpoint metadata at runtime; OpenAPI schema omits validated routes.",
@@ -389,7 +389,7 @@
     "required": false,
     "condition": {},
     "hint": "Add @validate_http to HTTP route handlers that should appear in the generated OpenAPI schema.",
-    "hint_url": "https://github.com/yeongseon/azure-functions-validation-python/blob/main/README.md#openapi-metadata",
+    "hint_url": "https://yeongseon.dev/contracts/endpoint/",
     "source_type": "heuristic",
     "why_it_matters": "Route handlers without @validate_http produce no endpoint metadata and stay invisible in auto-generated OpenAPI documentation.",
     "symptoms": "Endpoints missing from OpenAPI spec; incomplete API documentation.",


### PR DESCRIPTION
## Summary
- Repoint `check_decorator_order` rule `hint_url` → central worker-binding page (`https://yeongseon.dev/azure-functions-python/platform/how-the-worker-binds-handlers/`).
- Repoint `check_endpoint_metadata` rule `hint_url` → central endpoint metadata contract (`https://yeongseon.dev/contracts/endpoint/`).
- Flows through to SARIF `helpUri` (already wired in `cli.py`) and the `hint_url` surfaced by `doctor.py` — no code changes needed.

Part of the DX Toolkit "Platform mechanics" initiative: mechanism narrative lives once on the neutral hub; tools link to it.

The OTel trace-context rule hint is intentionally left pointing at the logging README for now — its central correlation page is still in flight (logging PRs #409-#411, hub #10). Because #333's checklist also covers repointing that OTel rule, this PR only completes part of it.

Refs #333 (kept open until the OTel/correlation hint can be repointed once the central correlation page lands).

## Test
- `make test` — 598 passed, 2 skipped, coverage 96.38%.
