### PR TITLE
feat(finding): add Finding Contract v2 with evidence and freshness fields

### DIFF
--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -3,14 +3,20 @@ import json
 import os
 from pathlib import Path
 import time
-from typing import Annotated, Optional
+from typing import Annotated, Mapping, Optional, cast
 
 from rich.console import Console
 from rich.text import Text
 import typer
 
 from azure_functions_doctor import __version__
-from azure_functions_doctor.doctor import Doctor, _resolve_severity, _resolve_tier
+from azure_functions_doctor.doctor import (
+    FINDING_EVIDENCE_KEYS,
+    FINDING_SCHEMA_VERSION,
+    Doctor,
+    _resolve_severity,
+    _resolve_tier,
+)
 from azure_functions_doctor.logging_config import (
     get_logger,
     log_diagnostic_complete,
@@ -23,7 +29,11 @@ from azure_functions_doctor.target_resolver import (
     is_supported_python_for_plan,
     resolve_python_target,
 )
-from azure_functions_doctor.utils import format_detail, format_status_icon
+from azure_functions_doctor.utils import (
+    format_detail,
+    format_freshness_line,
+    format_status_icon,
+)
 
 cli = typer.Typer()
 console = Console()
@@ -288,6 +298,7 @@ def doctor(
             **report_properties,
         }
         json_output = {
+            "schema_version": FINDING_SCHEMA_VERSION,
             "metadata": metadata,
             "results": results,
         }
@@ -361,8 +372,19 @@ def doctor(
                     "level": level,
                     "locations": [{"physicalLocation": physical_location}],
                 }
+                props: dict[str, object] = {}
                 if item.get("hint"):
-                    sarif_result["properties"] = {"hint": item.get("hint", "")}
+                    props["hint"] = item.get("hint", "")
+                item_map = cast(Mapping[str, object], item)
+                for key in FINDING_EVIDENCE_KEYS:
+                    val = item_map.get(key)
+                    if isinstance(val, str) and val:
+                        props[key] = val
+                analysis = item.get("analysis")
+                if analysis:
+                    props["analysis"] = analysis
+                if props:
+                    sarif_result["properties"] = props
                 sarif_results.append(sarif_result)
 
         sarif_output = {
@@ -461,6 +483,14 @@ def doctor(
                 line.append(f" ({status})", "italic dim")
 
             console.print(line)
+
+            # Finding Contract v2 (issue #348): surface source-verified freshness
+            # for date / compatibility findings that carry it.
+            freshness = format_freshness_line(
+                item.get("last_verified", ""), item.get("source_url", "")
+            )
+            if freshness:
+                console.print(f"    [dim]{freshness}[/dim]")
 
             # show hint as 'fix:' only when verbose is enabled
             if status != "pass" and verbose:

--- a/src/azure_functions_doctor/doctor.py
+++ b/src/azure_functions_doctor/doctor.py
@@ -4,12 +4,13 @@ import importlib.resources
 import json
 from pathlib import Path
 import time
-from typing import Literal, Optional, TypedDict
+from typing import Literal, Mapping, Optional, TypedDict, cast
 
 from jsonschema import ValidationError, validate
 
 from azure_functions_doctor.handlers import (
     EXCLUDED_PROJECT_DIRS,
+    HandlerResult,
     Rule,
     RuleContext,
     _discover_functionapp_aliases,
@@ -26,6 +27,24 @@ ProgrammingModel = Literal["v2", "unsupported_v1", "mixed", "unknown"]
 
 _VALID_SEVERITIES = ("error", "warning", "info")
 _VALID_TIERS = ("core", "extended", "experimental")
+
+# Finding Contract v2 (issue #348): the machine-output schema version for the
+# ``json`` format. Bumped from the implicit v1 (which carried only rule_id /
+# status / severity / tier) to v2, which adds auditable evidence and freshness
+# fields plus an ``analysis`` block. This is independent of the SARIF schema
+# version ("2.1.0").
+FINDING_SCHEMA_VERSION = "2.0"
+
+# Finding Contract v2 evidence / freshness fields carried from a handler result
+# into the emitted finding. All are optional strings.
+FINDING_EVIDENCE_KEYS = (
+    "evidence",
+    "expected",
+    "actual",
+    "source_url",
+    "last_verified",
+    "catalog_version",
+)
 
 
 def _resolve_severity(rule: Rule) -> str:
@@ -65,6 +84,14 @@ class CheckResult(TypedDict, total=False):
     line: int
     end_line: int
     column: int
+    # Finding Contract v2 (issue #348): auditable evidence + freshness metadata.
+    evidence: str
+    expected: str
+    actual: str
+    source_url: str
+    last_verified: str
+    catalog_version: str
+    analysis: dict[str, str]
 
 
 class SectionResult(TypedDict):
@@ -72,6 +99,27 @@ class SectionResult(TypedDict):
     category: str
     status: str  # 'pass' or 'fail'
     items: list[CheckResult]
+
+
+
+
+def _apply_finding_contract_v2(item: CheckResult, result: HandlerResult) -> None:
+    """Attach Finding Contract v2 metadata (issue #348) to a finding.
+
+    Copies any auditable evidence / freshness fields a handler emitted
+    (``evidence``, ``expected``, ``actual``, ``source_url``, ``last_verified``,
+    ``catalog_version``) into the finding, and always records the deterministic
+    analysis marker. ``analysis.type = "deterministic"`` is preferred over a
+    ``confidence`` float so this diagnostic output stays cleanly separated from
+    any future agent-inferred findings.
+    """
+    result_map = cast(Mapping[str, object], result)
+    item_map = cast("dict[str, object]", item)
+    for key in FINDING_EVIDENCE_KEYS:
+        value = result_map.get(key)
+        if isinstance(value, str) and value:
+            item_map[key] = value
+    item["analysis"] = {"type": "deterministic"}
 
 
 class Doctor:
@@ -234,6 +282,7 @@ class Doctor:
                     "severity": "error",
                     "tier": "core",
                     "hint": hint,
+                    "analysis": {"type": "deterministic"},
                 }
             ],
         }
@@ -366,6 +415,8 @@ class Doctor:
                     "severity": severity,
                     "tier": tier,
                 }
