### PR TITLE
docs(prd): finish runtime/deployment positioning by fixing stale command examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -34,14 +34,14 @@ Intentionally misconfigured projects that demonstrate specific rule failures.
 
 ```bash
 # Passing examples (all checks should pass)
-azure-functions doctor --path examples/v2/http-trigger
-azure-functions doctor --path examples/v2/timer-trigger
-azure-functions doctor --path examples/v2/multi-trigger
-azure-functions doctor --path examples/v2/blueprint
+azure-functions-doctor doctor --path examples/v2/http-trigger
+azure-functions-doctor doctor --path examples/v2/timer-trigger
+azure-functions-doctor doctor --path examples/v2/multi-trigger
+azure-functions-doctor doctor --path examples/v2/blueprint
 
 # Broken examples (expect specific failures)
-azure-functions doctor --path examples/v2/broken-missing-host-json
-azure-functions doctor --path examples/v2/broken-missing-requirements
-azure-functions doctor --path examples/v2/broken-missing-azure-functions
-azure-functions doctor --path examples/v2/broken-no-v2-decorators
+azure-functions-doctor doctor --path examples/v2/broken-missing-host-json
+azure-functions-doctor doctor --path examples/v2/broken-missing-requirements
+azure-functions-doctor doctor --path examples/v2/broken-missing-azure-functions
+azure-functions-doctor doctor --path examples/v2/broken-no-v2-decorators
 ```

--- a/examples/v2/blueprint/README.md
+++ b/examples/v2/blueprint/README.md
@@ -30,7 +30,7 @@ func start
 ## Diagnose
 
 ```bash
-azure-functions doctor --path examples/v2/blueprint
+azure-functions-doctor doctor --path examples/v2/blueprint
 ```
 
 All checks should pass for this example.

--- a/examples/v2/broken-missing-azure-functions/README.md
+++ b/examples/v2/broken-missing-azure-functions/README.md
@@ -8,4 +8,4 @@ This fixture is intentionally broken by including `requirements.txt` without `az
 
 ## Expected doctor output
 
-When running `azure-functions doctor --path examples/v2/broken-missing-azure-functions`, the report should include a failed `azure-functions package` check because `azure-functions` is not declared in `requirements.txt`.
+When running `azure-functions-doctor doctor --path examples/v2/broken-missing-azure-functions`, the report should include a failed `azure-functions package` check because `azure-functions` is not declared in `requirements.txt`.

--- a/examples/v2/broken-missing-host-json/README.md
+++ b/examples/v2/broken-missing-host-json/README.md
@@ -8,4 +8,4 @@ This fixture is intentionally broken by omitting `host.json`.
 
 ## Expected doctor output
 
-When running `azure-functions doctor --path examples/v2/broken-missing-host-json`, the report should include a failed `host.json` check because the file does not exist at the project root.
+When running `azure-functions-doctor doctor --path examples/v2/broken-missing-host-json`, the report should include a failed `host.json` check because the file does not exist at the project root.

--- a/examples/v2/broken-missing-requirements/README.md
+++ b/examples/v2/broken-missing-requirements/README.md
@@ -8,4 +8,4 @@ This fixture is intentionally broken by omitting `requirements.txt`.
 
 ## Expected doctor output
 
-When running `azure-functions doctor --path examples/v2/broken-missing-requirements`, the report should include a failed `requirements.txt` check because no dependency file exists at the project root.
+When running `azure-functions-doctor doctor --path examples/v2/broken-missing-requirements`, the report should include a failed `requirements.txt` check because no dependency file exists at the project root.

--- a/examples/v2/broken-no-v2-decorators/README.md
+++ b/examples/v2/broken-no-v2-decorators/README.md
@@ -11,6 +11,6 @@ but `function_app.py` does not use `func.FunctionApp()` or any `@app.*` decorato
 
 ## Expected doctor output
 
-When running `azure-functions doctor --path examples/v2/broken-no-v2-decorators`, the report
+When running `azure-functions-doctor doctor --path examples/v2/broken-no-v2-decorators`, the report
 should include a failed `Python v2 programming model was not detected` result because no
 `func.FunctionApp()`, `Blueprint()`, or `@app.` / `@bp.` trigger decorators are present.

--- a/examples/v2/http-trigger/README.md
+++ b/examples/v2/http-trigger/README.md
@@ -34,7 +34,7 @@ curl "http://localhost:7071/api/HttpExample?name=World"
 ## Diagnose
 
 ```bash
-azure-functions doctor --path examples/v2/http-trigger
+azure-functions-doctor doctor --path examples/v2/http-trigger
 ```
 
 All checks should pass for this example.

--- a/examples/v2/multi-trigger/README.md
+++ b/examples/v2/multi-trigger/README.md
@@ -34,7 +34,7 @@ func start
 ## Diagnose
 
 ```bash
