### PR TITLE
feat(flex): add Flex Consumption deployment storage configuration check (#351)

### DIFF
--- a/docs/rule_inventory.md
+++ b/docs/rule_inventory.md
@@ -22,6 +22,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `check_azure_functions_library` | azure-functions package | dependencies | python_env | `package_declared` | Yes | minimal, full |
 | `check_flex_deprecated_settings` | Flex Consumption deprecated app settings | configuration | runtime | `flex_deprecated_settings` | No | full |
 | `check_native_dependency_risk` | Native dependency risk | dependencies | python_env | `native_dependency_risk` | No | full |
+| `check_flex_deployment_storage` | Flex Consumption deployment storage | configuration | runtime | `flex_deployment_storage` | No | full |
 | `check_azure_functions_worker` | azure-functions-worker not pinned | dependencies | python_env | `package_forbidden` | No | full |
 | `check_host_json` | host.json | structure | project_structure | `file_exists` | Yes | minimal, full |
 | `check_host_json_version` | host.json version | structure | project_structure | `host_json_version` | Yes | minimal, full |
@@ -75,6 +76,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `hosting_plan_lifecycle` | Checks the resolved hosting plan against its published retirement date: informational when far off, WARN inside the retiring-soon window, and FAIL once retired (never a FAIL merely for being scheduled). |
 | `flex_runtime_config` | For a Flex Consumption app, validates the runtime declared under `functionAppConfig.runtime` (name/version) against the supported Python versions, and WARNs when a legacy `linuxFxVersion` is present (Flex ignores it). Non-Flex apps SKIP. |
 | `flex_deprecated_settings` | For a Flex Consumption app, WARNs (non-gating) when legacy app settings that Flex ignores are declared (worker-runtime selection, Oryx/remote-build toggles, Azure Files content-share settings, run-from-package, and VNet route-all), citing the replacement mechanism for each. `linuxFxVersion` and `FUNCTIONS_EXTENSION_VERSION` are owned by `flex_runtime_config` / `functions_extension_version` and never double-reported. Non-Flex apps SKIP. |
+| `flex_deployment_storage` | For a Flex Consumption app, validates the deployment storage shape declared under `functionAppConfig.deployment.storage`: a container URL (`value`) must be specified and authentication must be configured (managed identity or a named storage account connection string). Obviously wrong shapes WARN (non-gating); the storage account is never contacted. Non-Flex apps SKIP, and apps that declare no deployment storage block in infra SKIP gracefully. |
 
 ## False-positive Risk
 

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -153,6 +153,26 @@
     "check_order": 6
   },
   {
+    "id": "check_flex_deployment_storage",
+    "category": "configuration",
+    "section": "runtime",
+    "label": "Flex Consumption deployment storage",
+    "description": "For a Flex Consumption app, validates the deployment storage shape declared under functionAppConfig.deployment.storage: a container URL must be specified and authentication must be configured (managed identity or a named storage account connection string). Skips gracefully when infra declares no deployment storage block.",
+    "type": "flex_deployment_storage",
+    "required": false,
+    "tier": "core",
+    "condition": {},
+    "hint": "Declare a blob container under functionAppConfig.deployment.storage with a value URL and authentication (managed identity or a named connection string).",
+    "hint_url": "https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan",
+    "source_type": "ms_learn",
+    "source_title": "Azure Functions \u2014 Flex Consumption plan (functionAppConfig.deployment.storage)",
+    "source_url": "https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan",
+    "why_it_matters": "Flex Consumption deploys from a blob container declared under functionAppConfig.deployment.storage; a missing container or unconfigured authentication produces a deployment that cannot fetch its package.",
+    "symptoms": "A Flex app with no deployment container or no authentication configured fails to deploy or cannot fetch its package at scale-out.",
+    "tags": ["runtime", "flex-consumption", "deployment", "configuration"],
+    "check_order": 7
+  },
+  {
     "id": "check_venv",
     "category": "environment",
     "section": "python_env",

--- a/src/azure_functions_doctor/deploy_config.py
+++ b/src/azure_functions_doctor/deploy_config.py
@@ -252,6 +252,32 @@ def _deployment_storage_from_json(node: object) -> Optional[str]:
     return None
 
 
+def flex_deployment_storage_shape(project_path: Path) -> Optional[dict[str, object]]:
+    """Return the Flex ``functionAppConfig.deployment.storage`` object from infra.
+
+    Scans deployable infra JSON files for a ``deployment.storage`` block and
+    returns the first one found, or ``None`` when none is declared. Raw ``.bicep``
+    files are not statically parsed for nested shapes, so a project expressed only
+    in bicep yields ``None`` (the deployment-storage check then skips gracefully).
+    ``local.settings.json`` is excluded by :func:`_iter_infra_files`.
+    """
+    for candidate, kind in _iter_infra_files(project_path):
+        if kind != "json":
+            continue
+        try:
+            data = json.loads(candidate.read_text(encoding="utf-8"))
+        except (ValueError, UnicodeDecodeError, OSError):
+            continue
+        for obj in _walk_json(data):
+            deployment = obj.get("deployment")
+            if not isinstance(deployment, dict):
+                continue
+            storage = deployment.get("storage")
+            if isinstance(storage, dict):
+                return storage
+    return None
+
+
 def _has_function_app_config(node: object) -> bool:
     return any("functionAppConfig" in obj for obj in _walk_json(node))
 

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -14,6 +14,7 @@ from packaging.version import InvalidVersion
 from packaging.version import parse as parse_version
 
 from azure_functions_doctor.compatibility import Catalog, Fact, load_catalog
+from azure_functions_doctor.deploy_config import flex_deployment_storage_shape
 from azure_functions_doctor.handlers._helpers import (
     _HOST_JSON_MISSING,
     _PYTHON_CANDIDATES,
@@ -574,6 +575,84 @@ def _evaluate_flex_deprecated_settings(
     return result
 
 
+def _evaluate_flex_deployment_storage(
+    hosting_plan: Optional[str],
+    storage: Optional[dict[str, object]],
+) -> HandlerResult:
+    """Validate a Flex Consumption app's deployment storage shape (issue #351).
+
+    Only Flex apps are in scope (others SKIP). Flex stores the deployment package
+    in a blob container declared under ``functionAppConfig.deployment.storage``.
+    When no such block is declared in infra the check SKIPs gracefully; otherwise
+    obviously wrong shapes are flagged (non-gating WARN): a missing container URL
+    (``value``), or missing/incomplete ``authentication`` (a managed identity or a
+    named storage connection string). A well-formed block PASSes. This is a static
+    shape check only; the storage account is never contacted.
+    """
+    if hosting_plan != FLEX_CONSUMPTION_PLAN:
+        return _create_result(
+            "skip",
+            "Not a Flex Consumption app; deployment-storage check skipped.",
+        )
+    if storage is None:
+        return _create_result(
+            "skip",
+            "Flex Consumption app declares no functionAppConfig.deployment.storage "
+            "in infra; deployment-storage check skipped.",
+        )
+
+    problems: list[str] = []
+    value = storage.get("value")
+    if not isinstance(value, str) or not value.strip():
+        problems.append(
+            "no deployment container is specified "
+            "(functionAppConfig.deployment.storage.value)"
+        )
+
+    authentication = storage.get("authentication")
+    if not isinstance(authentication, dict):
+        problems.append(
+            "no authentication is configured; use a managed identity or a storage "
+            "account connection string"
+        )
+    else:
+        auth_type = authentication.get("type")
+        if not isinstance(auth_type, str) or not auth_type.strip():
+            problems.append(
+                "deployment storage authentication is missing a 'type'"
+            )
+        elif auth_type == "StorageAccountConnectionString":
+            name = authentication.get("storageAccountConnectionStringName")
+            if not isinstance(name, str) or not name.strip():
+                problems.append(
+                    "connection-string authentication is missing "
+                    "'storageAccountConnectionStringName'"
+                )
+
+    if not problems:
+        return _create_result(
+            "pass",
+            "Flex Consumption deployment storage is configured "
+            "(container + authentication).",
+        )
+
+    lines = ["Flex Consumption deployment storage is misconfigured:"]
+    lines.extend(f"  - {problem}" for problem in problems)
+    lines.append(
+        "Declare a blob container under functionAppConfig.deployment.storage with "
+        "a value URL and authentication (managed identity or connection string)."
+    )
+    detail = "\n".join(lines)
+    result = _create_result("fail", detail)
+    result["severity"] = "warning"
+    result["gate"] = False
+    result["expected"] = (
+        "functionAppConfig.deployment.storage with a container URL and authentication"
+    )
+    result["actual"] = "; ".join(problems)
+    return result
+
+
 class HandlerRegistry:
     """Registry for diagnostic check handlers with individual handler methods."""
 
@@ -775,6 +854,34 @@ class HandlerRegistry:
             target_config.hosting_plan.value,
             target_config.app_settings,
         )
+
+    @_rule_handler
+    def _handle_flex_deployment_storage(
+        self, rule: Rule, path: Path, context: Optional[RuleContext] = None
+    ) -> HandlerResult:
+        """Validate a Flex Consumption app's deployment storage shape (#351).
+
+        Flex Consumption stores the deployment package in a blob container declared
+        under ``functionAppConfig.deployment.storage``. This check is scoped to Flex
+        apps (others SKIP). When infra declares no such block it SKIPs gracefully;
+        otherwise obviously wrong shapes WARN (non-gating): a missing container URL
+        or missing/incomplete authentication. The storage account is never
+        contacted -- this is a static shape check only.
+        """
+        target_config = context.get("target_config") if context is not None else None
+        if target_config is None:
+            return _create_result(
+                "skip",
+                "Deployment target could not be resolved; "
+                "Flex deployment-storage check skipped.",
+            )
+        hosting_plan = target_config.hosting_plan.value
+        storage = (
+            flex_deployment_storage_shape(path)
+            if hosting_plan == FLEX_CONSUMPTION_PLAN
+            else None
+        )
+        return _evaluate_flex_deployment_storage(hosting_plan, storage)
 
     @_rule_handler
     def _handle_env_var_exists(

--- a/src/azure_functions_doctor/schemas/rules.schema.json
+++ b/src/azure_functions_doctor/schemas/rules.schema.json
@@ -86,7 +86,8 @@
           "functions_runtime_lifecycle",
           "hosting_plan_lifecycle",
           "flex_runtime_config",
-          "flex_deprecated_settings"
+          "flex_deprecated_settings",
+          "flex_deployment_storage"
         ]
       },
       "required": {

--- a/tests/test_flex_deployment_storage.py
+++ b/tests/test_flex_deployment_storage.py
@@ -1,0 +1,217 @@
+"""Tests for the Flex Consumption deployment storage configuration check (issue #351)."""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from azure_functions_doctor.deploy_config import (
+    ResolvedField,
+    TargetConfig,
+    flex_deployment_storage_shape,
+)
+from azure_functions_doctor.handlers._helpers import RuleContext
+from azure_functions_doctor.handlers.registry import (
+    FLEX_CONSUMPTION_PLAN,
+    HandlerRegistry,
+    _evaluate_flex_deployment_storage,
+)
+
+
+def _target_config(*, hosting_plan: Optional[str] = None) -> TargetConfig:
+    unknown = ResolvedField(None, "unknown")
+    return TargetConfig(
+        hosting_plan=ResolvedField(hosting_plan, "test") if hosting_plan else unknown,
+        runtime_name=unknown,
+        runtime_version=unknown,
+        extension_version=unknown,
+        deployment_storage=unknown,
+        app_settings={},
+    )
+
+
+def _write_infra(tmp_path: Path, storage: object) -> None:
+    doc = {
+        "resources": [
+            {
+                "properties": {
+                    "functionAppConfig": {
+                        "deployment": {"storage": storage},
+                    }
+                }
+            }
+        ]
+    }
+    (tmp_path / "main.json").write_text(json.dumps(doc), encoding="utf-8")
+
+
+class TestEvaluateFlexDeploymentStorage:
+    def test_non_flex_skips(self) -> None:
+        result = _evaluate_flex_deployment_storage("linux-consumption", None)
+        assert result["status"] == "skip"
+        assert "Not a Flex Consumption app" in result["detail"]
+
+    def test_none_plan_skips(self) -> None:
+        result = _evaluate_flex_deployment_storage(None, {"value": "x"})
+        assert result["status"] == "skip"
+
+    def test_flex_no_storage_block_skips(self) -> None:
+        result = _evaluate_flex_deployment_storage(FLEX_CONSUMPTION_PLAN, None)
+        assert result["status"] == "skip"
+        assert "no functionAppConfig.deployment.storage" in result["detail"]
+
+    def test_well_formed_managed_identity_passes(self) -> None:
+        result = _evaluate_flex_deployment_storage(
+            FLEX_CONSUMPTION_PLAN,
+            {
+                "type": "blobContainer",
+                "value": "https://acct.blob.core.windows.net/app",
+                "authentication": {
+                    "type": "SystemAssignedIdentity",
+                },
+            },
+        )
+        assert result["status"] == "pass"
+        assert "configured" in result["detail"]
+
+    def test_well_formed_connection_string_passes(self) -> None:
+        result = _evaluate_flex_deployment_storage(
+            FLEX_CONSUMPTION_PLAN,
+            {
+                "value": "https://acct.blob.core.windows.net/app",
+                "authentication": {
+                    "type": "StorageAccountConnectionString",
+                    "storageAccountConnectionStringName": "DEPLOYMENT_STORAGE",
+                },
+            },
+        )
+        assert result["status"] == "pass"
+
+    def test_missing_container_warns(self) -> None:
+        result = _evaluate_flex_deployment_storage(
+            FLEX_CONSUMPTION_PLAN,
+            {"authentication": {"type": "SystemAssignedIdentity"}},
+        )
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+        assert result["gate"] is False
+        assert "no deployment container" in result["detail"]
+
+    def test_empty_container_warns(self) -> None:
+        result = _evaluate_flex_deployment_storage(
+            FLEX_CONSUMPTION_PLAN,
+            {"value": "   ", "authentication": {"type": "SystemAssignedIdentity"}},
+        )
+        assert result["status"] == "fail"
+        assert "no deployment container" in result["detail"]
+
+    def test_missing_authentication_warns(self) -> None:
+        result = _evaluate_flex_deployment_storage(
+            FLEX_CONSUMPTION_PLAN,
+            {"value": "https://acct.blob.core.windows.net/app"},
+        )
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+        assert "no authentication is configured" in result["detail"]
+
+    def test_authentication_missing_type_warns(self) -> None:
+        result = _evaluate_flex_deployment_storage(
+            FLEX_CONSUMPTION_PLAN,
+            {
+                "value": "https://acct.blob.core.windows.net/app",
+                "authentication": {},
+            },
+        )
+        assert result["status"] == "fail"
+        assert "missing a 'type'" in result["detail"]
+
+    def test_connection_string_missing_name_warns(self) -> None:
+        result = _evaluate_flex_deployment_storage(
+            FLEX_CONSUMPTION_PLAN,
+            {
+                "value": "https://acct.blob.core.windows.net/app",
+                "authentication": {"type": "StorageAccountConnectionString"},
+            },
+        )
+        assert result["status"] == "fail"
+        assert "storageAccountConnectionStringName" in result["detail"]
+        assert result["actual"]
+
+    def test_multiple_problems_reported(self) -> None:
+        result = _evaluate_flex_deployment_storage(
+            FLEX_CONSUMPTION_PLAN,
+            {"authentication": "not-a-dict"},
+        )
+        assert result["status"] == "fail"
+        assert "no deployment container" in result["detail"]
+        assert "no authentication is configured" in result["detail"]
+
+
+class TestFlexDeploymentStorageShape:
+    def test_reads_storage_from_infra_json(self, tmp_path: Path) -> None:
+        storage = {"value": "https://acct.blob.core.windows.net/app"}
+        _write_infra(tmp_path, storage)
+        result = flex_deployment_storage_shape(tmp_path)
+        assert result == storage
+
+    def test_returns_none_when_absent(self, tmp_path: Path) -> None:
+        (tmp_path / "main.json").write_text(json.dumps({"resources": []}), encoding="utf-8")
+        assert flex_deployment_storage_shape(tmp_path) is None
+
+    def test_bicep_only_project_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "main.bicep").write_text(
+            "resource fa 'Microsoft.Web/sites@2023-01-01' = {}", encoding="utf-8"
+        )
+        assert flex_deployment_storage_shape(tmp_path) is None
+
+    def test_invalid_json_is_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "main.json").write_text("{not valid", encoding="utf-8")
+        assert flex_deployment_storage_shape(tmp_path) is None
+
+
+class TestHandler:
+    def _run(self, context: Optional[RuleContext], path: Path) -> dict[str, object]:
+        registry = HandlerRegistry()
+        return dict(registry._handle_flex_deployment_storage({}, path, context))
+
+    def test_no_context_skips(self, tmp_path: Path) -> None:
+        result = self._run(None, tmp_path)
+        assert result["status"] == "skip"
+        assert "could not be resolved" in str(result["detail"])
+
+    def test_non_flex_skips(self, tmp_path: Path) -> None:
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan="linux-consumption"),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "skip"
+
+    def test_flex_reads_infra_and_warns(self, tmp_path: Path) -> None:
+        _write_infra(tmp_path, {"value": "https://acct.blob.core.windows.net/app"})
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan=FLEX_CONSUMPTION_PLAN),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+        assert "no authentication is configured" in str(result["detail"])
+
+    def test_flex_well_formed_passes(self, tmp_path: Path) -> None:
+        _write_infra(
+            tmp_path,
+            {
+                "value": "https://acct.blob.core.windows.net/app",
+                "authentication": {"type": "SystemAssignedIdentity"},
+            },
+        )
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan=FLEX_CONSUMPTION_PLAN),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "pass"
+
+    def test_flex_no_infra_skips(self, tmp_path: Path) -> None:
+        context: RuleContext = {
+            "target_config": _target_config(hosting_plan=FLEX_CONSUMPTION_PLAN),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "skip"


### PR DESCRIPTION
## Summary
Adds `check_flex_deployment_storage`, a Flex Consumption-scoped diagnostic that statically validates the deployment storage shape declared under `functionAppConfig.deployment.storage`.

- **Container URL** (`value`) must be specified.
- **Authentication** must be configured — a managed identity or a named storage account connection string (`StorageAccountConnectionString` requires `storageAccountConnectionStringName`).
- Non-Flex apps **SKIP**; apps that declare no deployment-storage block in infra **SKIP gracefully**.
- Obviously wrong shapes **WARN** (non-gating). The storage account is never contacted — static shape check only.

## Implementation
- `deploy_config.flex_deployment_storage_shape(project_path)` — scans infra JSON files for the first `deployment.storage` object (bicep not statically parsed → `None`).
- `registry._evaluate_flex_deployment_storage(...)` classifier + `_handle_flex_deployment_storage` handler.
- Rule `check_flex_deployment_storage` (`type: flex_deployment_storage`, section `runtime`, `check_order 7`) in `v2.json`; type added to `rules.schema.json` enum.
- Docs: regenerated `docs/rule_inventory.md` (now **40 rules**) + hand-authored Rule Types row.

## Tests / gates
- New `tests/test_flex_deployment_storage.py` (20 tests: classifier, shape scanner, handler wiring).
- ruff PASS, mypy strict PASS (52 files), full-suite coverage **96.88%**, docs-consistency PASS, CLI smoke exit 0.

Closes #351
Part of #341