+
+                _apply_finding_contract_v2(item, result)
 
                 if failed and gate:
                     section_result["status"] = "fail"

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -66,6 +66,14 @@ class HandlerResult(TypedDict, total=False):
     line: int
     end_line: int
     column: int
+    # Finding Contract v2 (issue #348): optional auditable evidence a handler
+    # may emit for date / compatibility findings.
+    evidence: str
+    expected: str
+    actual: str
+    source_url: str
+    last_verified: str
+    catalog_version: str
 
 
 class RuleContext(TypedDict, total=False):

--- a/src/azure_functions_doctor/utils.py
+++ b/src/azure_functions_doctor/utils.py
@@ -68,3 +68,23 @@ def format_detail(status: str, value: str) -> Text:
     """
     color = DETAIL_COLOR_MAP.get(status, "white")
     return Text(value, style=color)
+
+
+def format_freshness_line(last_verified: str, source_url: str = "") -> str:
+    """Render the Finding Contract v2 freshness line for date/compat findings.
+
+    Args:
+        last_verified: The ``YYYY-MM-DD`` date the underlying fact was verified.
+        source_url: Optional authoritative source URL for the fact.
+
+    Returns:
+        A human-readable ``verified as of YYYY-MM-DD`` string, with the source
+        URL appended when available. Returns an empty string when
+        ``last_verified`` is missing so callers can skip rendering.
+    """
+    if not last_verified:
+        return ""
+    line = f"verified as of {last_verified}"
+    if source_url:
+        line += f" — {source_url}"
+    return line

--- a/tests/test_finding_contract_v2.py
+++ b/tests/test_finding_contract_v2.py
@@ -1,0 +1,203 @@
+"""Tests for Finding Contract v2 output (issue #348).
+
+Covers the machine-output schema bump (``schema_version``), the deterministic
+``analysis`` marker attached to every finding, threading of auditable evidence /
+freshness fields from a handler result into a finding, their surfacing in JSON /
+SARIF / human output, and the ``verified as of`` freshness rendering.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from azure_functions_doctor.cli import cli as app
+from azure_functions_doctor.doctor import (
+    FINDING_SCHEMA_VERSION,
+    CheckResult,
+    Doctor,
+    SectionResult,
+    _apply_finding_contract_v2,
+)
+from azure_functions_doctor.handlers import HandlerResult
+from azure_functions_doctor.utils import format_freshness_line
+
+runner = CliRunner()
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# format_freshness_line
+# ---------------------------------------------------------------------------
+
+
+def test_format_freshness_line_with_source() -> None:
+    line = format_freshness_line("2026-09-06", "https://learn.microsoft.com/azure")
+    assert line == "verified as of 2026-09-06 — https://learn.microsoft.com/azure"
+
+
+def test_format_freshness_line_without_source() -> None:
+    assert format_freshness_line("2026-09-06") == "verified as of 2026-09-06"
+
+
+def test_format_freshness_line_missing_date_is_empty() -> None:
+    assert format_freshness_line("") == ""
+    assert format_freshness_line("", "https://example.com") == ""
+
+
+# ---------------------------------------------------------------------------
+# _apply_finding_contract_v2
+# ---------------------------------------------------------------------------
+
+
+def test_apply_contract_copies_evidence_and_sets_analysis() -> None:
+    item: CheckResult = {"rule_id": "r", "status": "fail"}
+    result: HandlerResult = {
+        "status": "fail",
+        "evidence": "linuxFxVersion Python|3.9",
+        "expected": ">=3.10",
+        "actual": "3.9",
+        "source_url": "https://learn.microsoft.com/azure",
+        "last_verified": "2026-09-06",
+        "catalog_version": "1.0.0",
+    }
+    _apply_finding_contract_v2(item, result)
+    assert item["evidence"] == "linuxFxVersion Python|3.9"
+    assert item["expected"] == ">=3.10"
+    assert item["actual"] == "3.9"
+    assert item["source_url"] == "https://learn.microsoft.com/azure"
+    assert item["last_verified"] == "2026-09-06"
+    assert item["catalog_version"] == "1.0.0"
+    assert item["analysis"] == {"type": "deterministic"}
+
+
+def test_apply_contract_sets_analysis_without_evidence() -> None:
+    item: CheckResult = {"rule_id": "r", "status": "pass"}
+    _apply_finding_contract_v2(item, {"status": "pass"})
+    assert item["analysis"] == {"type": "deterministic"}
+    assert "evidence" not in item
+    assert "last_verified" not in item
+
+
+def test_apply_contract_ignores_empty_evidence_values() -> None:
+    item: CheckResult = {"rule_id": "r", "status": "fail"}
+    _apply_finding_contract_v2(item, {"status": "fail", "evidence": ""})
+    assert "evidence" not in item
+
+
+# ---------------------------------------------------------------------------
+# Every real finding carries the deterministic analysis marker
+# ---------------------------------------------------------------------------
+
+
+def _all_items(results: list[SectionResult]) -> list[CheckResult]:
+    return [item for section in results for item in section["items"]]
+
+
+def test_every_finding_has_deterministic_analysis(tmp_path: Path) -> None:
+    doctor = Doctor(str(tmp_path))
+    results = doctor.run_all_checks()
+    items = _all_items(results)
+    assert items  # non-v2 project short-circuits to at least one finding
+    assert all(item.get("analysis") == {"type": "deterministic"} for item in items)
+
+
+# ---------------------------------------------------------------------------
+# JSON output: schema_version + analysis
+# ---------------------------------------------------------------------------
+
+
+def test_json_output_includes_schema_version_and_analysis() -> None:
+    result = runner.invoke(
+        app, ["doctor", "--path", str(FIXTURES_DIR / "unknown"), "--format", "json"]
+    )
+    data = json.loads(result.output)
+    assert data["schema_version"] == FINDING_SCHEMA_VERSION
+    findings = [item for section in data["results"] for item in section["items"]]
+    assert findings
+    assert all(item["analysis"]["type"] == "deterministic" for item in findings)
+
+
+# ---------------------------------------------------------------------------
+# SARIF output: analysis in properties
+# ---------------------------------------------------------------------------
+
+
+def test_sarif_findings_carry_deterministic_analysis() -> None:
+    result = runner.invoke(
+        app, ["doctor", "--path", str(FIXTURES_DIR / "unknown"), "--format", "sarif"]
+    )
+    data = json.loads(result.output)
+    findings = data["runs"][0]["results"]
+    assert findings
+    for finding in findings:
+        assert finding["properties"]["analysis"]["type"] == "deterministic"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end evidence rendering (JSON / SARIF / human) via injected finding
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_section() -> list[SectionResult]:
+    item: CheckResult = {
+        "rule_id": "python_runtime_lifecycle",
+        "label": "Python runtime lifecycle",
+        "value": "Python 3.10 support ends in October 2026",
+        "status": "warn",
+        "severity": "warning",
+        "tier": "core",
+        "evidence": "requires-python >=3.10",
+        "expected": "supported runtime",
+        "actual": "retiring-soon",
+        "source_url": "https://learn.microsoft.com/azure/functions",
+        "last_verified": "2026-09-06",
+        "catalog_version": "1.0.0",
+        "analysis": {"type": "deterministic"},
+        "file": "pyproject.toml",
+        "line": 3,
+    }
+    return [
+        {
+            "title": "Python Env",
+            "category": "python_env",
+            "status": "pass",
+            "items": [item],
+        }
+    ]
+
+
+@pytest.fixture
+def _patched_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Doctor, "run_all_checks", lambda self, rules=None: _synthetic_section())
+
+
+def test_json_surfaces_evidence_fields(_patched_checks: None, tmp_path: Path) -> None:
+    result = runner.invoke(app, ["doctor", "--path", str(tmp_path), "--format", "json"])
+    data = json.loads(result.output)
+    finding = data["results"][0]["items"][0]
+    assert finding["evidence"] == "requires-python >=3.10"
+    assert finding["expected"] == "supported runtime"
+    assert finding["actual"] == "retiring-soon"
+    assert finding["source_url"] == "https://learn.microsoft.com/azure/functions"
+    assert finding["last_verified"] == "2026-09-06"
+    assert finding["catalog_version"] == "1.0.0"
+    assert finding["analysis"]["type"] == "deterministic"
+
+
+def test_sarif_surfaces_evidence_properties(_patched_checks: None, tmp_path: Path) -> None:
+    result = runner.invoke(app, ["doctor", "--path", str(tmp_path), "--format", "sarif"])
+    data = json.loads(result.output)
+    props = data["runs"][0]["results"][0]["properties"]
+    assert props["evidence"] == "requires-python >=3.10"
+    assert props["source_url"] == "https://learn.microsoft.com/azure/functions"
+    assert props["last_verified"] == "2026-09-06"
+    assert props["catalog_version"] == "1.0.0"
+    assert props["analysis"]["type"] == "deterministic"
+
+
+def test_human_output_shows_verified_as_of(_patched_checks: None, tmp_path: Path) -> None:
+    result = runner.invoke(app, ["doctor", "--path", str(tmp_path), "--format", "table"])
+    assert "verified as of 2026-09-06" in result.output
+    assert "https://learn.microsoft.com/azure/functions" in result.output

