### PR TITLE
feat(runtime): add date-based Python runtime lifecycle check

### DIFF
--- a/docs/rule_inventory.md
+++ b/docs/rule_inventory.md
@@ -12,6 +12,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `check_programming_model_v2` | Programming model v2 | project_structure | programming_model | `source_code_contains` | No | full |
 | `check_blueprint_registration` | Blueprint registration | project_structure | programming_model | `blueprint_registration` | No | full |
 | `check_python_version` | Python version | environment | python_env | `compare_version` | Yes | minimal, full |
+| `check_python_runtime_lifecycle` | Python runtime lifecycle | environment | python_env | `python_runtime_lifecycle` | No | full |
 | `check_venv` | Virtual environment | environment | python_env | `any_of_exists` | No | full |
 | `check_python_executable` | Python executable | environment | python_env | `path_exists` | No | full |
 | `check_requirements_txt` | requirements.txt | dependencies | python_env | `dependency_manifest` | Yes | minimal, full |
@@ -65,6 +66,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `host_json_version` | Checks that `host.json` declares `"version": "2.0"`. |
 | `local_settings_security` | Checks that `local.settings.json` is not tracked by git. |
 | `host_json_extension_bundle_version` | Checks that `extensionBundle` in `host.json` uses the recommended v4 range. |
+| `python_runtime_lifecycle` | Checks the target Python version against its published Azure Functions end-of-support date (WARN when retiring soon, FAIL when past end-of-support), rendered at the catalog's date precision. |
 
 ## False-positive Risk
 

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -48,8 +48,29 @@
     "source_url": "https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python#supported-python-versions",
     "why_it_matters": "Azure Functions supports only Python 3.10\u20133.14. Targeting an older interpreter (\u2264 3.9) or a version newer than the runtime supports causes deployment failures and unsupported runtime errors.",
     "symptoms": "Deployment fails with 'Python version not supported'; functions fail to start; a too-new interpreter is silently downgraded or rejected by the host.",
-    "fix_command": "pyenv install 3.10.16",
+    "fix_command": "pyenv install 3.12",
     "check_order": 1
