### PR TITLE
docs: replace hardcoded diagnostic-check count with a drift-guarded count (#354)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Deploying a broken Azure Functions app is expensive — the worker starts, the h
 
 ## What it does
 
-- **30 diagnostic checks** — Python version, dependencies, host.json, Core Tools, Durable Functions, and more
+- **41 diagnostic checks** — Python version, dependencies, host.json, Core Tools, Durable Functions, and more
 - **Multiple output formats** — table, JSON, SARIF, JUnit for CI integration
 - **Profile support** — `minimal` or `full` rulesets depending on your needs
 - **Official GitHub Action** — `yeongseon/azure-functions-doctor@v1` for CI gates

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -98,9 +98,33 @@ def _check_rule_inventory() -> list[str]:
     return errors
 
 
+def _check_readme_rule_count() -> list[str]:
+    """Assert README's "N diagnostic checks" count matches the shipped ruleset."""
+    readme = ROOT / "README.md"
+    content = readme.read_text(encoding="utf-8")
+    match = re.search(r"\*\*(\d+) diagnostic checks\*\*", content)
+    if not match:
+        return [
+            "README.md: could not find a '**N diagnostic checks**' count to "
+            "verify against the rule inventory."
+        ]
+    documented = int(match.group(1))
+    actual = len(_rule_ids_from_json())
+    if documented != actual:
+        return [
+            f"README.md: documented '{documented} diagnostic checks' does not "
+            f"match the {actual} rules in v2.json. Update the count in README.md."
+        ]
+    return []
+
+
 def main() -> int:
     version = _read_version()
-    errors = _check_version_refs(version) + _check_rule_inventory()
+    errors = (
+        _check_version_refs(version)
+        + _check_rule_inventory()
+        + _check_readme_rule_count()
+    )
     if errors:
         print("Documentation consistency check FAILED:")
         for err in errors:

--- a/tests/test_docs_consistency.py
+++ b/tests/test_docs_consistency.py
@@ -1,0 +1,54 @@
+"""Tests for the documentation-consistency guards (issue #354)."""
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "check_docs_consistency.py"
+RULES_JSON = ROOT / "src" / "azure_functions_doctor" / "assets" / "rules" / "v2.json"
+README = ROOT / "README.md"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_docs_consistency", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _rule_count() -> int:
+    return len(json.loads(RULES_JSON.read_text(encoding="utf-8")))
+
+
+class TestReadmeRuleCount:
+    def test_readme_count_matches_ruleset(self) -> None:
+        module = _load_module()
+        assert module._check_readme_rule_count() == []
+
+    def test_readme_states_exact_current_count(self) -> None:
+        content = README.read_text(encoding="utf-8")
+        assert f"**{_rule_count()} diagnostic checks**" in content
+
+    def test_guard_flags_stale_count(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        module = _load_module()
+        # Simulate a ruleset that grew without the README being updated.
+        monkeypatch.setattr(module, "_rule_ids_from_json", lambda: {f"r{i}" for i in range(999)})
+        errors = module._check_readme_rule_count()
+        assert errors
+        assert "does not" in errors[0]
+
+    def test_guard_flags_missing_count_phrase(self, monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        module = _load_module()
+        fake_readme = tmp_path / "README.md"
+        fake_readme.write_text("no count here", encoding="utf-8")
+        monkeypatch.setattr(module, "ROOT", tmp_path)
+        errors = module._check_readme_rule_count()
+        assert errors
+        assert "could not find" in errors[0]
+
+    def test_full_check_passes(self) -> None:
+        module = _load_module()
+        assert module.main() == 0


### PR DESCRIPTION
## Summary
The README claimed "**30 diagnostic checks**" while `assets/rules/v2.json` now defines **41** rules. This fixes the drift and makes it impossible to recur.

- Update README to the exact current count (**41**).
- Add `_check_readme_rule_count()` to `scripts/check_docs_consistency.py`: parses the `**N diagnostic checks**` phrase and asserts `N` equals the number of rules in `v2.json`. This runs in the same docs-consistency CI gate that already guards rule-ID and version parity.
- New `tests/test_docs_consistency.py` covering the guard: count-matches, stale-count detection, missing-phrase detection, and a full `main()` pass.

## Tests / gates
- ruff PASS, mypy strict PASS (54 files), full-suite coverage 96.96%, docs-consistency PASS.

Closes #354
Part of #341