--- a/tests/test_programming_model_detection.py
+++ b/tests/test_programming_model_detection.py
@@ -223,6 +223,7 @@ x = 1
                         "severity": "error",
                         "tier": "core",
                         "hint": UNSUPPORTED_V1_HINT,
+                        "analysis": {"type": "deterministic"},
                     }
                 ],
             }
@@ -250,6 +251,7 @@ x = 1
                         "severity": "error",
                         "tier": "core",
                         "hint": UNKNOWN_HINT,
+                        "analysis": {"type": "deterministic"},
                     }
                 ],
             }


### PR DESCRIPTION
## Summary
Implements **Finding Contract v2** (#348), extending the JSON finding schema with deterministic, auditable evidence so findings are offline-verifiable and traceable to a source.

- Adds top-level `schema_version` (`"2.0"`) to JSON output.
- Extends `CheckResult`/`HandlerResult` with `evidence`, `expected`, `actual`, `source_url`, `last_verified`, `catalog_version`.
- Attaches `analysis.type = "deterministic"` to **every** finding (including the programming-model short-circuit path) — a clean separation from future agent-inferred `confidence` scoring (explicitly out of scope).
- Surfaces evidence across all output formats:
  - **JSON**: new fields on each finding + top-level `schema_version`.
  - **SARIF**: evidence keys + `analysis` copied into result `properties`.
  - **Human**: `verified as of YYYY-MM-DD — {source_url}` freshness line for date/compat findings.

## Testing
- `hatch run pytest --cov` — **96.90%** total coverage (gate ≥95%), all tests pass.
- `hatch run style` (ruff) — pass.
- `hatch run typecheck` (mypy strict) — pass, 46 files.
- New `tests/test_finding_contract_v2.py` covers freshness rendering, evidence copying, deterministic-analysis invariant, and JSON/SARIF/human surfacing end-to-end.
- Updated existing exact-dict assertions in `test_programming_model_detection.py` for the new `analysis` key (documented, backward-compatible additive change).

Refs #341
Closes #348