### PR TITLE
feat(deploy-config): ingest target Azure config into a single TargetConfig

### DIFF
--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -218,6 +218,7 @@ def doctor(
         rules_path=rules,
         target_python=target_python,
         deployment_mode=deployment_mode,
+        hosting_plan=hosting_plan,
     )
     resolved_path = Path(path).resolve()
     report_properties = doctor.get_report_properties()

--- a/src/azure_functions_doctor/deploy_config.py
+++ b/src/azure_functions_doctor/deploy_config.py
@@ -1,0 +1,415 @@
+"""Deploy-config ingestion: one authoritative view of the target Azure config.
+
+The doctor's positioning is "will THIS app run on THIS Azure config?". Answering
+that requires ingesting the *target* Azure configuration — hosting plan, runtime
+name/version, extension version, deployment storage, and key app settings — from
+the infrastructure-as-code (bicep / ARM JSON) that already ships in the project,
+rather than every rule performing its own ad-hoc regex scan.
+
+This module resolves a single :class:`TargetConfig` object. Every field records
+its provenance (:class:`ResolvedField`) and is resolved with a documented
+precedence, first match wins:
+
+    CLI explicit override  >  IaC target configuration  >  project/local signal
+    >  unknown
+
+When no infrastructure is present the resolution degrades gracefully: every field
+is ``unknown`` and no exception is raised, so rules that need a plan can emit a
+clear SKIP instead of a false failure.
+
+No runtime network calls are made; only files already in the project are read.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+import re
+from typing import Mapping, Optional
+
+from azure_functions_doctor.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Provenance markers. IaC values carry the relative infra file path (e.g.
+# ``"infra/main.bicep"``) and project/local signals carry ``"local:<filename>"``.
+SOURCE_OVERRIDE = "cli-override"
+SOURCE_UNKNOWN = "unknown"
+
+# Canonical hosting-plan names (aligned with target_resolver.SUPPORTED_HOSTING_PLANS).
+PLAN_FLEX_CONSUMPTION = "flex-consumption"
+PLAN_LINUX_CONSUMPTION = "linux-consumption"
+PLAN_PREMIUM = "premium"
+PLAN_DEDICATED = "dedicated"
+
+# Specificity order used when multiple signals are present in one project: the
+# most specific plan wins so a Flex app that also declares a legacy sku block is
+# still reported as Flex.
+_PLAN_SPECIFICITY = (
+    PLAN_FLEX_CONSUMPTION,
+    PLAN_LINUX_CONSUMPTION,
+    PLAN_PREMIUM,
+    PLAN_DEDICATED,
+)
+
+_LINUX_FX_PYTHON_RE = re.compile(r"linuxFxVersion['\"]?\s*[:=]\s*['\"]?[Pp]ython\|(\d+\.\d+)")
+_EMULATOR_STORAGE = "UseDevelopmentStorage=true"
+
+# SKU signals. Names are matched case-insensitively as whole tokens.
+_PREMIUM_SKU_NAMES = {"ep1", "ep2", "ep3"}
+_DEDICATED_SKU_NAMES = {
+    "b1",
+    "b2",
+    "b3",
+    "s1",
+    "s2",
+    "s3",
+    "p1v2",
+    "p2v2",
+    "p3v2",
+    "p1v3",
+    "p2v3",
+    "p3v3",
+}
+_PREMIUM_SKU_TIERS = {"elasticpremium"}
+_DEDICATED_SKU_TIERS = {"basic", "standard", "premiumv2", "premiumv3"}
+_DYNAMIC_SKU_TIERS = {"dynamic"}
+
+
+@dataclass(frozen=True)
+class ResolvedField:
+    """A resolved configuration value together with its provenance."""
+
+    value: Optional[str]
+    source: str
+
+    @property
+    def is_known(self) -> bool:
+        """Return ``True`` when a concrete value was resolved."""
+        return self.value is not None
+
+
+@dataclass(frozen=True)
+class TargetConfig:
+    """The resolved target Azure configuration, one source of truth for handlers."""
+
+    hosting_plan: ResolvedField
+    runtime_name: ResolvedField
+    runtime_version: ResolvedField
+    extension_version: ResolvedField
+    deployment_storage: ResolvedField
+    app_settings: dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def unknown(cls) -> "TargetConfig":
+        """Return a fully-unknown config (used when nothing can be resolved)."""
+        blank = ResolvedField(None, SOURCE_UNKNOWN)
+        return cls(
+            hosting_plan=blank,
+            runtime_name=blank,
+            runtime_version=blank,
+            extension_version=blank,
+            deployment_storage=blank,
+            app_settings={},
+        )
+
+
+@dataclass
+class _IaCScan:
+    """Raw values discovered from a single IaC scan pass, with provenance."""
+
+    hosting_plan: Optional[ResolvedField] = None
+    runtime_name: Optional[ResolvedField] = None
+    runtime_version: Optional[ResolvedField] = None
+    extension_version: Optional[ResolvedField] = None
+    deployment_storage: Optional[ResolvedField] = None
+    app_settings: dict[str, str] = field(default_factory=dict)
+
+
+def _is_excluded(candidate: Path) -> bool:
+    # Imported lazily to avoid an import cycle: the ``handlers`` package
+    # re-exports this module's public API from its ``__init__``.
+    from azure_functions_doctor.handlers._helpers import EXCLUDED_PROJECT_DIRS
+
+    return any(part in EXCLUDED_PROJECT_DIRS for part in candidate.parts)
+
+
+def _read_text(candidate: Path) -> Optional[str]:
+    try:
+        return candidate.read_text(encoding="utf-8")
+    except (OSError, ValueError, UnicodeDecodeError):
+        logger.debug("Skip unreadable infra file %s", candidate)
+        return None
+
+
+def _rel(candidate: Path, project_path: Path) -> str:
+    try:
+        return str(candidate.relative_to(project_path))
+    except ValueError:  # pragma: no cover - candidate is always under project_path
+        return str(candidate)
+
+
+def _iter_infra_files(project_path: Path) -> list[tuple[Path, str]]:
+    """Return ``(path, kind)`` for infra files, kind in ``{"bicep", "json"}``.
+
+    ``local.settings.json`` is deliberately excluded: it is a local developer
+    signal, not deployable infrastructure.
+    """
+    files: list[tuple[Path, str]] = []
+    for candidate in sorted(project_path.rglob("*.bicep")):
+        if not _is_excluded(candidate):
+            files.append((candidate, "bicep"))
+    for candidate in sorted(project_path.rglob("*.json")):
+        if candidate.name == "local.settings.json" or _is_excluded(candidate):
+            continue
+        files.append((candidate, "json"))
+    return files
+
+
+def _plan_from_sku(name: Optional[str], tier: Optional[str]) -> Optional[str]:
+    """Map an Azure sku ``(name, tier)`` pair to a canonical hosting plan."""
+    name_l = name.lower() if isinstance(name, str) else ""
+    tier_l = tier.lower() if isinstance(tier, str) else ""
+    if tier_l in _DYNAMIC_SKU_TIERS or name_l == "y1":
+        return PLAN_LINUX_CONSUMPTION
+    if tier_l == "flexconsumption" or name_l == "fc1":
+        return PLAN_FLEX_CONSUMPTION
+    if tier_l in _PREMIUM_SKU_TIERS or name_l in _PREMIUM_SKU_NAMES:
+        return PLAN_PREMIUM
+    if tier_l in _DEDICATED_SKU_TIERS or name_l in _DEDICATED_SKU_NAMES:
+        return PLAN_DEDICATED
+    return None
+
+
+def _more_specific_plan(current: Optional[str], candidate: str) -> str:
+    """Return whichever of ``current``/``candidate`` is the more specific plan."""
+    if current is None:
+        return candidate
+    return min(
+        (current, candidate),
+        key=lambda plan: (
+            _PLAN_SPECIFICITY.index(plan) if plan in _PLAN_SPECIFICITY else len(_PLAN_SPECIFICITY)
+        ),
+    )
+
+
+def _walk_json(node: object) -> "list[dict[str, object]]":
+    """Yield every dict nested anywhere within a parsed JSON structure."""
+    found: list[dict[str, object]] = []
+    stack: list[object] = [node]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            found.append(current)
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+    return found
+
+
+def _app_settings_from_json(node: object) -> dict[str, str]:
+    """Collect ``{name: value}`` app settings from any ``appSettings`` array."""
+    settings: dict[str, str] = {}
+    for obj in _walk_json(node):
+        app_settings = obj.get("appSettings")
+        if not isinstance(app_settings, list):
+            continue
+        for entry in app_settings:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            value = entry.get("value")
+            if isinstance(name, str) and isinstance(value, str):
+                settings.setdefault(name, value)
+    return settings
+
+
+def _runtime_from_function_app_config(node: object) -> Optional[tuple[str, str]]:
+    """Return ``(name, version)`` from a ``functionAppConfig.runtime`` block."""
+    for obj in _walk_json(node):
+        runtime = obj.get("runtime")
+        if isinstance(runtime, dict):
+            name = runtime.get("name")
+            version = runtime.get("version")
+            if isinstance(name, str) and isinstance(version, str):
+                return name.lower(), version
+    return None
+
+
+def _deployment_storage_from_json(node: object) -> Optional[str]:
+    """Return a Flex ``functionAppConfig.deployment.storage.value`` URL if present."""
+    for obj in _walk_json(node):
+        deployment = obj.get("deployment")
+        if not isinstance(deployment, dict):
+            continue
+        storage = deployment.get("storage")
+        if not isinstance(storage, dict):
+            continue
+        value = storage.get("value")
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _has_function_app_config(node: object) -> bool:
+    return any("functionAppConfig" in obj for obj in _walk_json(node))
+
+
+def _plan_from_json(node: object) -> Optional[str]:
+    plan: Optional[str] = None
+    if _has_function_app_config(node):
+        plan = _more_specific_plan(plan, PLAN_FLEX_CONSUMPTION)
+    for obj in _walk_json(node):
+        sku = obj.get("sku")
+        if isinstance(sku, dict):
+            candidate = _plan_from_sku(
+                sku.get("name") if isinstance(sku.get("name"), str) else None,
+                sku.get("tier") if isinstance(sku.get("tier"), str) else None,
+            )
+            if candidate is not None:
+                plan = _more_specific_plan(plan, candidate)
+    return plan
+
+
+def _scan_json_file(text: str, rel: str, scan: _IaCScan) -> None:
+    try:
+        data = json.loads(text)
+    except (ValueError, UnicodeDecodeError):
+        logger.debug("Skip non-JSON / malformed infra file %s", rel)
+        return
+
+    plan = _plan_from_json(data)
+    if plan is not None and scan.hosting_plan is None:
+        scan.hosting_plan = ResolvedField(plan, rel)
+
+    runtime = _runtime_from_function_app_config(data)
+    if runtime is not None:
+        if scan.runtime_name is None:
+            scan.runtime_name = ResolvedField(runtime[0], rel)
+        if scan.runtime_version is None:
+            scan.runtime_version = ResolvedField(runtime[1], rel)
+
+    settings = _app_settings_from_json(data)
+    for name, value in settings.items():
+        scan.app_settings.setdefault(name, value)
+    ext = settings.get("FUNCTIONS_EXTENSION_VERSION")
+    if ext is not None and scan.extension_version is None:
+        scan.extension_version = ResolvedField(ext, rel)
+
+    storage = _deployment_storage_from_json(data)
+    if storage is None:
+        storage = settings.get("AzureWebJobsStorage")
+    if storage is not None and scan.deployment_storage is None:
+        scan.deployment_storage = ResolvedField(storage, rel)
+
+
+def _scan_bicep_file(text: str, rel: str, scan: _IaCScan) -> None:
+    if scan.hosting_plan is None and "functionAppConfig" in text:
+        scan.hosting_plan = ResolvedField(PLAN_FLEX_CONSUMPTION, rel)
+    match = _LINUX_FX_PYTHON_RE.search(text)
+    if match is not None:
+        if scan.runtime_name is None:
+            scan.runtime_name = ResolvedField("python", rel)
+        if scan.runtime_version is None:
+            scan.runtime_version = ResolvedField(match.group(1), rel)
+    for name, value in re.findall(r"name:\s*'([^']+)'\s*\n?\s*value:\s*'([^']*)'", text):
+        scan.app_settings.setdefault(name, value)
+    ext = scan.app_settings.get("FUNCTIONS_EXTENSION_VERSION")
+    if ext is not None and scan.extension_version is None:
+        scan.extension_version = ResolvedField(ext, rel)
+    storage = scan.app_settings.get("AzureWebJobsStorage")
+    if storage is None and _EMULATOR_STORAGE in text and "AzureWebJobsStorage" in text:
+        storage = _EMULATOR_STORAGE
+    if storage is not None and scan.deployment_storage is None:
+        scan.deployment_storage = ResolvedField(storage, rel)
+
+
+def _scan_iac(project_path: Path) -> _IaCScan:
+    scan = _IaCScan()
+    for candidate, kind in _iter_infra_files(project_path):
+        text = _read_text(candidate)
+        if text is None:
+            continue
+        rel = _rel(candidate, project_path)
+        if kind == "json":
+            _scan_json_file(text, rel, scan)
+        else:
+            _scan_bicep_file(text, rel, scan)
+    return scan
+
+
+def _local_signals(project_path: Path) -> _IaCScan:
+    """Resolve project/local signals (lowest precedence above ``unknown``)."""
+    signals = _IaCScan()
+    settings_path = project_path / "local.settings.json"
+    text = _read_text(settings_path)
+    if text is None:
+        return signals
+    try:
+        data = json.loads(text)
+    except (ValueError, UnicodeDecodeError):
+        return signals
+    values = data.get("Values") if isinstance(data, dict) else None
+    if not isinstance(values, dict):
+        return signals
+    source = "local:local.settings.json"
+    ext = values.get("FUNCTIONS_EXTENSION_VERSION")
+    if isinstance(ext, str):
+        signals.extension_version = ResolvedField(ext, source)
+    storage = values.get("AzureWebJobsStorage")
+    if isinstance(storage, str):
+        signals.deployment_storage = ResolvedField(storage, source)
+    return signals
+
+
+def _resolve_field(
+    override: Optional[str],
+    iac: Optional[ResolvedField],
+    local: Optional[ResolvedField],
+) -> ResolvedField:
+    """Apply precedence override > IaC > local signal > unknown for one field."""
+    if override is not None:
+        return ResolvedField(override, SOURCE_OVERRIDE)
+    if iac is not None:
+        return iac
+    if local is not None:
+        return local
+    return ResolvedField(None, SOURCE_UNKNOWN)
+
+
+def resolve_target_config(
+    project_path: Path,
+    overrides: Optional[Mapping[str, Optional[str]]] = None,
+) -> TargetConfig:
+    """Resolve the target Azure configuration for ``project_path``.
+
+    Args:
+        project_path: Root of the project under diagnosis.
+        overrides: Optional CLI overrides. Recognized keys are ``"hosting_plan"``
+            and ``"runtime_version"``; a non-``None`` value takes precedence over
+            any IaC or local signal for that field.
+
+    Returns:
+        A :class:`TargetConfig` where every field records its provenance. When no
+        infrastructure or signal is found, all fields are ``unknown``.
+    """
+    overrides = overrides or {}
+    iac = _scan_iac(project_path)
+    local = _local_signals(project_path)
+
+    app_settings = dict(local.app_settings)
+    app_settings.update(iac.app_settings)
+
+    return TargetConfig(
+        hosting_plan=_resolve_field(
+            overrides.get("hosting_plan"), iac.hosting_plan, local.hosting_plan
+        ),
+        runtime_name=_resolve_field(None, iac.runtime_name, local.runtime_name),
+        runtime_version=_resolve_field(
+            overrides.get("runtime_version"), iac.runtime_version, local.runtime_version
+        ),
+        extension_version=_resolve_field(None, iac.extension_version, local.extension_version),
+        deployment_storage=_resolve_field(None, iac.deployment_storage, local.deployment_storage),
+        app_settings=app_settings,
+    )

--- a/src/azure_functions_doctor/doctor.py
+++ b/src/azure_functions_doctor/doctor.py
@@ -16,6 +16,7 @@ from azure_functions_doctor.handlers import (
     _iter_project_py_contents,
     _source_contains_ast,
     generic_handler,
+    resolve_target_config,
 )
 from azure_functions_doctor.logging_config import get_logger, log_rule_execution
 
@@ -88,11 +89,13 @@ class Doctor:
         rules_path: Optional[Path] = None,
         target_python: Optional[str] = None,
         deployment_mode: str = "remote-build",
+        hosting_plan: Optional[str] = None,
     ) -> None:
         self.project_path: Path = Path(path).resolve()
         self.profile = profile
         self.target_python: Optional[str] = target_python
         self.deployment_mode: str = deployment_mode
+        self.hosting_plan: Optional[str] = hosting_plan
         self.rules_path: Optional[Path] = None
         if rules_path is not None:
             resolved = rules_path.resolve()
@@ -107,6 +110,7 @@ class Doctor:
             "programming_model": self.programming_model,
             "target_python": self.target_python,
             "deployment_mode": self.deployment_mode,
+            "hosting_plan": self.hosting_plan,
         }
 
     def _detect_programming_model(self) -> ProgrammingModel:
@@ -298,6 +302,14 @@ class Doctor:
         context: RuleContext = {
             "target_python": self.target_python,
             "deployment_mode": self.deployment_mode,
+            "target_config": resolve_target_config(
+                self.project_path,
+                {
+                    "hosting_plan": self.hosting_plan,
+                    "runtime_version": self.target_python,
+                    "deployment_mode": self.deployment_mode,
+                },
+            ),
         }
 
         for section, checks in grouped.items():

--- a/src/azure_functions_doctor/handlers/__init__.py
+++ b/src/azure_functions_doctor/handlers/__init__.py
@@ -6,6 +6,11 @@ before. Implementation lives in :mod:`._helpers` (pure helpers and types) and
 :mod:`.registry` (the ``HandlerRegistry`` dispatch class).
 """
 