+  },
+  {
+    "id": "check_python_runtime_lifecycle",
+    "category": "environment",
+    "section": "python_env",
+    "label": "Python runtime lifecycle",
+    "description": "Checks the target Python version against its published Azure Functions end-of-support date, warning on a retiring runtime and failing on one past end-of-support.",
+    "type": "python_runtime_lifecycle",
+    "required": false,
+    "tier": "core",
+    "condition": {
+      "target": "python"
+    },
+    "hint": "Target a Python version with a long support runway (3.12+). Upgrade a retiring runtime before its Azure Functions end-of-support date.",
+    "hint_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+    "source_type": "ms_learn",
+    "source_title": "Azure Functions \u2014 Supported languages (Python runtime lifecycle)",
+    "source_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+    "why_it_matters": "Azure Functions retires Python runtimes on a published schedule. Deploying on a runtime at or past end-of-support risks losing security updates and, eventually, the ability to deploy at all.",
+    "symptoms": "Deployments on a retiring runtime keep working until the end-of-support date, then fail or lose patching; upgrades left too late force a rushed migration.",
+    "check_order": 2
   },
   {
     "id": "check_venv",

--- a/src/azure_functions_doctor/compatibility.py
+++ b/src/azure_functions_doctor/compatibility.py
@@ -208,16 +208,21 @@ class Catalog:
         """Backward-compatible alias for :meth:`known_python_versions`."""
         return self.known_python_versions()
 
-    def python_eos(self, version: str) -> Optional[SupportEnd]:
-        """Return the published end-of-support date for a Python ``version``."""
+    def python_lifecycle_fact(self, version: str) -> Optional[Fact]:
+        """Return the ``python_runtime_lifecycle`` fact for a Python ``version``."""
         target = _parse_major_minor(version)
         if target is None:
             return None
         for fact in self.facts_by_category("python_runtime_lifecycle"):
             applies = fact.applies_to.get("python")
             if applies is not None and _parse_major_minor(applies) == target:
-                return fact.support_end
+                return fact
         return None
+
+    def python_eos(self, version: str) -> Optional[SupportEnd]:
+        """Return the published end-of-support date for a Python ``version``."""
+        fact = self.python_lifecycle_fact(version)
+        return fact.support_end if fact is not None else None
 
     def hosting_plan_matrix(self) -> dict[str, tuple[str, ...]]:
         """Reconstruct the per-plan supported-Python matrix from the catalog.

--- a/src/azure_functions_doctor/doctor.py
+++ b/src/azure_functions_doctor/doctor.py
@@ -391,6 +391,15 @@ class Doctor:
                 severity = _resolve_severity(rule)
                 gate = _resolve_gate(rule)
                 tier = _resolve_tier(rule)
+                # A handler may refine severity/gate per finding (issue #343):
+                # e.g. a runtime-lifecycle check WARNs on a retiring runtime but
+                # FAILs on one past end-of-support. When absent, rule defaults win.
+                handler_severity = result.get("severity")
+                if handler_severity in _VALID_SEVERITIES:
+                    severity = str(handler_severity)
+                handler_gate = result.get("gate")
+                if isinstance(handler_gate, bool):
+                    gate = handler_gate
                 rule_id = rule.get("id", "unknown_rule")
                 if handler_status == "pass":
                     canonical = "pass"

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -74,6 +74,11 @@ class HandlerResult(TypedDict, total=False):
     source_url: str
     last_verified: str
     catalog_version: str
+    # Per-finding severity / gate refinements (issue #343): a handler may WARN on
+    # a retiring runtime but FAIL on an unsupported one, overriding the rule's
+    # static severity/gate. Both are optional; when absent the rule defaults win.
+    severity: str
+    gate: bool
 
 
 class RuleContext(TypedDict, total=False):

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -1,3 +1,4 @@
+from datetime import date
 import importlib.util
 import json
 import os
@@ -12,6 +13,7 @@ from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion
 from packaging.version import parse as parse_version
 
+from azure_functions_doctor.compatibility import Catalog, load_catalog
 from azure_functions_doctor.handlers._helpers import (
     _HOST_JSON_MISSING,
     _PYTHON_CANDIDATES,
@@ -56,6 +58,82 @@ from azure_functions_doctor.target_resolver import (
     resolve_python_target,
     resolve_target_value,
 )
+
+# Issue #343: a Python runtime is flagged "retiring soon" (WARN) when its
+# published Azure Functions end-of-support date falls within this many days of
+# today. Beyond the window the runtime is "supported" (PASS); once the date has
+# passed it is "unsupported" (FAIL). Comparison uses the last calendar day the
+# source guarantees (month/year precision is widened, never narrowed), so the
+# tool never asserts a finer date than Microsoft publishes.
+PYTHON_RETIRING_SOON_WINDOW_DAYS = 180
+
+
+def _evaluate_python_lifecycle(
+    version: str,
+    *,
+    today: date,
+    catalog: Optional[Catalog] = None,
+) -> HandlerResult:
+    """Classify a Python ``version`` against its catalog end-of-support date.
+
+    Returns a :class:`HandlerResult` whose ``status``/``severity``/``gate`` encode
+    one of three deterministic states:
+
+    * **supported** -> ``pass``
+    * **retiring soon** (within :data:`PYTHON_RETIRING_SOON_WINDOW_DAYS`) ->
+      failing status refined to ``warning`` severity, non-gating
+    * **unsupported** (past end-of-support) -> failing status refined to
+      ``error`` severity, gating
+
+    Dates are rendered at the precision the catalog publishes (e.g.
+    ``"October 2026"``); no day-level countdown is synthesized. Auditable
+    evidence (source URL, ``last_verified``, ``catalog_version``) is attached so
+    the finding is offline-verifiable per the Finding Contract v2 (issue #348).
+    """
+    cat = load_catalog() if catalog is None else catalog
+    fact = cat.python_lifecycle_fact(version)
+    if fact is None or fact.support_end is None:
+        # No lifecycle data for this version (e.g. a version outside the
+        # supported band); check_python_version owns that failure, so stay quiet.
+        return _create_result("pass", f"Python {version}: no catalog lifecycle data")
+
+    eos = fact.support_end
+    rendered = eos.render()
+    end = eos.end_date()
+    last_verified = fact.last_verified or cat.last_verified
+
+    if end is not None and today > end:
+        status, severity, gate = "fail", "error", True
+        detail = (
+            f"Python {version} is past Azure Functions end-of-support "
+            f"(ended {rendered}); upgrade to a supported Python (3.12+)."
+        )
+    elif end is not None and (end - today).days <= PYTHON_RETIRING_SOON_WINDOW_DAYS:
+        status, severity, gate = "fail", "warning", False
+        detail = (
+            f"Python {version} support is expected to end in {rendered}; "
+            f"plan an upgrade to a newer Python (3.12+) before then."
+        )
+    else:
+        status, severity, gate = "pass", "info", False
+        detail = (
+            f"Python {version} is supported; Azure Functions support is "
+            f"expected to end in {rendered}."
+        )
+
+    result = _create_result(status, detail)
+    result["severity"] = severity
+    result["gate"] = gate
+    result["evidence"] = detail
+    result["expected"] = "A supported Azure Functions Python runtime (3.12+)"
+    result["actual"] = f"Python {version} (support ends {rendered})"
+    if fact.source_url:
+        result["source_url"] = fact.source_url
+    if last_verified:
+        result["last_verified"] = last_verified
+    if cat.catalog_version:
+        result["catalog_version"] = cat.catalog_version
+    return result
 
 
 class HandlerRegistry:
@@ -156,6 +234,21 @@ class HandlerRegistry:
             )
 
         return _create_result("fail", f"Unknown target for version comparison: {target}")
+
+    @_rule_handler
+    def _handle_python_runtime_lifecycle(
+        self, rule: Rule, path: Path, context: Optional[RuleContext] = None
+    ) -> HandlerResult:
+        """Flag a target Python runtime that is retiring soon or unsupported.
+
+        Reads end-of-support dates from the compatibility catalog (never
+        hardcoded) and renders them at the catalog's published precision, so a
+        month-precision source yields e.g. "October 2026" with no invented day
+        or countdown.
+        """
+        target_python = context.get("target_python") if context is not None else None
+        version, _source = resolve_python_target(path, override=target_python)
+        return _evaluate_python_lifecycle(version, today=date.today())
 
     @_rule_handler
     def _handle_env_var_exists(

--- a/src/azure_functions_doctor/schemas/rules.schema.json
+++ b/src/azure_functions_doctor/schemas/rules.schema.json
@@ -81,7 +81,8 @@
           "linux_fx_version",
           "host_json_log_level_conflict",
           "dev_storage_connection",
-          "unpinned_requirements"
+          "unpinned_requirements",
+          "python_runtime_lifecycle"
         ]
       },
       "required": {

--- a/tests/test_python_runtime_lifecycle.py
+++ b/tests/test_python_runtime_lifecycle.py
@@ -31,7 +31,10 @@ class TestEvaluatePythonLifecycle:
         # Rendered at month precision: no invented day or countdown.
         assert "October 2028" in result["detail"]
         assert "remaining" not in result["detail"]
-        assert result["source_url"].startswith("https://learn.microsoft.com")
+        assert (
+            result["source_url"]
+            == "https://learn.microsoft.com/azure/azure-functions/supported-languages"
+        )
         assert result["last_verified"] == "2026-09-06"
         assert result["catalog_version"] == "1.0.0"
 

--- a/tests/test_python_runtime_lifecycle.py
+++ b/tests/test_python_runtime_lifecycle.py
@@ -1,0 +1,138 @@
+"""Tests for the date-based Python runtime lifecycle check (issue #343)."""
+
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from azure_functions_doctor.compatibility import load_catalog
+from azure_functions_doctor.doctor import Doctor
+from azure_functions_doctor.handlers.registry import (
+    PYTHON_RETIRING_SOON_WINDOW_DAYS,
+    _evaluate_python_lifecycle,
+)
+
+EXAMPLE_V2 = Path(__file__).resolve().parent.parent / "examples" / "v2" / "http-trigger"
+
+# A date well before every catalog end-of-support (all EOS are 2026-10 or later),
+# yet within the retiring-soon window of the earliest (Python 3.10, Oct 2026).
+BEFORE_ANY_EOS = date(2026, 9, 6)
+# A date after Python 3.10's end-of-support (Oct 2026) but before 3.11's (Oct 2027).
+AFTER_310_EOS = date(2026, 11, 1)
+
+
+class TestEvaluatePythonLifecycle:
+    """Unit tests for the pure ``_evaluate_python_lifecycle`` classifier."""
+
+    def test_supported_version_passes_with_month_precision(self) -> None:
+        result = _evaluate_python_lifecycle("3.12", today=BEFORE_ANY_EOS)
+        assert result["status"] == "pass"
+        assert result["severity"] == "info"
+        assert result["gate"] is False
+        # Rendered at month precision: no invented day or countdown.
+        assert "October 2028" in result["detail"]
+        assert "remaining" not in result["detail"]
+        assert result["source_url"].startswith("https://learn.microsoft.com")
+        assert result["last_verified"] == "2026-09-06"
+        assert result["catalog_version"] == "1.0.0"
+
+    def test_retiring_soon_warns_without_gating(self) -> None:
+        result = _evaluate_python_lifecycle("3.10", today=BEFORE_ANY_EOS)
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+        assert result["gate"] is False
+        assert "expected to end in October 2026" in result["detail"]
+        # Month precision only — never a specific day or day countdown.
+        assert "October 2026" in result["actual"]
+        assert "days" not in result["detail"]
+
+    def test_unsupported_version_fails_and_gates(self) -> None:
+        result = _evaluate_python_lifecycle("3.10", today=AFTER_310_EOS)
+        assert result["status"] == "fail"
+        assert result["severity"] == "error"
+        assert result["gate"] is True
+        assert "past Azure Functions end-of-support" in result["detail"]
+        assert "October 2026" in result["detail"]
+
+    def test_unknown_version_is_neutral(self) -> None:
+        result = _evaluate_python_lifecycle("3.15", today=BEFORE_ANY_EOS)
+        assert result["status"] == "pass"
+        assert "no catalog lifecycle data" in result["detail"]
+        # No evidence fields are emitted when there is no catalog fact.
+        assert "source_url" not in result
+        assert "severity" not in result
+
+    def test_patch_version_is_normalized(self) -> None:
+        result = _evaluate_python_lifecycle("3.10.12", today=BEFORE_ANY_EOS)
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+
+    def test_retiring_soon_threshold_boundary(self) -> None:
+        """The retiring-soon window boundary is inclusive at month precision."""
+        catalog = load_catalog()
+        eos = catalog.python_eos("3.10")
+        assert eos is not None
+        end = eos.end_date()
+        assert end is not None
+
+        on_edge = end - timedelta(days=PYTHON_RETIRING_SOON_WINDOW_DAYS)
+        before_edge = on_edge - timedelta(days=1)
+
+        assert _evaluate_python_lifecycle("3.10", today=on_edge)["status"] == "fail"
+        assert _evaluate_python_lifecycle("3.10", today=before_edge)["status"] == "pass"
+
+    def test_explicit_catalog_is_honored(self) -> None:
+        catalog = load_catalog()
+        result = _evaluate_python_lifecycle("3.11", today=BEFORE_ANY_EOS, catalog=catalog)
+        assert result["status"] == "pass"
+        assert "October 2027" in result["detail"]
+
+
+class TestCatalogLifecycleFact:
+    """Tests for the catalog helper backing the lifecycle check."""
+
+    def test_python_lifecycle_fact_returns_fact(self) -> None:
+        fact = load_catalog().python_lifecycle_fact("3.10")
+        assert fact is not None
+        assert fact.applies_to["python"] == "3.10"
+        assert fact.support_end is not None
+
+    def test_python_lifecycle_fact_unknown_returns_none(self) -> None:
+        assert load_catalog().python_lifecycle_fact("3.15") is None
+
+    def test_python_lifecycle_fact_malformed_returns_none(self) -> None:
+        assert load_catalog().python_lifecycle_fact("not-a-version") is None
+
+
+class TestLifecycleHandlerIntegration:
+    """End-to-end tests wiring the handler through the Doctor run."""
+
+    def _lifecycle_item(self, today: date) -> dict[str, object]:
+        doctor = Doctor(str(EXAMPLE_V2), target_python="3.10")
+        with patch("azure_functions_doctor.handlers.registry.date") as mock_date:
+            mock_date.today.return_value = today
+            results = doctor.run_all_checks()
+        for section in results:
+            for item in section["items"]:
+                if item["rule_id"] == "check_python_runtime_lifecycle":
+                    return dict(item)
+        raise AssertionError("lifecycle finding not emitted")
+
+    def test_retiring_runtime_surfaces_as_warning(self) -> None:
+        item = self._lifecycle_item(BEFORE_ANY_EOS)
+        assert item["status"] == "warn"
+        assert item["severity"] == "warning"
+        assert item["analysis"] == {"type": "deterministic"}
+        assert item["last_verified"] == "2026-09-06"
+        assert item["catalog_version"] == "1.0.0"
+
+    def test_unsupported_runtime_gates_the_section(self) -> None:
+        doctor = Doctor(str(EXAMPLE_V2), target_python="3.10")
+        with patch("azure_functions_doctor.handlers.registry.date") as mock_date:
+            mock_date.today.return_value = AFTER_310_EOS
+            results = doctor.run_all_checks()
+        section = next(s for s in results if s["category"] == "python_env")
+        item = next(i for i in section["items"] if i["rule_id"] == "check_python_runtime_lifecycle")
+        assert item["status"] == "fail"
+        assert item["severity"] == "error"
+        # A gating failure marks the whole section failed.
+        assert section["status"] == "fail"


### PR DESCRIPTION
## Summary
Implements **#343**: a date-based Python runtime lifecycle check. Today Python versions are treated as binary supported/unsupported, so Python 3.10 silently PASSes even though its Azure Functions support ends **October 2026**. This adds a pre-deploy WARN on a retiring runtime and a FAIL once support has ended.

- New rule `check_python_runtime_lifecycle` (type `python_runtime_lifecycle`) reading end-of-support facts from the compatibility catalog — **no hardcoded dates**.
- Three deterministic states: **supported** (PASS) / **retiring soon** within 180 days (WARN, non-gating) / **past end-of-support** (FAIL, gating).
- Dates render at the catalog's published **precision** (e.g. `"October 2026"`); never a synthesized day or `N days remaining` countdown.
- Emits Finding Contract v2 evidence (`source_url`, `last_verified`, `catalog_version`, `expected`, `actual`) + `analysis.type = "deterministic"`; human output shows the `verified as of YYYY-MM-DD — {source}` line.
- Removes the stale `pyenv install 3.10.16` fix suggestion (pushed a retiring runtime) → recommends 3.12+.

## Mechanism
A single rule must WARN on a retiring runtime but FAIL on an unsupported one — states only knowable at runtime. Handlers may now return a per-finding `severity`/`gate` that override the rule's static values; `doctor.run_all_checks` honors them when present (rule defaults win when absent).

## Testing
- `hatch run pytest --cov` — **96.87%** (gate ≥95%), 693 passed / 2 skipped.
- `hatch run style` (ruff), `hatch run typecheck` (mypy strict, 47 files) — pass.
- Docs consistency + rule-inventory `--check` — pass (35 rules).
- New `tests/test_python_runtime_lifecycle.py`: supported/retiring/unsupported/unknown states, month-precision assertions (no invented day), an inclusive retiring-soon **threshold boundary** test, catalog lookup helper, and end-to-end Doctor integration proving WARN vs gating-FAIL (interpreter-independent via `target_python="3.10"`).

Refs #341
Closes #343