### PR TITLE
feat(bindings): add binding-to-connection resolution check (#352)

### DIFF
--- a/docs/rule_inventory.md
+++ b/docs/rule_inventory.md
@@ -25,6 +25,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `check_flex_deployment_storage` | Flex Consumption deployment storage | configuration | runtime | `flex_deployment_storage` | No | full |
 | `check_azure_functions_worker` | azure-functions-worker not pinned | dependencies | python_env | `package_forbidden` | No | full |
 | `check_host_json` | host.json | structure | project_structure | `file_exists` | Yes | minimal, full |
+| `check_binding_connection_resolution` | Binding connection resolution | configuration | runtime | `binding_connection_resolution` | No | full |
 | `check_host_json_version` | host.json version | structure | project_structure | `host_json_version` | Yes | minimal, full |
 | `check_local_settings` | local.settings.json | structure | project_structure | `file_exists` | No | full |
 | `check_func_cli` | Azure Functions Core Tools (func) | tooling | tooling | `executable_exists` | No | full |
@@ -77,6 +78,7 @@ Rules are defined in `src/azure_functions_doctor/assets/rules/v2.json`.
 | `flex_runtime_config` | For a Flex Consumption app, validates the runtime declared under `functionAppConfig.runtime` (name/version) against the supported Python versions, and WARNs when a legacy `linuxFxVersion` is present (Flex ignores it). Non-Flex apps SKIP. |
 | `flex_deprecated_settings` | For a Flex Consumption app, WARNs (non-gating) when legacy app settings that Flex ignores are declared (worker-runtime selection, Oryx/remote-build toggles, Azure Files content-share settings, run-from-package, and VNet route-all), citing the replacement mechanism for each. `linuxFxVersion` and `FUNCTIONS_EXTENSION_VERSION` are owned by `flex_runtime_config` / `functions_extension_version` and never double-reported. Non-Flex apps SKIP. |
 | `flex_deployment_storage` | For a Flex Consumption app, validates the deployment storage shape declared under `functionAppConfig.deployment.storage`: a container URL (`value`) must be specified and authentication must be configured (managed identity or a named storage account connection string). Obviously wrong shapes WARN (non-gating); the storage account is never contacted. Non-Flex apps SKIP, and apps that declare no deployment storage block in infra SKIP gracefully. |
+| `binding_connection_resolution` | Extracts `connection="..."` references from v2 trigger/binding decorators (Storage, Service Bus, Event Hub, Cosmos DB, and any binding exposing a `connection` keyword) and resolves each against `local.settings.json` Values plus the ingested deploy-config app settings. Unresolved connections WARN (non-gating). Identity-based connection groups (`<name>__serviceUri` / `<name>__accountName`) are treated as configured to avoid false positives. Only string-literal connection names are inspected; dynamic expressions are skipped. |
 
 ## False-positive Risk
 

--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -173,6 +173,26 @@
     "check_order": 7
   },
   {
+    "id": "check_binding_connection_resolution",
+    "category": "configuration",
+    "section": "runtime",
+    "label": "Binding connection resolution",
+    "description": "Extracts connection= references from v2 trigger/binding decorators (Storage, Service Bus, Event Hub, Cosmos DB, and any binding exposing a connection keyword) and resolves each against local.settings.json Values plus ingested deploy-config app settings. Warns when a referenced connection has no corresponding configuration; identity-based connection groups (<name>__...) are treated as configured.",
+    "type": "binding_connection_resolution",
+    "required": false,
+    "tier": "core",
+    "condition": {},
+    "hint": "Add the missing app setting for each referenced connection, or configure an identity-based connection group (<name>__serviceUri / <name>__accountName).",
+    "hint_url": "https://learn.microsoft.com/azure/azure-functions/functions-reference#connections",
+    "source_type": "ms_learn",
+    "source_title": "Azure Functions \u2014 Connections (binding connection resolution)",
+    "source_url": "https://learn.microsoft.com/azure/azure-functions/functions-reference#connections",
+    "why_it_matters": "A trigger or binding that references connection=\"Name\" fails to bind at runtime when no matching app setting or identity-based connection group is configured; catching this before deploy avoids a cold-start failure discovered only in production logs.",
+    "symptoms": "A binding references a connection name that has no corresponding app setting, so the function fails to start or the trigger never fires after deployment.",
+    "tags": ["bindings", "connections", "configuration", "deployment"],
+    "check_order": 8
+  },
+  {
     "id": "check_venv",
     "category": "environment",
     "section": "python_env",

--- a/src/azure_functions_doctor/deploy_config.py
+++ b/src/azure_functions_doctor/deploy_config.py
@@ -389,6 +389,32 @@ def _local_signals(project_path: Path) -> _IaCScan:
     return signals
 
 
+def local_settings_values(project_path: Path) -> dict[str, str]:
+    """Return the string entries of ``local.settings.json`` ``Values`` (empty if absent).
+
+    Only string-valued entries are returned; non-string values are ignored. This is
+    read directly (not through the precedence-based :func:`resolve_target_config`
+    ingestion) so the binding-connection resolution check (#352) can resolve
+    connection names against locally configured settings without changing what
+    :class:`TargetConfig.app_settings` exposes to other checks.
+    """
+    text = _read_text(project_path / "local.settings.json")
+    if text is None:
+        return {}
+    try:
+        data = json.loads(text)
+    except (ValueError, UnicodeDecodeError):
+        return {}
+    values = data.get("Values") if isinstance(data, dict) else None
+    if not isinstance(values, dict):
+        return {}
+    return {
+        key: value
+        for key, value in values.items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+
+
 def _resolve_field(
     override: Optional[str],
     iac: Optional[ResolvedField],

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -614,6 +614,49 @@ def _collect_anonymous_auth_routes(path: Path, flag_missing_auth_level: bool = F
     return flagged
 
 
+def _collect_binding_connections(path: Path) -> list[tuple[str, str]]:
+    """Return ``(connection_name, "file:function")`` pairs for v2 binding decorators.
+
+    Scans decorators applied to a discovered ``FunctionApp``/``Blueprint`` alias for a
+    ``connection="..."`` keyword and collects the referenced setting name. Only
+    string-literal connection names are collected; dynamic expressions (variables,
+    ``os.environ[...]``) cannot be resolved statically and are skipped. This covers
+    Storage, Service Bus, Event Hub, Cosmos DB and any other binding that exposes a
+    ``connection`` keyword, without hard-coding a decorator whitelist.
+    """
+    references: list[tuple[str, str]] = []
+    for py_file, content in _iter_project_py_contents(path):
+        try:
+            tree = ast.parse(content)
+        except SyntaxError:
+            continue
+        app_aliases = _discover_functionapp_aliases(content)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for dec in node.decorator_list:
+                if not isinstance(dec, ast.Call):
+                    continue
+                inner = dec.func
+                if not (
+                    isinstance(inner, ast.Attribute)
+                    and isinstance(inner.value, ast.Name)
+                    and inner.value.id in app_aliases
+                ):
+                    continue
+                for kw in dec.keywords:
+                    if kw.arg != "connection":
+                        continue
+                    if (
+                        isinstance(kw.value, ast.Constant)
+                        and isinstance(kw.value.value, str)
+                        and kw.value.value.strip()
+                    ):
+                        label = f"{py_file.relative_to(path)}:{node.name}"
+                        references.append((kw.value.value, label))
+    return references
+
+
 def _project_activates_trace_context(path: Path) -> list[str]:
     """Return "file:location" labels where the project explicitly opts into
     ``azure-functions-logging`` OTel trace-context activation.

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -14,7 +14,10 @@ from packaging.version import InvalidVersion
 from packaging.version import parse as parse_version
 
 from azure_functions_doctor.compatibility import Catalog, Fact, load_catalog
-from azure_functions_doctor.deploy_config import flex_deployment_storage_shape
+from azure_functions_doctor.deploy_config import (
+    flex_deployment_storage_shape,
+    local_settings_values,
+)
 from azure_functions_doctor.handlers._helpers import (
     _HOST_JSON_MISSING,
     _PYTHON_CANDIDATES,
@@ -23,6 +26,7 @@ from azure_functions_doctor.handlers._helpers import (
     Rule,
     RuleContext,
     _collect_anonymous_auth_routes,
+    _collect_binding_connections,
     _collect_inverted_decorator_order,
     _collect_openapi_version_mixing,
     _collect_orchestrator_nondeterminism,
@@ -653,6 +657,68 @@ def _evaluate_flex_deployment_storage(
     return result
 
 
+def _evaluate_binding_connection_resolution(
+    references: list[tuple[str, str]],
+    app_settings: dict[str, str],
+) -> HandlerResult:
+    """Resolve v2 binding ``connection`` references against configured settings (#352).
+
+    A referenced connection name is satisfied when an app setting matches it exactly
+    or when an identity-based setting group is present (any ``<name>__...`` key, e.g.
+    ``MyConn__serviceUri`` / ``MyConn__accountName``). References that resolve to no
+    configuration are reported as a non-gating WARN so a project cannot silently ship
+    a trigger whose connection will fail to bind at runtime. When no binding
+    references a named connection, the check PASSes.
+    """
+    if not references:
+        return _create_result(
+            "pass",
+            "No named binding connections referenced in v2 decorators.",
+        )
+    setting_names = set(app_settings)
+    identity_prefixes = {
+        name.split("__", 1)[0] for name in setting_names if "__" in name
+    }
+
+    def _is_resolved(name: str) -> bool:
+        return name in setting_names or name in identity_prefixes
+
+    unresolved: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for name, label in references:
+        if _is_resolved(name):
+            continue
+        key = (name, label)
+        if key in seen:
+            continue
+        seen.add(key)
+        unresolved.append((name, label))
+
+    if not unresolved:
+        return _create_result(
+            "pass",
+            "All referenced binding connections resolve to configured settings.",
+        )
+
+    lines = ["Binding connections reference unconfigured settings:"]
+    lines.extend(f"  - {name} ({label})" for name, label in unresolved)
+    lines.append(
+        "Add the missing app setting(s), or configure an identity-based connection "
+        "group (<name>__serviceUri / <name>__accountName)."
+    )
+    detail = "\n".join(lines)
+    result = _create_result("fail", detail)
+    result["severity"] = "warning"
+    result["gate"] = False
+    result["expected"] = (
+        "Every referenced binding connection has a matching app setting"
+    )
+    result["actual"] = "Unresolved connections: " + ", ".join(
+        sorted({name for name, _ in unresolved})
+    )
+    return result
+
+
 class HandlerRegistry:
     """Registry for diagnostic check handlers with individual handler methods."""
 
@@ -882,6 +948,24 @@ class HandlerRegistry:
             else None
         )
         return _evaluate_flex_deployment_storage(hosting_plan, storage)
+
+    @_rule_handler
+    def _handle_binding_connection_resolution(
+        self, rule: Rule, path: Path, context: Optional[RuleContext] = None
+    ) -> HandlerResult:
+        """Resolve v2 binding ``connection`` references against configuration (#352).
+
+        Collects ``connection="..."`` references from v2 trigger/binding decorators
+        and resolves each against ``local.settings.json`` Values plus the ingested
+        deploy-config app settings. Unresolved connections WARN (non-gating);
+        identity-based connection groups (``<name>__...``) suppress false positives.
+        """
+        references = _collect_binding_connections(path)
+        settings: dict[str, str] = dict(local_settings_values(path))
+        target_config = context.get("target_config") if context is not None else None
+        if target_config is not None:
+            settings.update(target_config.app_settings)
+        return _evaluate_binding_connection_resolution(references, settings)
 
     @_rule_handler
     def _handle_env_var_exists(

--- a/src/azure_functions_doctor/schemas/rules.schema.json
+++ b/src/azure_functions_doctor/schemas/rules.schema.json
@@ -87,7 +87,8 @@
           "hosting_plan_lifecycle",
           "flex_runtime_config",
           "flex_deprecated_settings",
-          "flex_deployment_storage"
+          "flex_deployment_storage",
+          "binding_connection_resolution"
         ]
       },
       "required": {

--- a/tests/test_binding_connection_resolution.py
+++ b/tests/test_binding_connection_resolution.py
@@ -1,0 +1,265 @@
+"""Tests for the binding-to-connection resolution check (issue #352)."""
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from azure_functions_doctor.deploy_config import (
+    ResolvedField,
+    TargetConfig,
+    local_settings_values,
+)
+from azure_functions_doctor.handlers._helpers import (
+    RuleContext,
+    _collect_binding_connections,
+)
+from azure_functions_doctor.handlers.registry import (
+    FLEX_CONSUMPTION_PLAN,
+    HandlerRegistry,
+    _evaluate_binding_connection_resolution,
+)
+
+SAMPLE_APP = """\
+import azure.functions as func
+
+app = func.FunctionApp()
+
+
+@app.service_bus_queue_trigger(arg_name="msg", queue_name="q", connection="ServiceBusConnection")
+def handle_bus(msg: func.ServiceBusMessage) -> None:
+    pass
+
+
+@app.blob_trigger(arg_name="blob", path="c/{name}", connection="StorageConnection")
+def handle_blob(blob: func.InputStream) -> None:
+    pass
+"""
+
+
+def _target_config(*, app_settings: Optional[dict[str, str]] = None) -> TargetConfig:
+    unknown = ResolvedField(None, "unknown")
+    return TargetConfig(
+        hosting_plan=unknown,
+        runtime_name=unknown,
+        runtime_version=unknown,
+        extension_version=unknown,
+        deployment_storage=unknown,
+        app_settings=app_settings or {},
+    )
+
+
+def _write_local_settings(tmp_path: Path, values: dict[str, str]) -> None:
+    (tmp_path / "local.settings.json").write_text(
+        json.dumps({"IsEncrypted": False, "Values": values}), encoding="utf-8"
+    )
+
+
+class TestCollectBindingConnections:
+    def test_collects_string_literal_connections(self, tmp_path: Path) -> None:
+        (tmp_path / "function_app.py").write_text(SAMPLE_APP, encoding="utf-8")
+        refs = _collect_binding_connections(tmp_path)
+        names = sorted(name for name, _ in refs)
+        assert names == ["ServiceBusConnection", "StorageConnection"]
+        labels = {label for _, label in refs}
+        assert any("function_app.py:handle_bus" in label for label in labels)
+
+    def test_ignores_non_literal_connection(self, tmp_path: Path) -> None:
+        src = (
+            "import azure.functions as func\n"
+            "import os\n"
+            "app = func.FunctionApp()\n\n"
+            "@app.blob_trigger(arg_name='b', path='c/{n}', "
+            "connection=os.environ['X'])\n"
+            "def h(b):\n    pass\n"
+        )
+        (tmp_path / "function_app.py").write_text(src, encoding="utf-8")
+        assert _collect_binding_connections(tmp_path) == []
+
+    def test_ignores_decorators_on_unknown_alias(self, tmp_path: Path) -> None:
+        src = (
+            "import azure.functions as func\n"
+            "other = something()\n\n"
+            "@other.blob_trigger(connection='StorageConnection')\n"
+            "def h(b):\n    pass\n"
+        )
+        (tmp_path / "function_app.py").write_text(src, encoding="utf-8")
+        assert _collect_binding_connections(tmp_path) == []
+
+    def test_syntax_error_file_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "broken.py").write_text("def (:", encoding="utf-8")
+        assert _collect_binding_connections(tmp_path) == []
+
+    def test_blueprint_alias_supported(self, tmp_path: Path) -> None:
+        src = (
+            "import azure.functions as func\n"
+            "bp = func.Blueprint()\n\n"
+            "@bp.queue_trigger(arg_name='m', queue_name='q', "
+            "connection='QueueConnection')\n"
+            "def h(m):\n    pass\n"
+        )
+        (tmp_path / "bp.py").write_text(src, encoding="utf-8")
+        refs = _collect_binding_connections(tmp_path)
+        assert [name for name, _ in refs] == ["QueueConnection"]
+
+
+class TestLocalSettingsValues:
+    def test_returns_string_values(self, tmp_path: Path) -> None:
+        _write_local_settings(tmp_path, {"A": "1", "B": "2"})
+        assert local_settings_values(tmp_path) == {"A": "1", "B": "2"}
+
+    def test_absent_file_returns_empty(self, tmp_path: Path) -> None:
+        assert local_settings_values(tmp_path) == {}
+
+    def test_invalid_json_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "local.settings.json").write_text("{bad", encoding="utf-8")
+        assert local_settings_values(tmp_path) == {}
+
+    def test_non_string_values_ignored(self, tmp_path: Path) -> None:
+        (tmp_path / "local.settings.json").write_text(
+            json.dumps({"Values": {"A": "x", "B": 5, "C": True}}), encoding="utf-8"
+        )
+        assert local_settings_values(tmp_path) == {"A": "x"}
+
+    def test_missing_values_key_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "local.settings.json").write_text(
+            json.dumps({"IsEncrypted": False}), encoding="utf-8"
+        )
+        assert local_settings_values(tmp_path) == {}
+
+
+class TestEvaluateBindingConnectionResolution:
+    def test_no_references_passes(self) -> None:
+        result = _evaluate_binding_connection_resolution([], {"A": "1"})
+        assert result["status"] == "pass"
+        assert "No named binding connections" in result["detail"]
+
+    def test_all_resolved_passes(self) -> None:
+        refs = [("StorageConnection", "app.py:h")]
+        result = _evaluate_binding_connection_resolution(
+            refs, {"StorageConnection": "DefaultEndpointsProtocol=..."}
+        )
+        assert result["status"] == "pass"
+
+    def test_unresolved_warns(self) -> None:
+        refs = [("ServiceBusConnection", "app.py:h")]
+        result = _evaluate_binding_connection_resolution(refs, {})
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+        assert result["gate"] is False
+        assert "ServiceBusConnection" in result["detail"]
+        assert result["actual"] == "Unresolved connections: ServiceBusConnection"
+
+    def test_identity_group_suffix_resolves(self) -> None:
+        refs = [("MyConn", "app.py:h")]
+        result = _evaluate_binding_connection_resolution(
+            refs, {"MyConn__serviceUri": "https://x.servicebus.windows.net"}
+        )
+        assert result["status"] == "pass"
+
+    def test_identity_group_account_name_resolves(self) -> None:
+        refs = [("MyConn", "app.py:h")]
+        result = _evaluate_binding_connection_resolution(refs, {"MyConn__accountName": "acct"})
+        assert result["status"] == "pass"
+
+    def test_mixed_resolved_and_unresolved(self) -> None:
+        refs = [
+            ("Configured", "app.py:a"),
+            ("Missing", "app.py:b"),
+        ]
+        result = _evaluate_binding_connection_resolution(refs, {"Configured": "x"})
+        assert result["status"] == "fail"
+        assert "Missing" in result["detail"]
+        assert "Configured" not in result["actual"]
+
+    def test_duplicate_references_deduplicated(self) -> None:
+        refs = [
+            ("Missing", "app.py:a"),
+            ("Missing", "app.py:a"),
+        ]
+        result = _evaluate_binding_connection_resolution(refs, {})
+        assert result["detail"].count("app.py:a") == 1
+
+    def test_actual_lists_unique_sorted_names(self) -> None:
+        refs = [
+            ("Zeta", "app.py:a"),
+            ("Alpha", "app.py:b"),
+            ("Zeta", "app.py:c"),
+        ]
+        result = _evaluate_binding_connection_resolution(refs, {})
+        assert result["actual"] == "Unresolved connections: Alpha, Zeta"
+
+
+class TestHandler:
+    def _run(self, context: Optional[RuleContext], path: Path) -> dict[str, object]:
+        registry = HandlerRegistry()
+        return dict(registry._handle_binding_connection_resolution({}, path, context))
+
+    def test_no_references_passes(self, tmp_path: Path) -> None:
+        (tmp_path / "function_app.py").write_text(
+            "import azure.functions as func\napp = func.FunctionApp()\n",
+            encoding="utf-8",
+        )
+        result = self._run(None, tmp_path)
+        assert result["status"] == "pass"
+
+    def test_resolves_from_local_settings(self, tmp_path: Path) -> None:
+        (tmp_path / "function_app.py").write_text(SAMPLE_APP, encoding="utf-8")
+        _write_local_settings(
+            tmp_path,
+            {"ServiceBusConnection": "Endpoint=...", "StorageConnection": "x"},
+        )
+        result = self._run(None, tmp_path)
+        assert result["status"] == "pass"
+
+    def test_resolves_from_target_config(self, tmp_path: Path) -> None:
+        (tmp_path / "function_app.py").write_text(SAMPLE_APP, encoding="utf-8")
+        context: RuleContext = {
+            "target_config": _target_config(
+                app_settings={
+                    "ServiceBusConnection": "x",
+                    "StorageConnection": "y",
+                }
+            ),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "pass"
+
+    def test_unresolved_warns(self, tmp_path: Path) -> None:
+        (tmp_path / "function_app.py").write_text(SAMPLE_APP, encoding="utf-8")
+        result = self._run(None, tmp_path)
+        assert result["status"] == "fail"
+        assert result["severity"] == "warning"
+        assert "ServiceBusConnection" in str(result["detail"])
+        assert "StorageConnection" in str(result["detail"])
+
+    def test_identity_group_in_target_config_resolves(self, tmp_path: Path) -> None:
+        src = (
+            "import azure.functions as func\n"
+            "app = func.FunctionApp()\n\n"
+            "@app.service_bus_queue_trigger(arg_name='m', queue_name='q', "
+            "connection='SbConn')\n"
+            "def h(m):\n    pass\n"
+        )
+        (tmp_path / "function_app.py").write_text(src, encoding="utf-8")
+        context: RuleContext = {
+            "target_config": _target_config(
+                app_settings={"SbConn__fullyQualifiedNamespace": "x.servicebus"}
+            ),
+        }
+        result = self._run(context, tmp_path)
+        assert result["status"] == "pass"
+
+    def test_hosting_plan_field_unused_but_context_ok(self, tmp_path: Path) -> None:
+        # A Flex target config with the setting present still resolves cleanly.
+        (tmp_path / "function_app.py").write_text(SAMPLE_APP, encoding="utf-8")
+        tc = TargetConfig(
+            hosting_plan=ResolvedField(FLEX_CONSUMPTION_PLAN, "test"),
+            runtime_name=ResolvedField(None, "unknown"),
+            runtime_version=ResolvedField(None, "unknown"),
+            extension_version=ResolvedField(None, "unknown"),
+            deployment_storage=ResolvedField(None, "unknown"),
+            app_settings={"ServiceBusConnection": "x", "StorageConnection": "y"},
+        )
+        context: RuleContext = {"target_config": tc}
+        result = self._run(context, tmp_path)
+        assert result["status"] == "pass"


### PR DESCRIPTION
## Summary
Adds `check_binding_connection_resolution`, a deterministic pre-deploy check that catches triggers/bindings referencing a `connection` that is not actually configured — a high-signal "will it actually run" check.

- Extracts `connection="..."` references from v2 trigger/binding decorators applied to a discovered `FunctionApp`/`Blueprint` alias (Storage, Service Bus, Event Hub, Cosmos DB, and any binding exposing a `connection` keyword — no hard-coded decorator whitelist).
- Resolves each name against `local.settings.json` `Values` **plus** the ingested deploy-config app settings.
- **WARN** (non-gating) when a referenced connection has no corresponding configuration.
- **Identity-based connections** (`<name>__serviceUri`, `<name>__accountName`, `<name>__fullyQualifiedNamespace`, …) are treated as configured, avoiding false positives.
- Only string-literal connection names are inspected; dynamic expressions (variables, `os.environ[...]`) are skipped.

## Implementation
- `_helpers._collect_binding_connections(path)` — AST collector returning `(connection_name, "file:function")` pairs.
- `deploy_config.local_settings_values(path)` — reads `local.settings.json` `Values` directly (does **not** alter `TargetConfig` ingestion, so existing checks are unaffected).
- `registry._evaluate_binding_connection_resolution(...)` classifier + `_handle_binding_connection_resolution` handler.
- Rule `check_binding_connection_resolution` (`type: binding_connection_resolution`, section `runtime`, `check_order 8`) in `v2.json`; type added to `rules.schema.json` enum.
- Docs: regenerated `docs/rule_inventory.md` (now **41 rules**) + hand-authored Rule Types row.

## Tests / gates
- New `tests/test_binding_connection_resolution.py` (24 tests: collector, `local_settings_values`, classifier, handler wiring, identity-group suppression).
- ruff PASS, mypy strict PASS (53 files), full-suite coverage **96.96%**, docs-consistency PASS, CLI smoke exit 0.

Closes #352
Part of #341