### PR TITLE
feat(flex): resolve Flex Consumption runtime from functionAppConfig.runtime (#345)

### DIFF
--- a/docs/rule_inventory.md
+++ b/docs/rule_inventory.md
@@ -18,6 +18,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `check_python_executable` | Python executable | environment | python_env | `path_exists` | No | full |
 | `check_hosting_plan_lifecycle` | Hosting plan lifecycle | configuration | runtime | `hosting_plan_lifecycle` | No | full |
 | `check_requirements_txt` | requirements.txt | dependencies | python_env | `dependency_manifest` | Yes | minimal, full |
+| `check_flex_runtime_config` | Flex Consumption runtime config | configuration | runtime | `flex_runtime_config` | No | full |
 | `check_azure_functions_library` | azure-functions package | dependencies | python_env | `package_declared` | Yes | minimal, full |
 | `check_native_dependency_risk` | Native dependency risk | dependencies | python_env | `native_dependency_risk` | No | full |
 | `check_azure_functions_worker` | azure-functions-worker not pinned | dependencies | python_env | `package_forbidden` | No | full |
@@ -71,6 +72,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `python_runtime_lifecycle` | Checks the target Python version against its published Azure Functions end-of-support date (WARN when retiring soon, FAIL when past end-of-support), rendered at the catalog's date precision. |
 | `functions_runtime_lifecycle` | Checks the Azure Functions runtime major version (from `FUNCTIONS_EXTENSION_VERSION`): v1 FAILs as incompatible with Python (with a lifecycle note), v2/v3 FAIL as out of support, v3 on Linux Consumption FAILs (apps stop running on a published date), and v4 PASSes. |
 | `hosting_plan_lifecycle` | Checks the resolved hosting plan against its published retirement date: informational when far off, WARN inside the retiring-soon window, and FAIL once retired (never a FAIL merely for being scheduled). |
+| `flex_runtime_config` | For a Flex Consumption app, validates the runtime declared under `functionAppConfig.runtime` (name/version) against the supported Python versions, and WARNs when a legacy `linuxFxVersion` is present (Flex ignores it). Non-Flex apps SKIP. |
 
 ## False-positive Risk
 

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -113,6 +113,26 @@
     "check_order": 4
   },
   {
+    "id": "check_flex_runtime_config",
+    "category": "configuration",
+    "section": "runtime",
+    "label": "Flex Consumption runtime config",
+    "description": "For a Flex Consumption app, validates the runtime declared under functionAppConfig.runtime (name/version) against the supported Python versions, and warns when a legacy linuxFxVersion is present (Flex ignores it).",
+    "type": "flex_runtime_config",
+    "required": false,
+    "tier": "core",
+    "condition": {},
+    "hint": "Declare the Flex Consumption runtime under functionAppConfig.runtime (name/version); do not use linuxFxVersion.",
+    "hint_url": "https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan",
+    "source_type": "ms_learn",
+    "source_title": "Azure Functions \u2014 Flex Consumption plan (functionAppConfig.runtime)",
+    "source_url": "https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan",
+    "why_it_matters": "Flex Consumption resolves its runtime from functionAppConfig.runtime and ignores linuxFxVersion; a misdeclared or unsupported runtime version fails to deploy or run.",
+    "symptoms": "A Flex app with only linuxFxVersion set has no effective runtime declaration; an unsupported Python version is rejected at deploy time.",
+    "tags": ["runtime", "flex-consumption", "configuration"],
+    "check_order": 5
+  },
+  {
     "id": "check_venv",
     "category": "environment",
     "section": "python_env",

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -53,8 +53,10 @@ from azure_functions_doctor.handlers._helpers import (
     pyproject_dependency_names,
 )
 from azure_functions_doctor.target_resolver import (
+    PYTHON_HOSTING_PLAN_MATRIX,
     SUPPORTED_PYTHON_VERSIONS,
-    is_supported_python_target,
+    is_supported_python_for_plan,
+is_supported_python_target,
     resolve_python_target,
     resolve_target_value,
 )
@@ -363,6 +365,101 @@ def _evaluate_hosting_plan_lifecycle(
     return result
 
 
+# Issue #345: Flex Consumption declares its runtime under
+# ``functionAppConfig.runtime`` (name/version) and ignores ``linuxFxVersion``.
+# The canonical plan name matches deploy_config.PLAN_FLEX_CONSUMPTION.
+FLEX_CONSUMPTION_PLAN = "flex-consumption"
+
+_LINUX_FX_KEY_RE = re.compile(r"linuxFxVersion", re.IGNORECASE)
+
+
+def _infra_declares_linux_fx_version(path: Path) -> bool:
+    """Return ``True`` when any infra file declares a ``linuxFxVersion`` key.
+
+    Flex Consumption ignores ``linuxFxVersion``; its presence on a Flex app is a
+    misconfiguration worth surfacing. ``local.settings.json`` is a local signal,
+    not deployable infrastructure, so it is excluded.
+    """
+    for pattern in ("*.bicep", "*.json"):
+        for infra in sorted(path.rglob(pattern)):
+            if infra.name == "local.settings.json":
+                continue
+            try:
+                text = infra.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            if _LINUX_FX_KEY_RE.search(text):
+                return True
+    return False
+
+
+def _evaluate_flex_runtime_config(
+    hosting_plan: Optional[str],
+    runtime_name: Optional[str],
+    runtime_version: Optional[str],
+    *,
+    linux_fx_present: bool,
+) -> HandlerResult:
+    """Validate a Flex Consumption app's ``functionAppConfig.runtime`` (issue #345).
+
+    Only Flex apps are in scope (others SKIP). A ``linuxFxVersion`` declaration on
+    a Flex app is a misconfiguration (WARN) because Flex ignores it. Otherwise the
+    declared Python runtime version is validated against the Flex hosting-plan
+    matrix (Flex supports through 3.14); an undeclared or non-Python runtime SKIPs.
+    """
+    if hosting_plan != FLEX_CONSUMPTION_PLAN:
+        return _create_result(
+            "skip",
+            "Not a Flex Consumption app; functionAppConfig.runtime check skipped.",
+        )
+
+    if linux_fx_present:
+        detail = (
+            "linuxFxVersion is declared on a Flex Consumption app, which ignores "
+            "it; declare the runtime under functionAppConfig.runtime (name/version) "
+            "instead."
+        )
+        result = _create_result("fail", detail)
+        result["severity"] = "warning"
+        result["gate"] = False
+        result["expected"] = "Runtime declared under functionAppConfig.runtime"
+        result["actual"] = "linuxFxVersion declared on a Flex Consumption app"
+        return result
+
+    if runtime_name is None or runtime_version is None:
+        return _create_result(
+            "skip",
+            "Flex Consumption app declares no functionAppConfig.runtime "
+            "name/version; check skipped.",
+        )
+
+    if runtime_name != "python":
+        return _create_result(
+            "skip",
+            f"Flex Consumption runtime is '{runtime_name}', not Python; "
+            "Python runtime check skipped.",
+        )
+
+    if is_supported_python_for_plan(runtime_version, FLEX_CONSUMPTION_PLAN):
+        return _create_result(
+            "pass",
+            f"Flex Consumption runtime Python {runtime_version} is supported.",
+        )
+
+    allowed = PYTHON_HOSTING_PLAN_MATRIX.get(FLEX_CONSUMPTION_PLAN, SUPPORTED_PYTHON_VERSIONS)
+    supported_range = f"{allowed[0]}\u2013{allowed[-1]}" if allowed else "the supported set"
+    detail = (
+        f"Flex Consumption runtime Python {runtime_version} is not supported; "
+        f"target a supported Python runtime ({supported_range})."
+    )
+    result = _create_result("fail", detail)
+    result["severity"] = "error"
+    result["gate"] = True
+    result["expected"] = f"A supported Flex Consumption Python runtime ({supported_range})"
+    result["actual"] = f"functionAppConfig.runtime = python {runtime_version}"
+    return result
+
+
 class HandlerRegistry:
     """Registry for diagnostic check handlers with individual handler methods."""
 
@@ -507,6 +604,37 @@ class HandlerRegistry:
             target_config.hosting_plan.value if target_config is not None else None
         )
         return _evaluate_hosting_plan_lifecycle(hosting_plan, today=date.today())
+
+    @_rule_handler
+    def _handle_flex_runtime_config(
+        self, rule: Rule, path: Path, context: Optional[RuleContext] = None
+    ) -> HandlerResult:
+        """Validate a Flex Consumption app's ``functionAppConfig.runtime`` (issue #345).
+
+        Flex Consumption declares its runtime under ``functionAppConfig.runtime``
+        (name/version) rather than ``linuxFxVersion``. This check is scoped to Flex
+        apps: it WARNs when a legacy ``linuxFxVersion`` is present (Flex ignores it)
+        and otherwise validates the declared Python runtime against the Flex
+        hosting-plan matrix.
+        """
+        target_config = context.get("target_config") if context is not None else None
+        hosting_plan: Optional[str] = None
+        runtime_name: Optional[str] = None
+        runtime_version: Optional[str] = None
+        if target_config is not None:
+            hosting_plan = target_config.hosting_plan.value
+            runtime_name = target_config.runtime_name.value
+            runtime_version = target_config.runtime_version.value
+        linux_fx_present = (
+            hosting_plan == FLEX_CONSUMPTION_PLAN
+            and _infra_declares_linux_fx_version(path)
+        )
+        return _evaluate_flex_runtime_config(
+            hosting_plan,
+            runtime_name,
+            runtime_version,
+            linux_fx_present=linux_fx_present,
+        )
 
     @_rule_handler
     def _handle_env_var_exists(
@@ -1534,11 +1662,23 @@ class HandlerRegistry:
     ) -> HandlerResult:
         """Validate any Python ``linuxFxVersion`` declared in infra (bicep) config.
 
-        Flex Consumption and Linux plan apps encode their runtime in
-        ``linuxFxVersion`` (e.g. ``Python|3.12``). When such a declaration targets
+        Scoped to legacy Linux / Premium / Dedicated / classic Consumption apps.
+        Flex Consumption declares its runtime under ``functionAppConfig.runtime``
+        and ignores ``linuxFxVersion``, so Flex apps SKIP here and are handled by
+        ``check_flex_runtime_config`` (issue #345). When such a declaration targets
         a Python version outside the supported set it is flagged; when no Python
         ``linuxFxVersion`` is determinable the check is skipped.
         """
+        target_config = context.get("target_config") if context is not None else None
+        if (
+            target_config is not None
+            and target_config.hosting_plan.value == FLEX_CONSUMPTION_PLAN
+        ):
+            return _create_result(
+                "skip",
+                "Flex Consumption app; linuxFxVersion is not used "
+                "(see check_flex_runtime_config).",
+            )
         findings: list[tuple[str, str]] = []
         pattern = re.compile(r"linuxFxVersion['\"]?\s*[:=]\s*['\"]?[Pp]ython\|(\d+\.\d+)")
         for bicep in sorted(path.rglob("*.bicep")):

--- a/src/azure_functions_doctor/schemas/rules.schema.json
+++ b/src/azure_functions_doctor/schemas/rules.schema.json
@@ -84,7 +84,8 @@
           "unpinned_requirements",
           "python_runtime_lifecycle",
           "functions_runtime_lifecycle",
-          "hosting_plan_lifecycle"
+          "hosting_plan_lifecycle",
+          "flex_runtime_config"
         ]
       },
       "required": {

--- a/tests/test_flex_runtime_config.py
+++ b/tests/test_flex_runtime_config.py
@@ -1,0 +1,213 @@
+"""Tests for the Flex Consumption runtime config check (issue #345)."""
+
+from pathlib import Path
+from typing import Optional
+
+from azure_functions_doctor.deploy_config import ResolvedField, TargetConfig
+from azure_functions_doctor.handlers._helpers import RuleContext
+from azure_functions_doctor.handlers.registry import (
+    FLEX_CONSUMPTION_PLAN,
+    HandlerRegistry,
+    _evaluate_flex_runtime_config,
+    _infra_declares_linux_fx_version,
+)
+
+
+def _target_config(
+    *,
+    hosting_plan: Optional[str] = None,
+    runtime_name: Optional[str] = None,
+    runtime_version: Optional[str] = None,
+) -> TargetConfig:
+    """Build a minimal :class:`TargetConfig` for handler-level tests."""
+    unknown = ResolvedField(None, "unknown")
+    return TargetConfig(
+        hosting_plan=ResolvedField(hosting_plan, "test") if hosting_plan else unknown,
+        runtime_name=ResolvedField(runtime_name, "test") if runtime_name else unknown,
+        runtime_version=(ResolvedField(runtime_version, "test") if runtime_version else unknown),
+        extension_version=unknown,
+        deployment_storage=unknown,
+        app_settings={},
+    )
+
+
+class TestEvaluateFlexRuntimeConfig:
+    def test_non_flex_plan_skips(self) -> None:
+        result = _evaluate_flex_runtime_config(
+            "linux-consumption", "python", "3.12", linux_fx_present=False
+        )
+        assert result["status"] == "skip"
+        assert "Not a Flex Consumption app" in result["detail"]
+
+    def test_unknown_plan_skips(self) -> None:
+        result = _evaluate_flex_runtime_config(None, None, None, linux_fx_present=False)
+        assert result["status"] == "skip"
+
+    def test_linux_fx_on_flex_warns(self) -> None:
+        result = _evaluate_flex_runtime_config(
+            FLEX_CONSUMPTION_PLAN, "python", "3.12", linux_fx_present=True
+        )
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+        assert result["gate"] is False
+        assert "linuxFxVersion" in result["detail"]
+        assert result["actual"] == "linuxFxVersion declared on a Flex Consumption app"
+
+    def test_linux_fx_warn_takes_precedence_over_missing_runtime(self) -> None:
+        result = _evaluate_flex_runtime_config(
+            FLEX_CONSUMPTION_PLAN, None, None, linux_fx_present=True
+        )
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+
+    def test_no_runtime_declared_skips(self) -> None:
+        result = _evaluate_flex_runtime_config(
+            FLEX_CONSUMPTION_PLAN, None, None, linux_fx_present=False
+        )
+        assert result["status"] == "skip"
+        assert "no functionAppConfig.runtime" in result["detail"]
+
+    def test_partial_runtime_declared_skips(self) -> None:
+        result = _evaluate_flex_runtime_config(
+            FLEX_CONSUMPTION_PLAN, "python", None, linux_fx_present=False
+        )
+        assert result["status"] == "skip"
+
+    def test_non_python_runtime_skips(self) -> None:
+        result = _evaluate_flex_runtime_config(
+            FLEX_CONSUMPTION_PLAN, "dotnet-isolated", "8.0", linux_fx_present=False
+        )
+        assert result["status"] == "skip"
+        assert "not Python" in result["detail"]
+
+    def test_supported_python_passes(self) -> None:
+        result = _evaluate_flex_runtime_config(
+            FLEX_CONSUMPTION_PLAN, "python", "3.12", linux_fx_present=False
+        )
+        assert result["status"] == "pass"
+        assert "3.12 is supported" in result["detail"]
+
+    def test_supported_python_314_passes(self) -> None:
+        result = _evaluate_flex_runtime_config(
+            FLEX_CONSUMPTION_PLAN, "python", "3.14", linux_fx_present=False
+        )
+        assert result["status"] == "pass"
+
+    def test_unsupported_python_fails(self) -> None:
+        result = _evaluate_flex_runtime_config(
+            FLEX_CONSUMPTION_PLAN, "python", "3.9", linux_fx_present=False
+        )
+        assert result["status"] == "fail"
+        assert result["severity"] == "error"
+        assert result["gate"] is True
+        assert "not supported" in result["detail"]
+        assert result["actual"] == "functionAppConfig.runtime = python 3.9"
+
+
+class TestInfraDeclaresLinuxFxVersion:
+    def test_detects_bicep_linux_fx(self, tmp_path: Path) -> None:
+        (tmp_path / "main.bicep").write_text(
+            "resource site 'x' = { properties: { linuxFxVersion: 'Python|3.12' } }",
+            encoding="utf-8",
+        )
+        assert _infra_declares_linux_fx_version(tmp_path) is True
+
+    def test_detects_json_linux_fx_case_insensitive(self, tmp_path: Path) -> None:
+        (tmp_path / "azuredeploy.json").write_text(
+            '{"properties": {"siteConfig": {"LinuxFxVersion": "Python|3.12"}}}',
+            encoding="utf-8",
+        )
+        assert _infra_declares_linux_fx_version(tmp_path) is True
+
+    def test_ignores_local_settings(self, tmp_path: Path) -> None:
+        (tmp_path / "local.settings.json").write_text(
+            '{"Values": {"linuxFxVersion": "Python|3.12"}}', encoding="utf-8"
+        )
+        assert _infra_declares_linux_fx_version(tmp_path) is False
+
+    def test_no_infra_returns_false(self, tmp_path: Path) -> None:
+        assert _infra_declares_linux_fx_version(tmp_path) is False
+
+    def test_skips_unreadable_file(self, tmp_path: Path) -> None:
+        bad = tmp_path / "broken.bicep"
+        bad.write_text("no runtime keyword here", encoding="utf-8")
+        assert _infra_declares_linux_fx_version(tmp_path) is False
+
+
+class TestFlexHandlerWiring:
+    def _run(self, context: Optional[RuleContext], path: Path) -> dict[str, object]:
+        registry = HandlerRegistry()
+        return dict(registry._handle_flex_runtime_config({}, path, context))
+
+    def test_handler_without_context_skips(self, tmp_path: Path) -> None:
+        result = self._run(None, tmp_path)
+        assert result["status"] == "skip"
+
+    def test_handler_flex_supported_python_passes(self, tmp_path: Path) -> None:
+        context: RuleContext = {
+            "target_config": _target_config(
+                hosting_plan=FLEX_CONSUMPTION_PLAN,
+                runtime_name="python",
+                runtime_version="3.12",
+            ),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "pass"
+
+    def test_handler_flex_with_linux_fx_warns(self, tmp_path: Path) -> None:
+        (tmp_path / "main.bicep").write_text(
+            "properties: { linuxFxVersion: 'Python|3.12' }", encoding="utf-8"
+        )
+        context: RuleContext = {
+            "target_config": _target_config(
+                hosting_plan=FLEX_CONSUMPTION_PLAN,
+                runtime_name="python",
+                runtime_version="3.12",
+            ),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+
+    def test_handler_non_flex_skips(self, tmp_path: Path) -> None:
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan="premium"),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "skip"
+
+
+class TestLinuxFxVersionScoping:
+    """check_linux_fx_version should defer to the Flex check for Flex apps."""
+
+    def _run(self, context: Optional[RuleContext], path: Path) -> dict[str, object]:
+        registry = HandlerRegistry()
+        return dict(registry._handle_linux_fx_version({}, path, context))
+
+    def test_flex_app_skips_linux_fx_check(self, tmp_path: Path) -> None:
+        (tmp_path / "main.bicep").write_text(
+            "properties: { linuxFxVersion: 'Python|3.12' }", encoding="utf-8"
+        )
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan=FLEX_CONSUMPTION_PLAN),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "skip"
+        assert "check_flex_runtime_config" in str(result["detail"])
+
+    def test_non_flex_app_still_validates_linux_fx(self, tmp_path: Path) -> None:
+        (tmp_path / "main.bicep").write_text(
+            "properties: { linuxFxVersion: 'Python|3.9' }", encoding="utf-8"
+        )
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan="linux-consumption"),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "fail"
+
+    def test_no_context_still_validates_linux_fx(self, tmp_path: Path) -> None:
+        (tmp_path / "main.bicep").write_text(
+            "properties: { linuxFxVersion: 'Python|3.12' }", encoding="utf-8"
+        )
+        result = self._run(None, tmp_path)
+        assert result["status"] == "pass"


### PR DESCRIPTION
## Summary
- Add `check_flex_runtime_config` (`flex_runtime_config` handler): for a Flex Consumption app, validates the runtime declared under `functionAppConfig.runtime` (`name`/`version`) against the supported Python versions (Flex supports through 3.14), and **WARNs** when a legacy `linuxFxVersion` is present since Flex ignores it. Non-Flex, undeclared, or non-Python runtimes SKIP.
- Scope `check_linux_fx_version` to legacy Linux / Premium / Dedicated / classic Consumption: it now SKIPs Flex apps and defers to `check_flex_runtime_config`, so the two checks no longer overlap.
- Register the rule in `assets/rules/v2.json` (`check_order` 5, section `runtime`, core tier) and the `type` enum in `schemas/rules.schema.json`; regenerate `docs/rule_inventory.md` and add a Rule Types row.
- New `tests/test_flex_runtime_config.py` (22 tests) covering the classifier, `linuxFxVersion` detection, handler wiring, and `check_linux_fx_version` scoping.

## Verification
- `hatch run style` ✓ · `hatch run typecheck` ✓ (49 files) · docs gates ✓
- `hatch run pytest --cov` ✓ — 96.79% (≥ 95% gate)

Part of #341. Closes #345.