### PR TITLE
feat(flex): make FUNCTIONS_EXTENSION_VERSION check Flex-aware (#346)

### DIFF
--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -460,6 +460,32 @@ def _evaluate_flex_runtime_config(
     return result
 
 
+def _evaluate_flex_extension_version(ext_value: Optional[str]) -> HandlerResult:
+    """Classify FUNCTIONS_EXTENSION_VERSION for a Flex Consumption app (issue #346).
+
+    Flex Consumption does not support the ``FUNCTIONS_EXTENSION_VERSION`` app
+    setting: it only runs on runtime v4 and the value is backend-managed. A
+    missing value is therefore correct (SKIP), while an explicit value is a
+    deprecated/unsupported setting worth surfacing (WARN).
+    """
+    if ext_value is None:
+        return _create_result(
+            "skip",
+            "FUNCTIONS_EXTENSION_VERSION is not required on Flex Consumption "
+            "(the runtime is v4 and backend-managed); check skipped.",
+        )
+    detail = (
+        f"FUNCTIONS_EXTENSION_VERSION is set to '{ext_value}' but is not supported "
+        "on Flex Consumption; the runtime is v4 and backend-managed. Remove the setting."
+    )
+    result = _create_result("fail", detail)
+    result["severity"] = "warning"
+    result["gate"] = False
+    result["expected"] = "No FUNCTIONS_EXTENSION_VERSION on Flex Consumption"
+    result["actual"] = f"FUNCTIONS_EXTENSION_VERSION = {ext_value}"
+    return result
+
+
 class HandlerRegistry:
     """Registry for diagnostic check handlers with individual handler methods."""
 
@@ -1627,7 +1653,17 @@ class HandlerRegistry:
         The v1/v2/v3 runtimes are retired, so ``local.settings.json`` should pin
         the extension version to the current runtime (``~4`` by default). The
         expected value is overridable via ``condition.value``.
+
+        Flex Consumption is special-cased (issue #346): it does not support this
+        app setting at all, so a missing value SKIPs and an explicit value WARNs
+        instead of following the legacy-runtime logic.
         """
+        target_config = context.get("target_config") if context is not None else None
+        if (
+            target_config is not None
+            and target_config.hosting_plan.value == FLEX_CONSUMPTION_PLAN
+        ):
+            return _evaluate_flex_extension_version(target_config.extension_version.value)
         condition = rule.get("condition", {}) or {}
         expected = str(condition.get("value") or "~4")
         settings_path = path / "local.settings.json"

--- a/tests/test_flex_extension_version.py
+++ b/tests/test_flex_extension_version.py
@@ -1,0 +1,112 @@
+"""Tests for the Flex-aware FUNCTIONS_EXTENSION_VERSION check (issue #346)."""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from azure_functions_doctor.deploy_config import ResolvedField, TargetConfig
+from azure_functions_doctor.handlers._helpers import RuleContext
+from azure_functions_doctor.handlers.registry import (
+    FLEX_CONSUMPTION_PLAN,
+    HandlerRegistry,
+    _evaluate_flex_extension_version,
+)
+
+
+def _target_config(
+    *,
+    hosting_plan: Optional[str] = None,
+    extension_version: Optional[str] = None,
+) -> TargetConfig:
+    unknown = ResolvedField(None, "unknown")
+    return TargetConfig(
+        hosting_plan=ResolvedField(hosting_plan, "test") if hosting_plan else unknown,
+        runtime_name=unknown,
+        runtime_version=unknown,
+        extension_version=(
+            ResolvedField(extension_version, "test") if extension_version else unknown
+        ),
+        deployment_storage=unknown,
+        app_settings={},
+    )
+
+
+def _write_local_settings(path: Path, ext: Optional[str]) -> None:
+    values = {} if ext is None else {"FUNCTIONS_EXTENSION_VERSION": ext}
+    (path / "local.settings.json").write_text(json.dumps({"Values": values}), encoding="utf-8")
+
+
+class TestEvaluateFlexExtensionVersion:
+    def test_missing_skips(self) -> None:
+        result = _evaluate_flex_extension_version(None)
+        assert result["status"] == "skip"
+        assert "not required on Flex Consumption" in result["detail"]
+
+    def test_present_warns(self) -> None:
+        result = _evaluate_flex_extension_version("~4")
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+        assert result["gate"] is False
+        assert "not supported" in result["detail"]
+        assert result["actual"] == "FUNCTIONS_EXTENSION_VERSION = ~4"
+
+
+class TestHandlerFlexAware:
+    def _run(self, context: Optional[RuleContext], path: Path) -> dict[str, object]:
+        registry = HandlerRegistry()
+        return dict(registry._handle_functions_extension_version({}, path, context))
+
+    def test_flex_missing_skips(self, tmp_path: Path) -> None:
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan=FLEX_CONSUMPTION_PLAN),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "skip"
+        assert "Flex Consumption" in str(result["detail"])
+
+    def test_flex_present_warns(self, tmp_path: Path) -> None:
+        context: RuleContext = {
+            "target_config": _target_config(
+                hosting_plan=FLEX_CONSUMPTION_PLAN, extension_version="~4"
+            ),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+
+    def test_non_flex_missing_still_fails(self, tmp_path: Path) -> None:
+        _write_local_settings(tmp_path, None)
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan="linux-consumption"),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "fail"
+        assert "not set" in str(result["detail"])
+
+    def test_non_flex_v4_passes(self, tmp_path: Path) -> None:
+        _write_local_settings(tmp_path, "~4")
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan="premium"),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "pass"
+
+    def test_non_flex_legacy_fails(self, tmp_path: Path) -> None:
+        _write_local_settings(tmp_path, "~3")
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan="linux-consumption"),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "fail"
+        assert "Legacy runtimes" in str(result["detail"])
+
+    def test_no_context_keeps_legacy_behavior(self, tmp_path: Path) -> None:
+        # No target_config: not treated as Flex, existing local.settings logic runs.
+        _write_local_settings(tmp_path, "~4")
+        result = self._run(None, tmp_path)
+        assert result["status"] == "pass"
+
+    def test_no_context_missing_settings_skips(self, tmp_path: Path) -> None:
+        result = self._run(None, tmp_path)
+        assert result["status"] == "skip"
+        assert "not present" in str(result["detail"])


### PR DESCRIPTION
## Summary
- Special-case Flex Consumption in `check_functions_extension_version`: Flex does not support the `FUNCTIONS_EXTENSION_VERSION` app setting (runtime is v4 and backend-managed), so a **missing** value now SKIPs and an **explicit** value now WARNs (non-gating) instead of following the legacy-runtime FAIL logic.
- Non-Flex plans keep the existing behavior: `~4` PASS, missing/legacy `~1/~2/~3` FAIL.
- Plan detection uses the resolved `TargetConfig` (issue #347); the presence signal is `extension_version` (IaC app settings + local.settings.json).
- New `tests/test_flex_extension_version.py` (9 tests) covering the Flex classifier and handler wiring across Flex vs non-Flex.

## Verification
- `hatch run style` ✓ · `hatch run typecheck` ✓ (50 files) · docs consistency ✓
- `hatch run pytest --cov` ✓ — 96.80% (≥ 95% gate)

Part of #341. Closes #346.