### PR TITLE
ci: promote azure/login canonical pin to v3.0.2

### DIFF
--- a/tools/lint_release_workflows.py
+++ b/tools/lint_release_workflows.py
@@ -42,7 +42,7 @@ CANONICAL_ACTIONS: dict[str, tuple[str, str]] = {
     # renovate: datasource=github-tags depName=actions/setup-python versioning=github-tags
     "actions/setup-python": ("5fda3b95a4ea91299a34e894583c3862153e4b97", "v7.0.0"),
     # renovate: datasource=github-tags depName=azure/login versioning=github-tags
-    "azure/login": ("f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca", "v3.0.1"),
+    "azure/login": ("7ddb5af1ef8758cf1353cf3b42f940aee27ba21c", "v3.0.2"),
     # renovate: datasource=github-tags depName=actions/upload-artifact versioning=github-tags
     "actions/upload-artifact": ("ea165f8d65b6e75b540449e92b4886f43607fa02", "v4"),
     # renovate: datasource=github-tags depName=actions/download-artifact versioning=github-tags


### PR DESCRIPTION
## Summary
- Dependabot (#340) bumped `azure/login` to **v3.0.2** (`7ddb5af`) in `e2e-azure.yml` but left `CANONICAL_ACTIONS` in `tools/lint_release_workflows.py` pinned to v3.0.1.
- The mismatch makes `tests/test_release_workflow_pins.py::test_repo_release_workflows_are_clean` fail on `main` and on **every open PR** (#359, #360, etc.).
- v3.0.2 is a security-hardening release; the pinned SHA matches the authentic upstream tag: https://github.com/Azure/login/releases/tag/v3.0.2
- This promotes the canonical registry to v3.0.2, unblocking CI. No workflow files change (they already use the correct SHA).

## Test
- `hatch run pytest tests/test_release_workflow_pins.py` → 8 passed.