-azure-functions doctor --path examples/v2/multi-trigger
+azure-functions-doctor doctor --path examples/v2/multi-trigger
 ```
 
 All checks should pass for this example.

--- a/examples/v2/timer-trigger/README.md
+++ b/examples/v2/timer-trigger/README.md
@@ -28,7 +28,7 @@ func start
 ## Diagnose
 
 ```bash
-azure-functions doctor --path examples/v2/timer-trigger
+azure-functions-doctor doctor --path examples/v2/timer-trigger
 ```
 
 All checks should pass for this example.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -23,7 +23,7 @@ pip install azure-functions-doctor
 All three commands are aliases to the same CLI:
 
 ```bash
-azure-functions doctor [OPTIONS]
+azure-functions-doctor doctor [OPTIONS]
 azure-functions-doctor doctor [OPTIONS]
 fdoctor doctor [OPTIONS]
 ```
@@ -35,7 +35,7 @@ Runs diagnostics on an Azure Functions Python v2 application.
 ### Syntax
 
 ```bash
-azure-functions doctor [OPTIONS]
+azure-functions-doctor doctor [OPTIONS]
 ```
 
 ### Options
@@ -105,47 +105,47 @@ azure-functions doctor [OPTIONS]
 
 **Basic check (current directory, table output):**
 ```bash
-azure-functions doctor
+azure-functions-doctor doctor
 ```
 
 **Verbose output for debugging:**
 ```bash
-azure-functions doctor --verbose
+azure-functions-doctor doctor --verbose
 ```
 
 **Required checks only (minimal profile):**
 ```bash
-azure-functions doctor --profile minimal
+azure-functions-doctor doctor --profile minimal
 ```
 
 **JSON output for CI integration:**
 ```bash
-azure-functions doctor --format json
+azure-functions-doctor doctor --format json
 ```
 
 **Save JSON to file with debug logging:**
 ```bash
-azure-functions doctor --format json --output diagnostics.json --debug
+azure-functions-doctor doctor --format json --output diagnostics.json --debug
 ```
 
 **SARIF output for GitHub Security tab:**
 ```bash
-azure-functions doctor --format sarif --output sarif.json
+azure-functions-doctor doctor --format sarif --output sarif.json
 ```
 
 **Custom rules with summary:**
 ```bash
-azure-functions doctor --rules ./custom-rules.json --summary-json summary.json
+azure-functions-doctor doctor --rules ./custom-rules.json --summary-json summary.json
 ```
 
 **JUnit output for CI/CD:**
 ```bash
-azure-functions doctor --format junit --output test-results.xml
+azure-functions-doctor doctor --format junit --output test-results.xml
 ```
 
 **Full diagnostics with all options:**
 ```bash
-azure-functions doctor \
+azure-functions-doctor doctor \
   --path ./my-app \
   --profile full \
   --format json \
@@ -173,7 +173,7 @@ Python Env
   [✓] Python version: 3.12 running
   [✗] Virtual environment
 
-Doctor summary (to see all details, run azure-functions doctor -v):
+Doctor summary (to see all details, run azure-functions-doctor doctor -v):
   1 fail, 1 warning, 8 passed
 Exit code: 1
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,7 @@ Outputs to table, JSON, SARIF, or JUnit formats. Integrates with CI/CD pipelines
 ## CLI Commands
 
 Main entry points (all aliases):
-- `azure-functions doctor` — Run all diagnostics
+- `azure-functions-doctor doctor` — Run all diagnostics
 - `azure-functions-doctor doctor` — Same as above
 - `fdoctor doctor` — Short alias
 


### PR DESCRIPTION
## Context

Closes #349. Part of #341.

`PRD.md` already reflects the next-generation positioning on `main` — it frames the tool as an "Azure Functions Python runtime & deployment diagnostic engine", documents the non-goals (multi-language, generic semantic lint, generic security scanning, runtime network calls, agent-inferred compatibility), describes the **deterministic core → findings → optional future agent** architecture, and states the auditable/deterministic/offline/source-linked/Python-specific moat.

The remaining acceptance item was fixing the **stale command examples**: the deprecated `azure-functions doctor` alias form still appeared in generated/reference docs and example READMEs.

## What changed

Replaced `azure-functions doctor` → `azure-functions-doctor doctor` (the canonical command) across:

- `llms.txt`, `llms-full.txt`
- `examples/README.md`
- all `examples/v2/*/README.md`

Intentionally **not** changed (the alias form is correct there):

- `CHANGELOG.md`, `docs/changelog.md` — historical records
- `docs/deprecated-aliases.md` — documents the deprecated alias by design

## Verification

- Docs-consistency gate passes (version 0.19.2, 41 rules; version references untouched).
- Docs/example/llms-related tests pass.
- No remaining `azure-functions doctor` occurrences outside changelogs and the deprecated-aliases guide.