+from azure_functions_doctor.deploy_config import (
+    ResolvedField,
+    TargetConfig,
+    resolve_target_config,
+)
 from azure_functions_doctor.handlers._helpers import (
     _HOST_JSON_MISSING,
     _PYTHON_CANDIDATES,
@@ -48,6 +53,9 @@ __all__ = [
     "RuleContext",
     "generic_handler",
     "resolve_target_value",
+    "ResolvedField",
+    "TargetConfig",
+    "resolve_target_config",
     "_collect_blueprint_aliases",
     "_collect_register_functions_args",
     "_collect_unregistered_blueprint_aliases",

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 import sys
 from typing import (
+    TYPE_CHECKING,
     Callable,
     Dict,
     Iterator,
@@ -27,6 +28,9 @@ except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
 from azure_functions_doctor.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from azure_functions_doctor.deploy_config import TargetConfig
 
 EXCLUDED_PROJECT_DIRS = {
     # Python virtual environments
@@ -67,6 +71,7 @@ class HandlerResult(TypedDict, total=False):
 class RuleContext(TypedDict, total=False):
     target_python: Optional[str]
     deployment_mode: Optional[str]
+    target_config: Optional["TargetConfig"]
 
 
 # Platform-aware candidates for executables (for symmetric fallback)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -279,6 +279,7 @@ def test_cli_sarif_output_includes_target_python_override() -> None:
         "programming_model": "v2",
         "target_python": "3.11",
         "deployment_mode": "remote-build",
+        "hosting_plan": None,
     }
 
 

--- a/tests/test_deploy_config.py
+++ b/tests/test_deploy_config.py
@@ -1,0 +1,420 @@
+"""Tests for deploy-config ingestion (issue #347).
+
+Exercises :func:`resolve_target_config` across the four canonical hosting plans
+(Flex Consumption, Linux Consumption, Premium, Dedicated), extension-version /
+deployment-storage / app-settings extraction, the documented resolution
+precedence (override > IaC > local signal > unknown) including a
+conflicting-sources case, and graceful degradation when no infrastructure is
+present. Also verifies the Doctor/CLI wiring that surfaces ``hosting_plan`` in
+report properties.
+"""
+
+import json
+from pathlib import Path
+
+from azure_functions_doctor.deploy_config import (
+    PLAN_DEDICATED,
+    PLAN_FLEX_CONSUMPTION,
+    PLAN_LINUX_CONSUMPTION,
+    PLAN_PREMIUM,
+    SOURCE_OVERRIDE,
+    SOURCE_UNKNOWN,
+    ResolvedField,
+    TargetConfig,
+    resolve_target_config,
+)
+from azure_functions_doctor.doctor import Doctor
+
+
+def _write(path: Path, name: str, content: str) -> None:
+    (path / name).write_text(content, encoding="utf-8")
+
+
+def _arm_with_sku(name: str, tier: str) -> str:
+    return json.dumps(
+        {
+            "resources": [
+                {
+                    "type": "Microsoft.Web/serverfarms",
+                    "sku": {"name": name, "tier": tier},
+                }
+            ]
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# ResolvedField / TargetConfig primitives
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_field_is_known() -> None:
+    assert ResolvedField("3.12", "infra/main.bicep").is_known is True
+    assert ResolvedField(None, SOURCE_UNKNOWN).is_known is False
+
+
+def test_target_config_unknown_factory() -> None:
+    cfg = TargetConfig.unknown()
+    assert cfg.hosting_plan.value is None
+    assert cfg.hosting_plan.source == SOURCE_UNKNOWN
+    assert cfg.runtime_name.is_known is False
+    assert cfg.runtime_version.is_known is False
+    assert cfg.extension_version.is_known is False
+    assert cfg.deployment_storage.is_known is False
+    assert cfg.app_settings == {}
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+def test_absent_infra_degrades_to_unknown(tmp_path: Path) -> None:
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.hosting_plan.source == SOURCE_UNKNOWN
+    assert cfg.hosting_plan.is_known is False
+    assert cfg.runtime_version.is_known is False
+    assert cfg.app_settings == {}
+
+
+def test_unreadable_and_malformed_infra_is_tolerated(tmp_path: Path) -> None:
+    _write(tmp_path, "broken.json", "{not valid json")
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.hosting_plan.is_known is False
+
+
+def test_excluded_dirs_are_skipped(tmp_path: Path) -> None:
+    venv = tmp_path / ".venv"
+    venv.mkdir()
+    _write(venv, "main.bicep", "linuxFxVersion: 'Python|3.12'")
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.runtime_version.is_known is False
+
+
+# ---------------------------------------------------------------------------
+# Hosting-plan detection across the four canonical plans
+# ---------------------------------------------------------------------------
+
+
+def test_flex_consumption_from_function_app_config_bicep(tmp_path: Path) -> None:
+    _write(tmp_path, "main.bicep", "resource fa 'x' = {\n  functionAppConfig: {}\n}")
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.hosting_plan.value == PLAN_FLEX_CONSUMPTION
+    assert cfg.hosting_plan.source == "main.bicep"
+
+
+def test_flex_consumption_from_function_app_config_json(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "main.json",
+        json.dumps({"resources": [{"functionAppConfig": {"runtime": {}}}]}),
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.hosting_plan.value == PLAN_FLEX_CONSUMPTION
+
+
+def test_linux_consumption_from_dynamic_sku(tmp_path: Path) -> None:
+    _write(tmp_path, "plan.json", _arm_with_sku("Y1", "Dynamic"))
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.hosting_plan.value == PLAN_LINUX_CONSUMPTION
+
+
+def test_premium_from_ep_sku(tmp_path: Path) -> None:
+    _write(tmp_path, "plan.json", _arm_with_sku("EP1", "ElasticPremium"))
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.hosting_plan.value == PLAN_PREMIUM
+
+
+def test_dedicated_from_standard_sku(tmp_path: Path) -> None:
+    _write(tmp_path, "plan.json", _arm_with_sku("S1", "Standard"))
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.hosting_plan.value == PLAN_DEDICATED
+
+
+def test_unrecognized_sku_stays_unknown(tmp_path: Path) -> None:
+    _write(tmp_path, "plan.json", _arm_with_sku("mystery", "custom"))
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.hosting_plan.is_known is False
+
+
+def test_flex_wins_over_legacy_sku_specificity(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "main.json",
+        json.dumps(
+            {
+                "resources": [
+                    {"functionAppConfig": {}},
+                    {"sku": {"name": "S1", "tier": "Standard"}},
+                ]
+            }
+        ),
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.hosting_plan.value == PLAN_FLEX_CONSUMPTION
+
+
+# ---------------------------------------------------------------------------
+# Runtime / extension / storage / app-settings extraction
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_from_linux_fx_version_bicep(tmp_path: Path) -> None:
+    _write(tmp_path, "main.bicep", "linuxFxVersion: 'Python|3.12'")
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.runtime_name.value == "python"
+    assert cfg.runtime_version.value == "3.12"
+
+
+def test_runtime_from_function_app_config_json(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "main.json",
+        json.dumps({"functionAppConfig": {"runtime": {"name": "Python", "version": "3.11"}}}),
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.runtime_name.value == "python"
+    assert cfg.runtime_version.value == "3.11"
+
+
+def test_extension_and_storage_and_app_settings_from_json(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "main.json",
+        json.dumps(
+            {
+                "resources": [
+                    {
+                        "appSettings": [
+                            {"name": "FUNCTIONS_EXTENSION_VERSION", "value": "~4"},
+                            {"name": "AzureWebJobsStorage", "value": "conn-str"},
+                            {"name": "CUSTOM", "value": "x"},
+                        ]
+                    }
+                ]
+            }
+        ),
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.extension_version.value == "~4"
+    assert cfg.deployment_storage.value == "conn-str"
+    assert cfg.app_settings["CUSTOM"] == "x"
+
+
+def test_flex_deployment_storage_value_preferred(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "main.json",
+        json.dumps(
+            {"functionAppConfig": {"deployment": {"storage": {"value": "https://flexstore"}}}}
+        ),
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.deployment_storage.value == "https://flexstore"
+
+
+def test_extension_and_storage_from_bicep(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "main.bicep",
+        "appSettings: [\n"
+        "  {\n    name: 'FUNCTIONS_EXTENSION_VERSION'\n    value: '~4'\n  }\n"
+        "  {\n    name: 'AzureWebJobsStorage'\n    value: 'UseDevelopmentStorage=true'\n  }\n"
+        "]",
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.extension_version.value == "~4"
+    assert cfg.deployment_storage.value == "UseDevelopmentStorage=true"
+
+
+def test_bicep_emulator_storage_without_explicit_setting(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "main.bicep",
+        "var conn = 'AzureWebJobsStorage'\nvalue: 'UseDevelopmentStorage=true'",
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.deployment_storage.value == "UseDevelopmentStorage=true"
+
+
+def test_app_settings_ignore_non_string_entries(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "main.json",
+        json.dumps(
+            {
+                "appSettings": [
+                    {"name": "OK", "value": "yes"},
+                    {"name": "NUM", "value": 5},
+                    "not-a-dict",
+                ]
+            }
+        ),
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.app_settings == {"OK": "yes"}
+
+
+# ---------------------------------------------------------------------------
+# Local signals (lowest precedence above unknown)
+# ---------------------------------------------------------------------------
+
+
+def test_local_settings_provide_signals(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "local.settings.json",
+        json.dumps(
+            {
+                "Values": {
+                    "FUNCTIONS_EXTENSION_VERSION": "~4",
+                    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+                }
+            }
+        ),
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.extension_version.value == "~4"
+    assert cfg.extension_version.source == "local:local.settings.json"
+    assert cfg.deployment_storage.value == "UseDevelopmentStorage=true"
+
+
+def test_local_settings_not_treated_as_infra(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "local.settings.json",
+        json.dumps({"Values": {"functionAppConfig": "x"}}),
+    )
+    cfg = resolve_target_config(tmp_path)
+    # local.settings.json is never scanned as deployable infra.
+    assert cfg.hosting_plan.is_known is False
+
+
+def test_local_settings_malformed_is_ignored(tmp_path: Path) -> None:
+    _write(tmp_path, "local.settings.json", "{bad json")
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.extension_version.is_known is False
+
+
+def test_local_settings_without_values_block(tmp_path: Path) -> None:
+    _write(tmp_path, "local.settings.json", json.dumps({"IsEncrypted": False}))
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.extension_version.is_known is False
+
+
+# ---------------------------------------------------------------------------
+# Precedence: override > IaC > local > unknown (conflicting-sources case)
+# ---------------------------------------------------------------------------
+
+
+def test_conflicting_sources_precedence(tmp_path: Path) -> None:
+    # IaC declares Dedicated + Python 3.11; local declares extension version;
+    # CLI overrides both hosting_plan and runtime_version.
+    _write(
+        tmp_path,
+        "main.json",
+        json.dumps(
+            {
+                "resources": [
+                    {"sku": {"name": "S1", "tier": "Standard"}},
+                    {"functionAppConfig": {"runtime": {"name": "python", "version": "3.11"}}},
+                ]
+            }
+        ),
+    )
+    _write(
+        tmp_path,
+        "local.settings.json",
+        json.dumps({"Values": {"FUNCTIONS_EXTENSION_VERSION": "~4"}}),
+    )
+    cfg = resolve_target_config(
+        tmp_path,
+        {"hosting_plan": "premium", "runtime_version": "3.12"},
+    )
+    # Override wins for both overridable fields.
+    assert cfg.hosting_plan.value == "premium"
+    assert cfg.hosting_plan.source == SOURCE_OVERRIDE
+    assert cfg.runtime_version.value == "3.12"
+    assert cfg.runtime_version.source == SOURCE_OVERRIDE
+    # IaC wins for non-overridable runtime_name.
+    assert cfg.runtime_name.value == "python"
+    assert cfg.runtime_name.source == "main.json"
+    # Local wins where IaC is silent.
+    assert cfg.extension_version.value == "~4"
+    assert cfg.extension_version.source == "local:local.settings.json"
+
+
+def test_iac_beats_local_for_shared_field(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "main.json",
+        json.dumps({"appSettings": [{"name": "FUNCTIONS_EXTENSION_VERSION", "value": "~4"}]}),
+    )
+    _write(
+        tmp_path,
+        "local.settings.json",
+        json.dumps({"Values": {"FUNCTIONS_EXTENSION_VERSION": "~3"}}),
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.extension_version.value == "~4"
+    assert cfg.extension_version.source == "main.json"
+
+
+def test_override_none_values_are_ignored(tmp_path: Path) -> None:
+    _write(tmp_path, "plan.json", _arm_with_sku("EP1", "ElasticPremium"))
+    cfg = resolve_target_config(tmp_path, {"hosting_plan": None, "runtime_version": None})
+    assert cfg.hosting_plan.value == PLAN_PREMIUM
+
+
+# ---------------------------------------------------------------------------
+# Doctor / CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_surfaces_hosting_plan_in_report_properties(tmp_path: Path) -> None:
+    doctor = Doctor(str(tmp_path), hosting_plan="premium")
+    props = doctor.get_report_properties()
+    assert props["hosting_plan"] == "premium"
+
+
+def test_doctor_hosting_plan_defaults_to_none(tmp_path: Path) -> None:
+    doctor = Doctor(str(tmp_path))
+    assert doctor.get_report_properties()["hosting_plan"] is None
+
+
+def test_flex_from_fc1_sku(tmp_path: Path) -> None:
+    _write(tmp_path, "plan.json", _arm_with_sku("FC1", "FlexConsumption"))
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.hosting_plan.value == PLAN_FLEX_CONSUMPTION
+
+
+def test_dedicated_from_sku_name(tmp_path: Path) -> None:
+    _write(tmp_path, "plan.json", _arm_with_sku("P1v2", "unknown-tier"))
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.hosting_plan.value == PLAN_DEDICATED
+
+
+def test_flex_deployment_storage_non_string_value_ignored(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "main.json",
+        json.dumps(
+            {
+                "functionAppConfig": {
+                    "deployment": {"storage": {"value": 123, "type": "blobContainer"}}
+                }
+            }
+        ),
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.deployment_storage.is_known is False
+
+
+def test_flex_deployment_storage_non_dict_ignored(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "main.json",
+        json.dumps({"functionAppConfig": {"deployment": {"storage": "not-a-dict"}}}),
+    )
+    cfg = resolve_target_config(tmp_path)
+    assert cfg.deployment_storage.is_known is False

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -121,6 +121,7 @@ def test_get_report_properties_includes_target_python(tmp_path: Path) -> None:
         "programming_model": "v2",
         "target_python": "3.12",
         "deployment_mode": "remote-build",
+        "hosting_plan": None,
     }
 
 


### PR DESCRIPTION
## Context

Closes #347 (part of the #341 repositioning umbrella).

The doctor's positioning is *"will THIS app run on THIS Azure config?"*. Answering that requires ingesting the **target** Azure configuration rather than every rule performing its own ad-hoc regex scan of the IaC.

## Summary

- New `deploy_config.py` module resolving a single authoritative `TargetConfig` (hosting plan, runtime name/version, extension version, deployment storage, app settings) from the bicep / ARM-JSON already shipping in the project.
- Every field records provenance via `ResolvedField` and is resolved with a documented precedence (first match wins):

  ```
  CLI override > IaC target config > project/local signal > unknown
  ```
- **Graceful degradation**: when no infrastructure is present, resolution returns a fully-unknown config with no exceptions — rules that need a plan can emit a clear SKIP instead of a false FAIL.
- **No runtime network calls** — only files already in the project are read.
- Threaded through `RuleContext`, `Doctor`, and the CLI; `--hosting-plan` is now surfaced in report properties.

## Hosting-plan detection

Maps SKU `(name, tier)` and Flex `functionAppConfig` signals to the four canonical plans: `flex-consumption`, `linux-consumption`, `premium`, `dedicated` (most-specific plan wins).

## Tests

`tests/test_deploy_config.py` covers:
- All four canonical hosting plans (SKU + `functionAppConfig` paths)
- Extension version / deployment storage / app-settings extraction (bicep + JSON)
- Local-settings signals and their lower precedence
- A **conflicting-sources precedence** case (override vs IaC vs local)
- Graceful degradation with absent / malformed / excluded-dir infrastructure
- Doctor/CLI wiring surfacing `hosting_plan`

## Validation

- `hatch run style` ✅
- `hatch run typecheck` ✅
- `hatch run pytest --cov` ✅ — total coverage **96.81%** (`deploy_config.py` at 98%)

Refs #347, #341