### PR TITLE
feat(flex): add Flex Consumption deprecated app settings check (#350)

### DIFF
--- a/docs/rule_inventory.md
+++ b/docs/rule_inventory.md
@@ -20,6 +20,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `check_requirements_txt` | requirements.txt | dependencies | python_env | `dependency_manifest` | Yes | minimal, full |
 | `check_flex_runtime_config` | Flex Consumption runtime config | configuration | runtime | `flex_runtime_config` | No | full |
 | `check_azure_functions_library` | azure-functions package | dependencies | python_env | `package_declared` | Yes | minimal, full |
+| `check_flex_deprecated_settings` | Flex Consumption deprecated app settings | configuration | runtime | `flex_deprecated_settings` | No | full |
 | `check_native_dependency_risk` | Native dependency risk | dependencies | python_env | `native_dependency_risk` | No | full |
 | `check_azure_functions_worker` | azure-functions-worker not pinned | dependencies | python_env | `package_forbidden` | No | full |
 | `check_host_json` | host.json | structure | project_structure | `file_exists` | Yes | minimal, full |
@@ -73,6 +74,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `functions_runtime_lifecycle` | Checks the Azure Functions runtime major version (from `FUNCTIONS_EXTENSION_VERSION`): v1 FAILs as incompatible with Python (with a lifecycle note), v2/v3 FAIL as out of support, v3 on Linux Consumption FAILs (apps stop running on a published date), and v4 PASSes. |
 | `hosting_plan_lifecycle` | Checks the resolved hosting plan against its published retirement date: informational when far off, WARN inside the retiring-soon window, and FAIL once retired (never a FAIL merely for being scheduled). |
 | `flex_runtime_config` | For a Flex Consumption app, validates the runtime declared under `functionAppConfig.runtime` (name/version) against the supported Python versions, and WARNs when a legacy `linuxFxVersion` is present (Flex ignores it). Non-Flex apps SKIP. |
+| `flex_deprecated_settings` | For a Flex Consumption app, WARNs (non-gating) when legacy app settings that Flex ignores are declared (worker-runtime selection, Oryx/remote-build toggles, Azure Files content-share settings, run-from-package, and VNet route-all), citing the replacement mechanism for each. `linuxFxVersion` and `FUNCTIONS_EXTENSION_VERSION` are owned by `flex_runtime_config` / `functions_extension_version` and never double-reported. Non-Flex apps SKIP. |
 
 ## False-positive Risk
 

--- a/src/azure_functions_doctor/assets/compatibility/catalog.json
+++ b/src/azure_functions_doctor/assets/compatibility/catalog.json
@@ -4,7 +4,8 @@
   "sources": {
     "supported_languages": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
     "functions_versions": "https://learn.microsoft.com/azure/azure-functions/functions-versions",
-    "consumption_plan": "https://learn.microsoft.com/azure/azure-functions/consumption-plan"
+    "consumption_plan": "https://learn.microsoft.com/azure/azure-functions/consumption-plan",
+    "functions_app_settings": "https://learn.microsoft.com/azure/azure-functions/functions-app-settings"
   },
   "facts": [
     {
@@ -151,6 +152,14 @@
       "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-versions",
       "last_verified": "2026-09-06",
       "verification_notes": "Microsoft Learn: 'Function apps still running the end-of-life v3 runtime on Linux in a Consumption plan stop running after September 30, 2026.'"
+    },
+    {
+      "fact_id": "flex-deprecated-app-settings",
+      "category": "flex_deprecated_settings",
+      "applies_to": { "hosting_plan": "flex-consumption" },
+      "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-app-settings",
+      "last_verified": "2026-09-06",
+      "verification_notes": "Microsoft Learn 'App settings reference for Azure Functions': the Flex Consumption plan does not use a set of legacy app settings (runtime worker selection, Oryx/remote-build toggles, Azure Files content-share settings, run-from-package, and VNet route-all); the runtime stack, deployment package, scaling, and networking are configured through functionAppConfig and site networking properties instead."
     }
   ]
 }

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -133,6 +133,26 @@
     "check_order": 5
   },
   {
+    "id": "check_flex_deprecated_settings",
+    "category": "configuration",
+    "section": "runtime",
+    "label": "Flex Consumption deprecated app settings",
+    "description": "For a Flex Consumption app, warns when legacy app settings that Flex ignores are declared (worker-runtime selection, Oryx/remote-build toggles, Azure Files content-share settings, run-from-package, and VNet route-all), citing the replacement mechanism for each.",
+    "type": "flex_deprecated_settings",
+    "required": false,
+    "tier": "core",
+    "condition": {},
+    "hint": "Remove legacy app settings on Flex Consumption; configure the runtime, deployment, scaling, and networking through functionAppConfig and site networking properties instead.",
+    "hint_url": "https://learn.microsoft.com/azure/azure-functions/functions-app-settings",
+    "source_type": "ms_learn",
+    "source_title": "Azure Functions \u2014 App settings reference (Flex Consumption plan deprecations)",
+    "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-app-settings",
+    "why_it_matters": "Flex Consumption ignores a set of legacy app settings; leaving them in place is a configuration smell that masks the correct functionAppConfig-based configuration and can confuse deployments.",
+    "symptoms": "Deprecated app settings are silently ignored on Flex Consumption, so settings such as FUNCTIONS_WORKER_RUNTIME or WEBSITE_RUN_FROM_PACKAGE have no effect and hide the real configuration.",
+    "tags": ["runtime", "flex-consumption", "app-settings", "configuration"],
+    "check_order": 6
+  },
+  {
     "id": "check_venv",
     "category": "environment",
     "section": "python_env",

--- a/src/azure_functions_doctor/compatibility.py
+++ b/src/azure_functions_doctor/compatibility.py
@@ -258,6 +258,16 @@ class Catalog:
                 return fact
         return None
 
+    def flex_deprecated_settings_fact(self) -> Optional[Fact]:
+        """Return the ``flex_deprecated_settings`` catalog fact or ``None``.
+
+        This single fact carries the source URL and freshness metadata for the
+        Flex Consumption deprecated-app-settings check (issue #350); the list of
+        deprecated settings itself lives in the rule handler.
+        """
+        facts = self.facts_by_category("flex_deprecated_settings")
+        return facts[0] if facts else None
+
     def hosting_plan_matrix(self) -> dict[str, tuple[str, ...]]:
         """Reconstruct the per-plan supported-Python matrix from the catalog.
 

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -486,6 +486,94 @@ def _evaluate_flex_extension_version(ext_value: Optional[str]) -> HandlerResult:
     return result
 
 
+# Legacy app settings that Flex Consumption ignores, mapped to the replacement
+# mechanism documented in Microsoft Learn's 'Flex Consumption plan deprecations'
+# table (issue #350). LinuxFxVersion (owned by check_flex_runtime_config, #345)
+# and FUNCTIONS_EXTENSION_VERSION (owned by check_functions_extension_version,
+# #346) are deliberately excluded so this rule never double-reports them.
+FLEX_DEPRECATED_APP_SETTINGS: dict[str, str] = {
+    "FUNCTIONS_WORKER_RUNTIME": "replaced by 'name' under functionAppConfig.runtime.",
+    "FUNCTIONS_WORKER_RUNTIME_VERSION": (
+        "replaced by 'version' under functionAppConfig.runtime."
+    ),
+    "FUNCTIONS_WORKER_PROCESS_COUNT": (
+        "not valid on Flex Consumption; per-instance concurrency is platform-managed."
+    ),
+    "SCM_DO_BUILD_DURING_DEPLOYMENT": (
+        "replaced by the remoteBuild parameter when deploying to Flex Consumption."
+    ),
+    "ENABLE_ORYX_BUILD": (
+        "replaced by the remoteBuild parameter when deploying to Flex Consumption."
+    ),
+    "WEBSITE_CONTENTSHARE": "replaced by functionAppConfig's deployment section.",
+    "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING": (
+        "replaced by functionAppConfig's deployment section."
+    ),
+    "WEBSITE_RUN_FROM_PACKAGE": (
+        "not used for deployments on Flex Consumption; use functionAppConfig.deployment."
+    ),
+    "WEBSITE_SKIP_CONTENTSHARE_VALIDATION": (
+        "a content share isn't used on Flex Consumption."
+    ),
+    "WEBSITE_VNET_ROUTE_ALL": (
+        "not used for networking on Flex Consumption; configure VNet integration "
+        "on the app's networking settings instead."
+    ),
+}
+
+
+def _evaluate_flex_deprecated_settings(
+    hosting_plan: Optional[str],
+    app_settings: dict[str, str],
+    *,
+    catalog: Optional[Catalog] = None,
+) -> HandlerResult:
+    """Warn on legacy app settings that Flex Consumption ignores (issue #350).
+
+    Only Flex apps are in scope (others SKIP). Declared settings are matched
+    against :data:`FLEX_DEPRECATED_APP_SETTINGS`; none present PASSes, otherwise a
+    non-gating WARN lists each deprecated setting with its replacement mechanism
+    and cites the catalog source. ``linuxFxVersion`` and
+    ``FUNCTIONS_EXTENSION_VERSION`` are intentionally absent from the map (owned by
+    #345 and #346), so this rule never emits a duplicate finding for them.
+    """
+    if hosting_plan != FLEX_CONSUMPTION_PLAN:
+        return _create_result(
+            "skip",
+            "Not a Flex Consumption app; deprecated-app-settings check skipped.",
+        )
+
+    present = [name for name in FLEX_DEPRECATED_APP_SETTINGS if name in app_settings]
+    if not present:
+        return _create_result(
+            "pass",
+            "No deprecated Flex Consumption app settings are declared.",
+        )
+
+    lines = ["Deprecated app settings declared on a Flex Consumption app:"]
+    lines.extend(f"  - {name}: {FLEX_DEPRECATED_APP_SETTINGS[name]}" for name in present)
+    lines.append(
+        "Flex Consumption ignores these settings; remove them and use the listed "
+        "replacement mechanism."
+    )
+    detail = "\n".join(lines)
+    result = _create_result("fail", detail)
+    result["severity"] = "warning"
+    result["gate"] = False
+    expected = "No deprecated legacy app settings on Flex Consumption"
+    actual = "Deprecated app settings declared: " + ", ".join(present)
+    cat = load_catalog() if catalog is None else catalog
+    fact = cat.flex_deprecated_settings_fact()
+    if fact is not None:
+        _attach_catalog_evidence(
+            result, fact, cat, detail=detail, expected=expected, actual=actual
+        )
+    else:
+        result["expected"] = expected
+        result["actual"] = actual
+    return result
+
+
 class HandlerRegistry:
     """Registry for diagnostic check handlers with individual handler methods."""
 
@@ -660,6 +748,32 @@ class HandlerRegistry:
             runtime_name,
             runtime_version,
             linux_fx_present=linux_fx_present,
+        )
+
+    @_rule_handler
+    def _handle_flex_deprecated_settings(
+        self, rule: Rule, path: Path, context: Optional[RuleContext] = None
+    ) -> HandlerResult:
+        """Warn when a Flex Consumption app declares deprecated legacy app settings (#350).
+
+        Flex Consumption ignores a set of legacy app settings (worker-runtime
+        selection, Oryx/remote-build toggles, Azure Files content-share settings,
+        run-from-package, and VNet route-all). This check is scoped to Flex apps and
+        WARNs (non-gating) with a per-setting replacement mechanism. ``linuxFxVersion``
+        and ``FUNCTIONS_EXTENSION_VERSION`` are owned by check_flex_runtime_config
+        (#345) and check_functions_extension_version (#346), so they are never
+        reported here.
+        """
+        target_config = context.get("target_config") if context is not None else None
+        if target_config is None:
+            return _create_result(
+                "skip",
+                "Deployment target could not be resolved; "
+                "Flex deprecated-app-settings check skipped.",
+            )
+        return _evaluate_flex_deprecated_settings(
+            target_config.hosting_plan.value,
+            target_config.app_settings,
         )
 
     @_rule_handler

--- a/src/azure_functions_doctor/schemas/rules.schema.json
+++ b/src/azure_functions_doctor/schemas/rules.schema.json
@@ -85,7 +85,8 @@
           "python_runtime_lifecycle",
           "functions_runtime_lifecycle",
           "hosting_plan_lifecycle",
-          "flex_runtime_config"
+          "flex_runtime_config",
+          "flex_deprecated_settings"
         ]
       },
       "required": {

--- a/tests/test_flex_deprecated_settings.py
+++ b/tests/test_flex_deprecated_settings.py
@@ -1,0 +1,197 @@
+"""Tests for the Flex Consumption deprecated app settings check (issue #350)."""
+
+from pathlib import Path
+from typing import Optional
+
+from azure_functions_doctor.compatibility import Catalog, load_catalog
+from azure_functions_doctor.deploy_config import ResolvedField, TargetConfig
+from azure_functions_doctor.handlers._helpers import RuleContext
+from azure_functions_doctor.handlers.registry import (
+    FLEX_CONSUMPTION_PLAN,
+    FLEX_DEPRECATED_APP_SETTINGS,
+    HandlerRegistry,
+    _evaluate_flex_deprecated_settings,
+)
+
+
+def _target_config(
+    *,
+    hosting_plan: Optional[str] = None,
+    app_settings: Optional[dict[str, str]] = None,
+) -> TargetConfig:
+    unknown = ResolvedField(None, "unknown")
+    return TargetConfig(
+        hosting_plan=ResolvedField(hosting_plan, "test") if hosting_plan else unknown,
+        runtime_name=unknown,
+        runtime_version=unknown,
+        extension_version=unknown,
+        deployment_storage=unknown,
+        app_settings=app_settings or {},
+    )
+
+
+class TestCatalogFact:
+    def test_flex_deprecated_settings_fact_present(self) -> None:
+        fact = load_catalog().flex_deprecated_settings_fact()
+        assert fact is not None
+        assert fact.fact_id == "flex-deprecated-app-settings"
+        assert fact.applies_to.get("hosting_plan") == FLEX_CONSUMPTION_PLAN
+        assert fact.source_url.startswith("https://learn.microsoft.com/")
+
+    def test_deprecated_map_excludes_owned_settings(self) -> None:
+        # LinuxFxVersion is owned by #345 and FUNCTIONS_EXTENSION_VERSION by #346;
+        # neither may appear in this rule's map to avoid duplicate findings.
+        assert "LinuxFxVersion" not in FLEX_DEPRECATED_APP_SETTINGS
+        assert "FUNCTIONS_EXTENSION_VERSION" not in FLEX_DEPRECATED_APP_SETTINGS
+
+
+class TestEvaluateFlexDeprecatedSettings:
+    def test_non_flex_skips(self) -> None:
+        result = _evaluate_flex_deprecated_settings(
+            "linux-consumption", {"FUNCTIONS_WORKER_RUNTIME": "python"}
+        )
+        assert result["status"] == "skip"
+        assert "Not a Flex Consumption app" in result["detail"]
+
+    def test_none_plan_skips(self) -> None:
+        result = _evaluate_flex_deprecated_settings(None, {})
+        assert result["status"] == "skip"
+
+    def test_flex_clean_passes(self) -> None:
+        result = _evaluate_flex_deprecated_settings(
+            FLEX_CONSUMPTION_PLAN, {"APPLICATIONINSIGHTS_CONNECTION_STRING": "x"}
+        )
+        assert result["status"] == "pass"
+        assert "No deprecated" in result["detail"]
+
+    def test_flex_deprecated_warns_with_remediation(self) -> None:
+        result = _evaluate_flex_deprecated_settings(
+            FLEX_CONSUMPTION_PLAN,
+            {
+                "FUNCTIONS_WORKER_RUNTIME": "python",
+                "WEBSITE_RUN_FROM_PACKAGE": "1",
+            },
+        )
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+        assert result["gate"] is False
+        assert "FUNCTIONS_WORKER_RUNTIME" in result["detail"]
+        assert "WEBSITE_RUN_FROM_PACKAGE" in result["detail"]
+        # Per-setting remediation text is included.
+        assert "functionAppConfig.runtime" in result["detail"]
+        assert result["actual"] == (
+            "Deprecated app settings declared: FUNCTIONS_WORKER_RUNTIME, WEBSITE_RUN_FROM_PACKAGE"
+        )
+        # Catalog evidence is attached.
+        assert result["source_url"].startswith("https://learn.microsoft.com/")
+        assert result["catalog_version"]
+        assert result["last_verified"]
+
+    def test_reports_in_catalog_map_order(self) -> None:
+        # Declared out of order, reported in FLEX_DEPRECATED_APP_SETTINGS order.
+        result = _evaluate_flex_deprecated_settings(
+            FLEX_CONSUMPTION_PLAN,
+            {
+                "WEBSITE_VNET_ROUTE_ALL": "1",
+                "FUNCTIONS_WORKER_RUNTIME": "python",
+            },
+        )
+        assert result["actual"] == (
+            "Deprecated app settings declared: FUNCTIONS_WORKER_RUNTIME, WEBSITE_VNET_ROUTE_ALL"
+        )
+
+    def test_linux_fx_version_not_reported(self) -> None:
+        # De-duplication: LinuxFxVersion is owned by #345 and must never be
+        # emitted here even if present as an app setting on a Flex app.
+        result = _evaluate_flex_deprecated_settings(
+            FLEX_CONSUMPTION_PLAN,
+            {"LinuxFxVersion": "Python|3.11", "linuxFxVersion": "Python|3.11"},
+        )
+        assert result["status"] == "pass"
+        assert "LinuxFxVersion" not in result["detail"]
+
+    def test_extension_version_not_reported(self) -> None:
+        # De-duplication: FUNCTIONS_EXTENSION_VERSION is owned by #346.
+        result = _evaluate_flex_deprecated_settings(
+            FLEX_CONSUMPTION_PLAN, {"FUNCTIONS_EXTENSION_VERSION": "~4"}
+        )
+        assert result["status"] == "pass"
+
+    def test_all_documented_settings_detected(self) -> None:
+        result = _evaluate_flex_deprecated_settings(
+            FLEX_CONSUMPTION_PLAN,
+            {name: "x" for name in FLEX_DEPRECATED_APP_SETTINGS},
+        )
+        assert result["status"] == "fail"
+        for name in FLEX_DEPRECATED_APP_SETTINGS:
+            assert name in result["detail"]
+
+    def test_explicit_catalog_argument_is_used(self) -> None:
+        catalog = load_catalog()
+        fact = catalog.flex_deprecated_settings_fact()
+        assert fact is not None
+        result = _evaluate_flex_deprecated_settings(
+            FLEX_CONSUMPTION_PLAN,
+            {"ENABLE_ORYX_BUILD": "true"},
+            catalog=catalog,
+        )
+        assert result["status"] == "fail"
+        assert result["source_url"] == fact.source_url
+
+    def test_missing_catalog_fact_falls_back(self) -> None:
+        # Defensive path: if the catalog has no flex_deprecated_settings fact,
+        # the finding still reports expected/actual without catalog evidence.
+        empty = Catalog(
+            catalog_version="0.0.0",
+            last_verified="2026-09-06",
+            sources={},
+            facts=(),
+        )
+        result = _evaluate_flex_deprecated_settings(
+            FLEX_CONSUMPTION_PLAN,
+            {"ENABLE_ORYX_BUILD": "true"},
+            catalog=empty,
+        )
+        assert result["status"] == "fail"
+        assert result["expected"] == "No deprecated legacy app settings on Flex Consumption"
+        assert "source_url" not in result
+
+
+class TestHandler:
+    def _run(self, context: Optional[RuleContext], path: Path) -> dict[str, object]:
+        registry = HandlerRegistry()
+        return dict(registry._handle_flex_deprecated_settings({}, path, context))
+
+    def test_no_context_skips(self, tmp_path: Path) -> None:
+        result = self._run(None, tmp_path)
+        assert result["status"] == "skip"
+        assert "could not be resolved" in str(result["detail"])
+
+    def test_flex_deprecated_warns(self, tmp_path: Path) -> None:
+        context: RuleContext = {
+            "target_config": _target_config(
+                hosting_plan=FLEX_CONSUMPTION_PLAN,
+                app_settings={"SCM_DO_BUILD_DURING_DEPLOYMENT": "true"},
+            ),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+        assert "SCM_DO_BUILD_DURING_DEPLOYMENT" in str(result["detail"])
+
+    def test_flex_clean_passes(self, tmp_path: Path) -> None:
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan=FLEX_CONSUMPTION_PLAN),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "pass"
+
+    def test_non_flex_skips(self, tmp_path: Path) -> None:
+        context: RuleContext = {
+            "target_config": _target_config(
+                hosting_plan="linux-consumption",
+                app_settings={"WEBSITE_CONTENTSHARE": "share"},
+            ),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "skip"


### PR DESCRIPTION
Part of #341. Closes #350.

## Summary
- Adds `check_flex_deprecated_settings` — a non-gating **WARN** that fires only when the deployment plan resolves to **Flex Consumption** (via #347 `TargetConfig`) and the app declares legacy app settings that Flex ignores.
- Each finding lists the offending settings with a **per-setting replacement mechanism** and cites the catalog source (`functions-app-settings` "Flex Consumption plan deprecations" table).
- Settings detected: `FUNCTIONS_WORKER_RUNTIME`, `FUNCTIONS_WORKER_RUNTIME_VERSION`, `FUNCTIONS_WORKER_PROCESS_COUNT`, `SCM_DO_BUILD_DURING_DEPLOYMENT`, `ENABLE_ORYX_BUILD`, `WEBSITE_CONTENTSHARE`, `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, `WEBSITE_RUN_FROM_PACKAGE`, `WEBSITE_SKIP_CONTENTSHARE_VALIDATION`, `WEBSITE_VNET_ROUTE_ALL`.

## Finding ownership / de-duplication
`LinuxFxVersion` (owned by `check_flex_runtime_config`, #345) and `FUNCTIONS_EXTENSION_VERSION` (owned by `check_functions_extension_version`, #346) are intentionally **excluded** from the deprecated-settings map, so this rule never double-reports a token owned by a specialized rule. Covered by an explicit de-duplication test.

## Changes
- `catalog.json`: new `flex_deprecated_settings` fact + `functions_app_settings` source (deterministic, offline).
- `compatibility.py`: `Catalog.flex_deprecated_settings_fact()` helper.
- `registry.py`: `FLEX_DEPRECATED_APP_SETTINGS` map, `_evaluate_flex_deprecated_settings` classifier, `_handle_flex_deprecated_settings` handler.
- `v2.json` / `rules.schema.json` / `docs/rule_inventory.md`: register the new rule type (39 rules total).
- `tests/test_flex_deprecated_settings.py`: 16 tests incl. LinuxFxVersion de-dup, catalog-evidence, and map-order cases.

## Verification
- `hatch run style` ✅  `hatch run typecheck` ✅ (51 files)
- `hatch run pytest --cov` ✅ — total coverage **96.84%** (≥95%)
- Docs consistency + rule-inventory `--check` ✅
- CLI smoke: `azure-functions-doctor doctor --path examples/v2/http-trigger --profile minimal` exit 0 ✅