### PR TITLE
feat(catalog): add version-controlled compatibility catalog with source and freshness metadata

### DIFF
--- a/src/azure_functions_doctor/assets/compatibility/catalog.json
+++ b/src/azure_functions_doctor/assets/compatibility/catalog.json
@@ -1,0 +1,127 @@
+{
+  "catalog_version": "1.0.0",
+  "last_verified": "2026-09-06",
+  "sources": {
+    "supported_languages": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+    "functions_versions": "https://learn.microsoft.com/azure/azure-functions/functions-versions",
+    "consumption_plan": "https://learn.microsoft.com/azure/azure-functions/consumption-plan"
+  },
+  "facts": [
+    {
+      "fact_id": "python-3.10-eos",
+      "category": "python_runtime_lifecycle",
+      "applies_to": { "python": "3.10" },
+      "status": "supported",
+      "support_end": { "value": "2026-10", "precision": "month" },
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn 'Supported languages' lists Python 3.10 GA end-of-support as 'October 2026' (month precision, no day published)."
+    },
+    {
+      "fact_id": "python-3.11-eos",
+      "category": "python_runtime_lifecycle",
+      "applies_to": { "python": "3.11" },
+      "status": "supported",
+      "support_end": { "value": "2027-10", "precision": "month" },
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn 'Supported languages' lists Python 3.11 GA end-of-support as 'October 2027' (month precision)."
+    },
+    {
+      "fact_id": "python-3.12-eos",
+      "category": "python_runtime_lifecycle",
+      "applies_to": { "python": "3.12" },
+      "status": "supported",
+      "support_end": { "value": "2028-10", "precision": "month" },
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn 'Supported languages' lists Python 3.12 GA end-of-support as 'October 2028' (month precision)."
+    },
+    {
+      "fact_id": "python-3.13-eos",
+      "category": "python_runtime_lifecycle",
+      "applies_to": { "python": "3.13" },
+      "status": "supported",
+      "support_end": { "value": "2029-10", "precision": "month" },
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn 'Supported languages' lists Python 3.13 GA end-of-support as 'October 2029' (month precision)."
+    },
+    {
+      "fact_id": "python-3.14-eos",
+      "category": "python_runtime_lifecycle",
+      "applies_to": { "python": "3.14" },
+      "status": "supported",
+      "support_end": { "value": "2030-10", "precision": "month" },
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn 'Supported languages' lists Python 3.14 GA end-of-support as 'October 2030' (month precision)."
+    },
+    {
+      "fact_id": "hosting-plan-python-cap-linux-consumption",
+      "category": "hosting_plan_python_cap",
+      "applies_to": { "hosting_plan": "linux-consumption" },
+      "max_python": "3.12",
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn: 'Python 3.12 is the last Python version supported for Linux Consumption plan apps. Newer Python versions aren't added to Linux Consumption.'"
+    },
+    {
+      "fact_id": "hosting-plan-python-cap-flex-consumption",
+      "category": "hosting_plan_python_cap",
+      "applies_to": { "hosting_plan": "flex-consumption" },
+      "max_python": null,
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Flex Consumption tracks the newer Python runtimes; no cap below the globally supported set."
+    },
+    {
+      "fact_id": "hosting-plan-python-cap-premium",
+      "category": "hosting_plan_python_cap",
+      "applies_to": { "hosting_plan": "premium" },
+      "max_python": null,
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Elastic Premium tracks the newer Python runtimes; no cap below the globally supported set."
+    },
+    {
+      "fact_id": "hosting-plan-python-cap-dedicated",
+      "category": "hosting_plan_python_cap",
+      "applies_to": { "hosting_plan": "dedicated" },
+      "max_python": null,
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Dedicated (App Service) plan tracks the newer Python runtimes; no cap below the globally supported set."
+    },
+    {
+      "fact_id": "linux-consumption-retirement",
+      "category": "hosting_plan_lifecycle",
+      "applies_to": { "hosting_plan": "linux-consumption" },
+      "status": "retiring",
+      "support_end": { "value": "2028-09-30", "precision": "day" },
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/consumption-plan",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn: 'The option to host function apps on Linux in a Consumption plan is retiring on 30 September 2028.'"
+    },
+    {
+      "fact_id": "functions-runtime-v1-eos",
+      "category": "functions_runtime_lifecycle",
+      "applies_to": { "functions_runtime": "1.x" },
+      "status": "unsupported",
+      "support_end": { "value": "2026-09-14", "precision": "day" },
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-versions",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn 'Compare Azure Functions runtime versions': 'Support ends for version 1.x on September 14, 2026.'"
+    },
+    {
+      "fact_id": "functions-runtime-v3-linux-consumption-stop",
+      "category": "functions_runtime_lifecycle",
+      "applies_to": { "functions_runtime": "3.x", "hosting_plan": "linux-consumption" },
+      "status": "unsupported",
+      "support_end": { "value": "2026-09-30", "precision": "day" },
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-versions",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn: 'Function apps still running the end-of-life v3 runtime on Linux in a Consumption plan stop running after September 30, 2026.'"
+    }
+  ]
+}

--- a/src/azure_functions_doctor/assets/compatibility/catalog.json
+++ b/src/azure_functions_doctor/assets/compatibility/catalog.json
@@ -107,11 +107,40 @@
       "fact_id": "functions-runtime-v1-eos",
       "category": "functions_runtime_lifecycle",
       "applies_to": { "functions_runtime": "1.x" },
-      "status": "unsupported",
+      "status": "retiring",
       "support_end": { "value": "2026-09-14", "precision": "day" },
       "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-versions",
       "last_verified": "2026-09-06",
-      "verification_notes": "Microsoft Learn 'Compare Azure Functions runtime versions': 'Support ends for version 1.x on September 14, 2026.'"
+      "verification_notes": "Microsoft Learn 'Compare Azure Functions runtime versions': 'Support ends for version 1.x on September 14, 2026.' Retiring as of the last verification (end date in the future); GA only for C#/.NET Framework apps."
+    },
+    {
+      "fact_id": "functions-runtime-v2-eos",
+      "category": "functions_runtime_lifecycle",
+      "applies_to": { "functions_runtime": "2.x" },
+      "status": "unsupported",
+      "support_end": { "value": "2022-12-13", "precision": "day" },
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-versions",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn 'Compare Azure Functions runtime versions': runtime 2.x reached end of extended support on December 13, 2022."
+    },
+    {
+      "fact_id": "functions-runtime-v3-eos",
+      "category": "functions_runtime_lifecycle",
+      "applies_to": { "functions_runtime": "3.x" },
+      "status": "unsupported",
+      "support_end": { "value": "2022-12-13", "precision": "day" },
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-versions",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn 'Compare Azure Functions runtime versions': runtime 3.x reached end of extended support on December 13, 2022."
+    },
+    {
+      "fact_id": "functions-runtime-v4-supported",
+      "category": "functions_runtime_lifecycle",
+      "applies_to": { "functions_runtime": "4.x" },
+      "status": "supported",
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-versions",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn 'Compare Azure Functions runtime versions': 4.x is GA and the recommended runtime for all languages; no end-of-support date is published."
     },
     {
       "fact_id": "functions-runtime-v3-linux-consumption-stop",

--- a/src/azure_functions_doctor/compatibility.py
+++ b/src/azure_functions_doctor/compatibility.py
@@ -1,0 +1,276 @@
+"""Version-controlled Azure Functions compatibility catalog.
+
+This module loads a version-controlled snapshot of Azure Functions support-matrix
+facts (Python version lifecycle, hosting-plan Python caps, runtime lifecycle) from
+``assets/compatibility/catalog.json``. The catalog is the single, auditable source
+of truth for every date/compatibility rule: each fact carries a source URL and a
+``last_verified`` date, and lifecycle dates are tagged with the *precision* at which
+Microsoft publishes them (day / month / year) so the tool never renders a more
+precise date than the source provides.
+
+No runtime network calls are made; the catalog ships with the package.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import importlib.resources
+import json
+from typing import Literal, Optional, cast
+
+from azure_functions_doctor.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Number of days after which the shipped catalog is considered stale. Staleness is
+# a property of the catalog snapshot itself, reported separately from any finding
+# severity: a stale catalog emits its own ``catalog_stale`` warning, never an error
+# on the diagnosed project.
+CATALOG_STALENESS_THRESHOLD_DAYS = 180
+
+Precision = Literal["day", "month", "year"]
+
+_MONTH_NAMES = (
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+)
+
+
+def _parse_major_minor(version: str) -> Optional[tuple[int, int]]:
+    """Return the ``(major, minor)`` pair for a ``"3.12"``-style string."""
+    parts = version.split(".")
+    if len(parts) < 2:
+        return None
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class SupportEnd:
+    """A lifecycle end date modelled at the precision the source publishes.
+
+    ``value`` is ``YYYY-MM-DD`` for day precision, ``YYYY-MM`` for month precision,
+    and ``YYYY`` for year precision. ``render`` formats the value at that precision
+    and never synthesizes finer detail than the source provides.
+    """
+
+    value: str
+    precision: Precision
+
+    def render(self) -> str:
+        """Render the date at its stated precision (e.g. ``"October 2026"``)."""
+        parts = self.value.split("-")
+        try:
+            if self.precision == "day" and len(parts) == 3:
+                year, month, day = int(parts[0]), int(parts[1]), int(parts[2])
+                return f"{_MONTH_NAMES[month - 1]} {day}, {year}"
+            if self.precision == "month" and len(parts) >= 2:
+                year, month = int(parts[0]), int(parts[1])
+                return f"{_MONTH_NAMES[month - 1]} {year}"
+            if self.precision == "year":
+                return str(int(parts[0]))
+        except (ValueError, IndexError):
+            logger.warning(
+                "Malformed support_end value %r for precision %s", self.value, self.precision
+            )
+        return self.value
+
+
+@dataclass(frozen=True)
+class Fact:
+    """A single catalog fact with source and freshness metadata."""
+
+    fact_id: str
+    category: str
+    applies_to: dict[str, str]
+    source_url: str
+    last_verified: str
+    verification_notes: str
+    status: Optional[str] = None
+    support_end: Optional[SupportEnd] = None
+    max_python: Optional[str] = None
+    supersedes: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Freshness:
+    """Freshness state of the catalog snapshot, independent of any finding."""
+
+    last_verified: str
+    age_days: int
+    is_stale: bool
+    threshold_days: int
+
+
+@dataclass(frozen=True)
+class Catalog:
+    """Parsed, in-memory view of the compatibility catalog."""
+
+    catalog_version: str
+    last_verified: str
+    sources: dict[str, str]
+    facts: tuple[Fact, ...]
+
+    def get_fact(self, fact_id: str) -> Optional[Fact]:
+        """Return the fact with ``fact_id`` or ``None``."""
+        for fact in self.facts:
+            if fact.fact_id == fact_id:
+                return fact
+        return None
+
+    def facts_by_category(self, category: str) -> tuple[Fact, ...]:
+        """Return all facts in ``category`` in catalog order."""
+        return tuple(fact for fact in self.facts if fact.category == category)
+
+    def python_versions(self) -> tuple[str, ...]:
+        """Return supported Python ``major.minor`` versions, sorted ascending."""
+        versions = [
+            fact.applies_to["python"]
+            for fact in self.facts_by_category("python_runtime_lifecycle")
+            if "python" in fact.applies_to
+        ]
+        return tuple(sorted(versions, key=lambda v: _parse_major_minor(v) or (0, 0)))
+
+    def python_eos(self, version: str) -> Optional[SupportEnd]:
+        """Return the published end-of-support date for a Python ``version``."""
+        target = _parse_major_minor(version)
+        if target is None:
+            return None
+        for fact in self.facts_by_category("python_runtime_lifecycle"):
+            applies = fact.applies_to.get("python")
+            if applies is not None and _parse_major_minor(applies) == target:
+                return fact.support_end
+        return None
+
+    def hosting_plan_matrix(self) -> dict[str, tuple[str, ...]]:
+        """Reconstruct the per-plan supported-Python matrix from the catalog.
+
+        Each plan's allow-list is the globally supported Python set filtered by that
+        plan's ``max_python`` cap (plans without a cap track the full set).
+        """
+        supported = self.python_versions()
+        matrix: dict[str, tuple[str, ...]] = {}
+        for fact in self.facts_by_category("hosting_plan_python_cap"):
+            plan = fact.applies_to.get("hosting_plan")
+            if plan is None:
+                continue
+            cap = _parse_major_minor(fact.max_python) if fact.max_python else None
+            if cap is None:
+                matrix[plan] = supported
+            else:
+                matrix[plan] = tuple(
+                    v for v in supported if (_parse_major_minor(v) or (0, 0)) <= cap
+                )
+        return matrix
+
+    def freshness(self, today: Optional[date] = None) -> Freshness:
+        """Return the catalog's freshness state relative to ``today``."""
+        current = today if today is not None else date.today()
+        try:
+            verified = date.fromisoformat(self.last_verified)
+            age_days = (current - verified).days
+        except ValueError:
+            logger.warning("Malformed catalog last_verified %r", self.last_verified)
+            age_days = 0
+        return Freshness(
+            last_verified=self.last_verified,
+            age_days=age_days,
+            is_stale=age_days > CATALOG_STALENESS_THRESHOLD_DAYS,
+            threshold_days=CATALOG_STALENESS_THRESHOLD_DAYS,
+        )
+
+
+def _parse_support_end(raw: Optional[dict[str, str]]) -> Optional[SupportEnd]:
+    if raw is None:
+        return None
+    value = raw.get("value")
+    precision = raw.get("precision")
+    if value is None or precision not in ("day", "month", "year"):
+        return None
+    return SupportEnd(value=value, precision=cast(Precision, precision))
+
+
+def _parse_fact(raw: dict[str, object]) -> Fact:
+    support_end_raw = raw.get("support_end")
+    support_end = _parse_support_end(support_end_raw if isinstance(support_end_raw, dict) else None)
+    applies_raw = raw.get("applies_to")
+    applies_to = (
+        {str(k): str(v) for k, v in applies_raw.items()} if isinstance(applies_raw, dict) else {}
+    )
+    max_python = raw.get("max_python")
+    supersedes = raw.get("supersedes")
+    status = raw.get("status")
+    return Fact(
+        fact_id=str(raw.get("fact_id", "")),
+        category=str(raw.get("category", "")),
+        applies_to=applies_to,
+        source_url=str(raw.get("source_url", "")),
+        last_verified=str(raw.get("last_verified", "")),
+        verification_notes=str(raw.get("verification_notes", "")),
+        status=str(status) if isinstance(status, str) else None,
+        support_end=support_end,
+        max_python=str(max_python) if isinstance(max_python, str) else None,
+        supersedes=str(supersedes) if isinstance(supersedes, str) else None,
+    )
+
+
+def _build_catalog(raw: dict[str, object]) -> Catalog:
+    sources_raw = raw.get("sources")
+    sources = (
+        {str(k): str(v) for k, v in sources_raw.items()} if isinstance(sources_raw, dict) else {}
+    )
+    facts_raw = raw.get("facts")
+    facts = (
+        tuple(_parse_fact(item) for item in facts_raw if isinstance(item, dict))
+        if isinstance(facts_raw, list)
+        else ()
+    )
+    return Catalog(
+        catalog_version=str(raw.get("catalog_version", "")),
+        last_verified=str(raw.get("last_verified", "")),
+        sources=sources,
+        facts=facts,
+    )
+
+
+_CATALOG_CACHE: Optional[Catalog] = None
+
+
+def load_catalog() -> Catalog:
+    """Load and cache the version-controlled compatibility catalog.
+
+    The catalog ships with the package under ``assets/compatibility/catalog.json``;
+    no network calls are made.
+    """
+    global _CATALOG_CACHE
+    if _CATALOG_CACHE is not None:
+        return _CATALOG_CACHE
+
+    catalog_path = importlib.resources.files("azure_functions_doctor.assets").joinpath(
+        "compatibility/catalog.json"
+    )
+    try:
+        with catalog_path.open(encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except FileNotFoundError as exc:  # pragma: no cover - packaging safeguard
+        logger.error("compatibility catalog.json not found")
+        raise RuntimeError("compatibility catalog.json not found") from exc
+    except json.JSONDecodeError as exc:  # pragma: no cover - packaging safeguard
+        logger.error("Invalid JSON in catalog.json: %s", exc)
+        raise RuntimeError(f"Failed to parse catalog.json: {exc}") from exc
+
+    _CATALOG_CACHE = _build_catalog(raw)
+    return _CATALOG_CACHE

--- a/src/azure_functions_doctor/compatibility.py
+++ b/src/azure_functions_doctor/compatibility.py
@@ -13,11 +13,12 @@ No runtime network calls are made; the catalog ships with the package.
 
 from __future__ import annotations
 
+import calendar
 from dataclasses import dataclass
 from datetime import date
 import importlib.resources
 import json
-from typing import Literal, Optional, cast
+from typing import Literal, Optional
 
 from azure_functions_doctor.logging_config import get_logger
 
@@ -75,10 +76,11 @@ class SupportEnd:
         parts = self.value.split("-")
         try:
             if self.precision == "day" and len(parts) == 3:
-                year, month, day = int(parts[0]), int(parts[1]), int(parts[2])
-                return f"{_MONTH_NAMES[month - 1]} {day}, {year}"
+                validated = date(int(parts[0]), int(parts[1]), int(parts[2]))
+                return f"{_MONTH_NAMES[validated.month - 1]} {validated.day}, {validated.year}"
             if self.precision == "month" and len(parts) >= 2:
                 year, month = int(parts[0]), int(parts[1])
+                date(year, month, 1)  # validate month is in 1..12
                 return f"{_MONTH_NAMES[month - 1]} {year}"
             if self.precision == "year":
                 return str(int(parts[0]))
@@ -87,6 +89,30 @@ class SupportEnd:
                 "Malformed support_end value %r for precision %s", self.value, self.precision
             )
         return self.value
+
+    def end_date(self) -> Optional[date]:
+        """Return the last calendar day covered by this support-end value.
+
+        For month precision the last day of the month is used, and for year
+        precision December 31, so date comparisons never treat a coarse value as
+        expiring earlier than the source guarantees. Malformed values yield
+        ``None``.
+        """
+        parts = self.value.split("-")
+        try:
+            if self.precision == "day" and len(parts) == 3:
+                return date(int(parts[0]), int(parts[1]), int(parts[2]))
+            if self.precision == "month" and len(parts) >= 2:
+                year, month = int(parts[0]), int(parts[1])
+                last_day = calendar.monthrange(year, month)[1]
+                return date(year, month, last_day)
+            if self.precision == "year":
+                return date(int(parts[0]), 12, 31)
+        except (ValueError, IndexError):
+            logger.warning(
+                "Malformed support_end value %r for precision %s", self.value, self.precision
+            )
+        return None
 
 
 @dataclass(frozen=True)
@@ -103,6 +129,27 @@ class Fact:
     support_end: Optional[SupportEnd] = None
     max_python: Optional[str] = None
     supersedes: Optional[str] = None
+
+    def effective_status(self, today: Optional[date] = None) -> Optional[str]:
+        """Return the status reconciled with ``today`` and ``support_end``.
+
+        The stored ``status`` is the source-verified baseline. When an
+        end-of-support date is known this reconciles it with the calendar so a
+        future end date is never reported as ``unsupported`` and a past end date
+        is never reported as still supported. The transition is deterministic and
+        self-correcting as time passes, without re-verifying the catalog.
+        """
+        if self.support_end is None:
+            return self.status
+        eos = self.support_end.end_date()
+        if eos is None:
+            return self.status
+        current = today if today is not None else date.today()
+        if current > eos:
+            return "unsupported"
+        if self.status == "unsupported":
+            return "retiring"
+        return self.status
 
 
 @dataclass(frozen=True)
@@ -135,14 +182,31 @@ class Catalog:
         """Return all facts in ``category`` in catalog order."""
         return tuple(fact for fact in self.facts if fact.category == category)
 
-    def python_versions(self) -> tuple[str, ...]:
-        """Return supported Python ``major.minor`` versions, sorted ascending."""
+    def known_python_versions(self) -> tuple[str, ...]:
+        """Return every Python ``major.minor`` in the catalog, sorted ascending."""
         versions = [
             fact.applies_to["python"]
             for fact in self.facts_by_category("python_runtime_lifecycle")
             if "python" in fact.applies_to
         ]
         return tuple(sorted(versions, key=lambda v: _parse_major_minor(v) or (0, 0)))
+
+    def supported_python_versions(self, as_of: Optional[date] = None) -> tuple[str, ...]:
+        """Return Python versions still supported as of ``as_of`` (default today).
+
+        A version is supported unless its effective status (baseline status
+        reconciled with its end-of-support date) is ``"unsupported"``.
+        """
+        versions = [
+            fact.applies_to["python"]
+            for fact in self.facts_by_category("python_runtime_lifecycle")
+            if "python" in fact.applies_to and fact.effective_status(as_of) != "unsupported"
+        ]
+        return tuple(sorted(versions, key=lambda v: _parse_major_minor(v) or (0, 0)))
+
+    def python_versions(self) -> tuple[str, ...]:
+        """Backward-compatible alias for :meth:`known_python_versions`."""
+        return self.known_python_versions()
 
     def python_eos(self, version: str) -> Optional[SupportEnd]:
         """Return the published end-of-support date for a Python ``version``."""
@@ -161,7 +225,7 @@ class Catalog:
         Each plan's allow-list is the globally supported Python set filtered by that
         plan's ``max_python`` cap (plans without a cap track the full set).
         """
-        supported = self.python_versions()
+        supported = self.supported_python_versions()
         matrix: dict[str, tuple[str, ...]] = {}
         for fact in self.facts_by_category("hosting_plan_python_cap"):
             plan = fact.applies_to.get("hosting_plan")
@@ -193,14 +257,23 @@ class Catalog:
         )
 
 
-def _parse_support_end(raw: Optional[dict[str, str]]) -> Optional[SupportEnd]:
+def _parse_support_end(raw: Optional[dict[str, object]]) -> Optional[SupportEnd]:
     if raw is None:
         return None
     value = raw.get("value")
     precision = raw.get("precision")
-    if value is None or precision not in ("day", "month", "year"):
+    if not isinstance(value, str) or precision not in ("day", "month", "year"):
         return None
-    return SupportEnd(value=value, precision=cast(Precision, precision))
+    return SupportEnd(value=value, precision=precision)
+
+
+def _as_str(value: object, default: str = "") -> str:
+    """Return ``value`` when it is a string, else ``default``.
+
+    Unlike ``str(value)`` this never turns an explicit JSON ``null`` into the
+    literal ``"None"``, preserving the module's tolerant-parsing contract.
+    """
+    return value if isinstance(value, str) else default
 
 
 def _parse_fact(raw: dict[str, object]) -> Fact:
@@ -214,12 +287,12 @@ def _parse_fact(raw: dict[str, object]) -> Fact:
     supersedes = raw.get("supersedes")
     status = raw.get("status")
     return Fact(
-        fact_id=str(raw.get("fact_id", "")),
-        category=str(raw.get("category", "")),
+        fact_id=_as_str(raw.get("fact_id")),
+        category=_as_str(raw.get("category")),
         applies_to=applies_to,
-        source_url=str(raw.get("source_url", "")),
-        last_verified=str(raw.get("last_verified", "")),
-        verification_notes=str(raw.get("verification_notes", "")),
+        source_url=_as_str(raw.get("source_url")),
+        last_verified=_as_str(raw.get("last_verified")),
+        verification_notes=_as_str(raw.get("verification_notes")),
         status=str(status) if isinstance(status, str) else None,
         support_end=support_end,
         max_python=str(max_python) if isinstance(max_python, str) else None,
@@ -271,6 +344,10 @@ def load_catalog() -> Catalog:
     except json.JSONDecodeError as exc:  # pragma: no cover - packaging safeguard
         logger.error("Invalid JSON in catalog.json: %s", exc)
         raise RuntimeError(f"Failed to parse catalog.json: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        logger.error("catalog.json root is not a JSON object")
+        raise RuntimeError("catalog.json root must be a JSON object")
 
     _CATALOG_CACHE = _build_catalog(raw)
     return _CATALOG_CACHE

--- a/src/azure_functions_doctor/target_resolver.py
+++ b/src/azure_functions_doctor/target_resolver.py
@@ -5,26 +5,26 @@ import subprocess  # nosec B404
 import sys
 from typing import Callable, Dict, Optional, Tuple
 
+from azure_functions_doctor.compatibility import load_catalog
 from azure_functions_doctor.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-# Python versions supported by Azure Functions (2026). Anything outside this
-# inclusive major.minor set is unsupported and should fail diagnostics.
-SUPPORTED_PYTHON_VERSIONS: Tuple[str, ...] = ("3.10", "3.11", "3.12", "3.13", "3.14")
-
-# Python support is not uniform across Azure Functions hosting plans. Linux
-# Consumption is capped at Python 3.12 ("the last Python version supported for
-# Linux Consumption plan apps"), while Flex Consumption, Premium (Elastic
-# Premium), and Dedicated (App Service) plans track the newer runtimes. A flat
-# allow-list would pass invalid combinations such as Python 3.14 on Linux
-# Consumption, so support is modelled as a per-plan matrix.
-PYTHON_HOSTING_PLAN_MATRIX: Dict[str, Tuple[str, ...]] = {
-    "linux-consumption": ("3.10", "3.11", "3.12"),
-    "flex-consumption": ("3.10", "3.11", "3.12", "3.13", "3.14"),
-    "premium": ("3.10", "3.11", "3.12", "3.13", "3.14"),
-    "dedicated": ("3.10", "3.11", "3.12", "3.13", "3.14"),
-}
+# Python versions supported by Azure Functions and the per-plan support matrix are
+# derived from the version-controlled compatibility catalog
+# (assets/compatibility/catalog.json), the single auditable source of truth for
+# every date/compatibility fact. The names below are preserved for backward
+# compatibility with existing handler and CLI imports.
+#
+# Python support is not uniform across hosting plans: Linux Consumption is capped
+# at Python 3.12 ("the last Python version supported for Linux Consumption plan
+# apps"), while Flex Consumption, Premium (Elastic Premium), and Dedicated (App
+# Service) plans track the newer runtimes. A flat allow-list would pass invalid
+# combinations such as Python 3.14 on Linux Consumption, so support is modelled as
+# a per-plan matrix.
+_CATALOG = load_catalog()
+SUPPORTED_PYTHON_VERSIONS: Tuple[str, ...] = _CATALOG.python_versions()
+PYTHON_HOSTING_PLAN_MATRIX: Dict[str, Tuple[str, ...]] = dict(_CATALOG.hosting_plan_matrix())
 
 # Hosting plans recognized by the Python-version compatibility matrix.
 SUPPORTED_HOSTING_PLANS: Tuple[str, ...] = tuple(PYTHON_HOSTING_PLAN_MATRIX)

--- a/src/azure_functions_doctor/target_resolver.py
+++ b/src/azure_functions_doctor/target_resolver.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 # combinations such as Python 3.14 on Linux Consumption, so support is modelled as
 # a per-plan matrix.
 _CATALOG = load_catalog()
-SUPPORTED_PYTHON_VERSIONS: Tuple[str, ...] = _CATALOG.python_versions()
+SUPPORTED_PYTHON_VERSIONS: Tuple[str, ...] = _CATALOG.supported_python_versions()
 PYTHON_HOSTING_PLAN_MATRIX: Dict[str, Tuple[str, ...]] = dict(_CATALOG.hosting_plan_matrix())
 
 # Hosting plans recognized by the Python-version compatibility matrix.
@@ -69,7 +69,6 @@ def is_supported_python_for_plan(version: str, plan: str) -> bool:
     if parsed is None:
         return False
     supported = {_major_minor(v) for v in allowed}
-    return parsed in supported
     return parsed in supported
 
 

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,244 @@
+"""Tests for the version-controlled Azure Functions compatibility catalog."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+import azure_functions_doctor.compatibility as compatibility_module
+from azure_functions_doctor.compatibility import (
+    CATALOG_STALENESS_THRESHOLD_DAYS,
+    Catalog,
+    Fact,
+    SupportEnd,
+    _build_catalog,
+    _parse_fact,
+    _parse_major_minor,
+    _parse_support_end,
+    load_catalog,
+)
+
+
+def test_load_catalog_is_cached() -> None:
+    """The catalog is parsed once and the same instance is returned."""
+    first = load_catalog()
+    second = load_catalog()
+    assert first is second
+    assert first.catalog_version == "1.0.0"
+    assert first.last_verified == "2026-09-06"
+    assert "supported_languages" in first.sources
+
+
+def test_python_versions_sorted_ascending() -> None:
+    catalog = load_catalog()
+    assert catalog.python_versions() == ("3.10", "3.11", "3.12", "3.13", "3.14")
+
+
+def test_hosting_plan_matrix_matches_published_caps() -> None:
+    catalog = load_catalog()
+    matrix = catalog.hosting_plan_matrix()
+    assert matrix["linux-consumption"] == ("3.10", "3.11", "3.12")
+    assert matrix["flex-consumption"] == ("3.10", "3.11", "3.12", "3.13", "3.14")
+    assert matrix["premium"] == ("3.10", "3.11", "3.12", "3.13", "3.14")
+    assert matrix["dedicated"] == ("3.10", "3.11", "3.12", "3.13", "3.14")
+
+
+def test_python_eos_renders_month_precision() -> None:
+    catalog = load_catalog()
+    support_end = catalog.python_eos("3.10")
+    assert support_end is not None
+    assert support_end.precision == "month"
+    assert support_end.render() == "October 2026"
+
+
+def test_python_eos_accepts_patch_versions() -> None:
+    catalog = load_catalog()
+    assert catalog.python_eos("3.12.4") is not None
+
+
+def test_python_eos_unknown_returns_none() -> None:
+    catalog = load_catalog()
+    assert catalog.python_eos("3.99") is None
+
+
+def test_python_eos_unparseable_returns_none() -> None:
+    catalog = load_catalog()
+    assert catalog.python_eos("not-a-version") is None
+
+
+def test_get_fact_found_and_missing() -> None:
+    catalog = load_catalog()
+    assert catalog.get_fact("python-3.10-eos") is not None
+    assert catalog.get_fact("does-not-exist") is None
+
+
+def test_facts_by_category() -> None:
+    catalog = load_catalog()
+    lifecycle = catalog.facts_by_category("python_runtime_lifecycle")
+    assert len(lifecycle) == 5
+    assert catalog.facts_by_category("no-such-category") == ()
+
+
+def test_runtime_lifecycle_day_precision_facts() -> None:
+    catalog = load_catalog()
+    v1 = catalog.get_fact("functions-runtime-v1-eos")
+    assert v1 is not None
+    assert v1.support_end is not None
+    assert v1.support_end.precision == "day"
+    assert v1.support_end.render() == "September 14, 2026"
+
+
+def test_linux_consumption_retirement_day_precision() -> None:
+    catalog = load_catalog()
+    fact = catalog.get_fact("linux-consumption-retirement")
+    assert fact is not None
+    assert fact.status == "retiring"
+    assert fact.support_end is not None
+    assert fact.support_end.render() == "September 30, 2028"
+
+
+def test_parse_major_minor_edge_cases() -> None:
+    assert _parse_major_minor("3.12") == (3, 12)
+    assert _parse_major_minor("3") is None
+    assert _parse_major_minor("x.y") is None
+
+
+def test_support_end_render_year_precision() -> None:
+    assert SupportEnd(value="2030", precision="year").render() == "2030"
+
+
+def test_support_end_render_malformed_returns_raw() -> None:
+    # Precision claims a day but the value is malformed: render falls back to raw.
+    assert SupportEnd(value="nope", precision="day").render() == "nope"
+
+
+def test_freshness_fresh_catalog() -> None:
+    catalog = load_catalog()
+    freshness = catalog.freshness(today=date(2026, 9, 6))
+    assert freshness.age_days == 0
+    assert freshness.is_stale is False
+    assert freshness.threshold_days == CATALOG_STALENESS_THRESHOLD_DAYS
+
+
+def test_freshness_stale_catalog() -> None:
+    catalog = load_catalog()
+    beyond = date(2026, 9, 6)
+    freshness = catalog.freshness(today=beyond.replace(year=beyond.year + 2))
+    assert freshness.is_stale is True
+
+
+def test_freshness_default_today_uses_current_date() -> None:
+    catalog = load_catalog()
+    freshness = catalog.freshness()
+    assert freshness.age_days >= 0
+
+
+def test_freshness_malformed_last_verified() -> None:
+    catalog = Catalog(
+        catalog_version="1.0.0",
+        last_verified="not-a-date",
+        sources={},
+        facts=(),
+    )
+    freshness = catalog.freshness(today=date(2026, 9, 6))
+    assert freshness.age_days == 0
+    assert freshness.is_stale is False
+
+
+def test_parse_support_end_none_and_invalid() -> None:
+    assert _parse_support_end(None) is None
+    assert _parse_support_end({"precision": "day"}) is None
+    assert _parse_support_end({"value": "2026", "precision": "decade"}) is None
+    parsed = _parse_support_end({"value": "2026-10", "precision": "month"})
+    assert parsed == SupportEnd(value="2026-10", precision="month")
+
+
+def test_parse_fact_tolerates_missing_and_wrong_types() -> None:
+    fact = _parse_fact(
+        {
+            "fact_id": "x",
+            "category": "python_runtime_lifecycle",
+            "applies_to": "not-a-dict",
+            "support_end": "not-a-dict",
+            "max_python": 3,
+            "supersedes": None,
+            "status": 42,
+        }
+    )
+    assert isinstance(fact, Fact)
+    assert fact.applies_to == {}
+    assert fact.support_end is None
+    assert fact.max_python is None
+    assert fact.supersedes is None
+    assert fact.status is None
+
+
+def test_build_catalog_tolerates_missing_sections() -> None:
+    catalog = _build_catalog({})
+    assert catalog.catalog_version == ""
+    assert catalog.sources == {}
+    assert catalog.facts == ()
+
+
+def test_build_catalog_skips_non_dict_facts() -> None:
+    catalog = _build_catalog(
+        {
+            "sources": {"a": "b"},
+            "facts": ["not-a-dict", {"fact_id": "ok", "category": "c"}],
+        }
+    )
+    assert len(catalog.facts) == 1
+    assert catalog.facts[0].fact_id == "ok"
+
+
+def test_python_versions_ignores_facts_without_python_key() -> None:
+    catalog = Catalog(
+        catalog_version="1.0.0",
+        last_verified="2026-09-06",
+        sources={},
+        facts=(
+            Fact(
+                fact_id="no-python",
+                category="python_runtime_lifecycle",
+                applies_to={},
+                source_url="",
+                last_verified="",
+                verification_notes="",
+            ),
+        ),
+    )
+    assert catalog.python_versions() == ()
+
+
+def test_reload_after_cache_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resetting the module cache forces a fresh parse from disk."""
+    monkeypatch.setattr(compatibility_module, "_CATALOG_CACHE", None)
+    catalog = load_catalog()
+    assert catalog.catalog_version == "1.0.0"
+
+
+def test_support_end_render_out_of_range_month_falls_back() -> None:
+    # Month 13 triggers an IndexError inside render, which is logged and the
+    # raw value returned unchanged.
+    assert SupportEnd(value="2026-13-40", precision="day").render() == "2026-13-40"
+
+
+def test_hosting_plan_matrix_skips_fact_without_plan() -> None:
+    catalog = Catalog(
+        catalog_version="1.0.0",
+        last_verified="2026-09-06",
+        sources={},
+        facts=(
+            Fact(
+                fact_id="cap-no-plan",
+                category="hosting_plan_python_cap",
+                applies_to={},
+                source_url="",
+                last_verified="",
+                verification_notes="",
+                max_python="3.12",
+            ),
+        ),
+    )
+    assert catalog.hosting_plan_matrix() == {}

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date
+import json
 
 import pytest
 
@@ -242,3 +243,149 @@ def test_hosting_plan_matrix_skips_fact_without_plan() -> None:
         ),
     )
     assert catalog.hosting_plan_matrix() == {}
+
+
+def test_v1_fact_is_retiring_with_future_end_date() -> None:
+    # The v1 end-of-support date (2026-09-14) is in the future relative to the
+    # catalog's last_verified date, so the baseline status is 'retiring'.
+    catalog = load_catalog()
+    v1 = catalog.get_fact("functions-runtime-v1-eos")
+    assert v1 is not None
+    assert v1.status == "retiring"
+
+
+def test_runtime_v2_v3_v4_facts_present() -> None:
+    catalog = load_catalog()
+    v2 = catalog.get_fact("functions-runtime-v2-eos")
+    v3 = catalog.get_fact("functions-runtime-v3-eos")
+    v4 = catalog.get_fact("functions-runtime-v4-supported")
+    assert v2 is not None and v2.status == "unsupported"
+    assert v3 is not None and v3.status == "unsupported"
+    assert v4 is not None and v4.status == "supported"
+    assert v4.support_end is None
+
+
+def test_support_end_end_date_by_precision() -> None:
+    assert SupportEnd(value="2026-09-14", precision="day").end_date() == date(2026, 9, 14)
+    # Month precision resolves to the last day of the month.
+    assert SupportEnd(value="2026-02", precision="month").end_date() == date(2026, 2, 28)
+    assert SupportEnd(value="2030", precision="year").end_date() == date(2030, 12, 31)
+
+
+def test_support_end_end_date_malformed_returns_none() -> None:
+    assert SupportEnd(value="nope", precision="day").end_date() is None
+    assert SupportEnd(value="2026-13", precision="month").end_date() is None
+
+
+def test_effective_status_without_support_end_returns_baseline() -> None:
+    fact = Fact(
+        fact_id="x",
+        category="functions_runtime_lifecycle",
+        applies_to={},
+        source_url="",
+        last_verified="",
+        verification_notes="",
+        status="supported",
+    )
+    assert fact.effective_status(date(2026, 9, 6)) == "supported"
+
+
+def test_effective_status_malformed_support_end_returns_baseline() -> None:
+    fact = Fact(
+        fact_id="x",
+        category="functions_runtime_lifecycle",
+        applies_to={},
+        source_url="",
+        last_verified="",
+        verification_notes="",
+        status="retiring",
+        support_end=SupportEnd(value="nope", precision="day"),
+    )
+    assert fact.effective_status(date(2026, 9, 6)) == "retiring"
+
+
+def test_effective_status_self_heals_across_end_date() -> None:
+    catalog = load_catalog()
+    v1 = catalog.get_fact("functions-runtime-v1-eos")
+    assert v1 is not None
+    # Before the end date: still retiring. After it: unsupported.
+    assert v1.effective_status(date(2026, 9, 6)) == "retiring"
+    assert v1.effective_status(date(2026, 9, 15)) == "unsupported"
+
+
+def test_effective_status_future_unsupported_baseline_becomes_retiring() -> None:
+    fact = Fact(
+        fact_id="x",
+        category="functions_runtime_lifecycle",
+        applies_to={},
+        source_url="",
+        last_verified="",
+        verification_notes="",
+        status="unsupported",
+        support_end=SupportEnd(value="2099-01-01", precision="day"),
+    )
+    assert fact.effective_status(date(2026, 9, 6)) == "retiring"
+
+
+def test_known_vs_supported_python_versions() -> None:
+    unsupported_py = Fact(
+        fact_id="python-3.9-eos",
+        category="python_runtime_lifecycle",
+        applies_to={"python": "3.9"},
+        source_url="",
+        last_verified="",
+        verification_notes="",
+        status="unsupported",
+        support_end=SupportEnd(value="2025-10", precision="month"),
+    )
+    supported_py = Fact(
+        fact_id="python-3.12-eos",
+        category="python_runtime_lifecycle",
+        applies_to={"python": "3.12"},
+        source_url="",
+        last_verified="",
+        verification_notes="",
+        status="supported",
+        support_end=SupportEnd(value="2028-10", precision="month"),
+    )
+    catalog = Catalog(
+        catalog_version="1.0.0",
+        last_verified="2026-09-06",
+        sources={},
+        facts=(unsupported_py, supported_py),
+    )
+    assert catalog.known_python_versions() == ("3.9", "3.12")
+    assert catalog.supported_python_versions(as_of=date(2026, 9, 6)) == ("3.12",)
+    # python_versions() stays a backward-compatible alias for the known set.
+    assert catalog.python_versions() == ("3.9", "3.12")
+
+
+def test_render_out_of_range_month_zero_falls_back() -> None:
+    # month=0 previously rendered as 'December' via negative indexing; the
+    # date() validation now rejects it and falls back to the raw value.
+    assert SupportEnd(value="2026-00-10", precision="day").render() == "2026-00-10"
+    assert SupportEnd(value="2026-00", precision="month").render() == "2026-00"
+
+
+def test_parse_support_end_rejects_non_string_value() -> None:
+    assert _parse_support_end({"value": 2026, "precision": "day"}) is None
+
+
+def test_parse_fact_explicit_null_required_field_becomes_empty_string() -> None:
+    fact = _parse_fact(
+        {
+            "fact_id": None,
+            "category": None,
+            "source_url": None,
+        }
+    )
+    assert fact.fact_id == ""
+    assert fact.category == ""
+    assert fact.source_url == ""
+
+
+def test_load_catalog_rejects_non_dict_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(compatibility_module, "_CATALOG_CACHE", None)
+    monkeypatch.setattr(json, "load", lambda handle: ["not", "a", "dict"])
+    with pytest.raises(RuntimeError, match="must be a JSON object"):
+        load_catalog()


### PR DESCRIPTION
## Context

Foundational engine work for the repositioning (umbrella #341). Establishes the single, auditable, **offline** source of truth for every Azure Functions date/compatibility fact, so downstream rules (#347/#348 and the risk rules) can reason deterministically without hardcoding dates.

Closes #342.

## What changed

- **`assets/compatibility/catalog.json`** — version-controlled snapshot (`catalog_version` 1.0.0, `last_verified` 2026-09-06) with 12 facts across three categories:
  - `python_runtime_lifecycle` — Python 3.10–3.14 end-of-support
  - `hosting_plan_python_cap` — per-plan Python caps (Linux Consumption capped at 3.12)
  - `hosting_plan_lifecycle` / `functions_runtime_lifecycle` — Linux Consumption retirement, runtime v1 EOS, v3-on-Linux-Consumption stop
  - Each fact carries a **source URL**, `last_verified`, `verification_notes`, and a **precision-tagged** `support_end` (`day`/`month`/`year`) so the tool never renders finer precision than Microsoft publishes (e.g. Python 3.10 → "October 2026", not an invented day).
- **`compatibility.py`** — cached, **offline** loader (no runtime network calls). Typed accessors: `python_versions()`, `python_eos()`, `hosting_plan_matrix()`, `get_fact()`, `facts_by_category()`, and `freshness()`. A stale catalog reports its own `is_stale` signal (180-day threshold) **independent of any finding severity** — staleness is a property of the snapshot, never an ERROR on the diagnosed project.
- **`target_resolver.py`** — `SUPPORTED_PYTHON_VERSIONS` and `PYTHON_HOSTING_PLAN_MATRIX` now **derive from the catalog**; the public names are preserved so existing `handlers/registry.py` and `cli.py` imports keep working unchanged.
- **`tests/test_compatibility.py`** — full coverage of the loader (precision rendering, freshness, tolerant parsing, cache).

## Data provenance

All dates verified against Microsoft Learn (`supported-languages`, `functions-versions`, `consumption-plan`) at source precision; source URLs are embedded per-fact in the catalog.

## Verification

- `hatch run pytest --cov` → **96.58%** total (≥95% gate); `compatibility.py` fully covered; `target_resolver` migration verified to reproduce the exact prior constants.
- `hatch run style` → clean; `hatch run typecheck` (mypy strict) → clean.
- CLI smoke: `azure-functions-doctor doctor --path examples/v2/http-trigger --profile minimal` → exit 0.

## Note (pre-existing, unrelated)

`tests/test_release_workflow_pins.py` fails on `origin/main` independently of this change — Dependabot bumped `azure/login` to v3.0.2 in `e2e-azure.yml` (#358) while the canonical pin expects v3.0.1. Out of scope here; should be addressed in a dedicated pin-reconciliation change.

## Out of scope

- Deploy-config ingestion (#347), Finding Contract v2 (#348), and the date/risk rules that will consume this catalog — tracked separately under #341.