### PR TITLE
docs: add positioning/comparison page vs official azure-functions-skills doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中
 
 **Azure Functions Doctor** is the pre-deploy health gate for **Azure Functions Python v2** projects — a diagnostic CLI that catches configuration issues, missing dependencies, and environment problems before they cause runtime failures in production.
 
+> **Looking for the official `azure-functions-skills` doctor?** This is an independent, offline, deterministic Python package — see [how it compares](docs/comparison.md) and when to use each.
+
 ---
 
 Part of the **Azure Functions Python DX Toolkit**

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,68 @@
+# Positioning: how this compares to the official `azure-functions-skills` doctor
+
+**Use this when you need offline, deterministic, source-linked Python compatibility checks before deploy (no AI/cloud dependency required).**
+
+Microsoft ships an official `doctor` skill inside
+[`Azure/azure-functions-skills`](https://github.com/Azure/azure-functions-skills),
+a coding-agent plugin for GitHub Copilot, Claude Code, and Codex. It shares the
+`doctor` name with this package, so this page explains what each tool is for and
+how they fit together.
+
+## TL;DR
+
+- **`azure-functions-doctor` (this package)** — a PyPI-installed CLI that runs
+  **offline** and **deterministically**. It has no LLM, no cloud calls, and no
+  network dependency. Every finding maps to a source-linked rule in an auditable
+  catalog, and it goes deep on **Python v2** runtime, hosting-plan, and deploy
+  compatibility. It is safe to run unattended in CI and on pull-request
+  workspaces.
+- **The official `azure-functions-skills` doctor** — a multi-language
+  **coding-agent skill** whose headline value is **LLM semantic analysis**. Its
+  `--deep` mode runs an AI agent (with elevated file-write / shell-exec
+  permissions) to catch semantic issues that deterministic rules cannot.
+
+These are complementary. You can run this package as a fast, deterministic
+pre-deploy gate and use the official skill's AI analysis for semantic review
+inside your coding agent.
+
+## Comparison
+
+| Dimension | `azure-functions-doctor` (this package) | `azure-functions-skills` doctor (official) |
+| --- | --- | --- |
+| **Primary form** | PyPI Python package + official GitHub Action | Coding-agent plugin (skills + Azure MCP), distributed via npm `@azure/functions-skills` and plugin marketplaces |
+| **Core engine** | Deterministic rule catalog — **no LLM required** | LLM semantic analysis is the headline value (`--deep`); a `--no-deep` Tier-1 deterministic mode also exists |
+| **Offline / CI-safe** | Yes — fully offline, no network or cloud, safe to run on PR workspaces | Deep mode needs an AI agent with elevated permissions and **refuses to run on PR workspaces** (prompt-injection risk); `--no-deep` is the CI-safe tier |
+| **Transparency / auditability** | Every finding cites a rule in a source-linked catalog; output is reproducible | Deep findings come from LLM reasoning; `--no-deep` is deterministic |
+| **Language focus** | **Python v2** decorator model — deep runtime/hosting-plan/deploy checks (Python lifecycle, hosting-plan Python caps, Flex config, binding connection resolution) | Multi-language, not Python-specific |
+| **Runtime required** | Python 3.10+ | Node.js 20+ (Node 24+ for Copilot CLI) |
+| **Determinism** | Deterministic — same inputs produce the same findings | Deep mode is non-deterministic; `--no-deep` is deterministic |
+
+## Naming relationship
+
+This project is an **independent community package** published on PyPI as
+`azure-functions-doctor`. It is **not affiliated with, endorsed by, or
+maintained by Microsoft**. The official skill lives at
+`templates/skills/azure-functions-doctor` inside `Azure/azure-functions-skills`
+and happens to share the `doctor` name because both diagnose Azure Functions
+projects.
+
+To disambiguate:
+
+- **This package** is what you `pip install azure-functions-doctor` and invoke as
+  `azure-functions-doctor doctor`.
+- **The official skill** is what you add to a coding agent via the
+  `azure-functions-skills` plugin.
+
+## When to use which
+
+- **Reach for this package** when you want a fast, offline, deterministic gate
+  that runs the same way locally, in CI, and on pull requests — with every
+  finding traceable to a documented rule, focused on Python v2 deploy
+  compatibility.
+- **Reach for the official skill** when you want AI-assisted semantic review
+  (missing error handling, blocking I/O, hardcoded secrets, durable-orchestrator
+  non-determinism) from inside your coding agent, and you can grant it a trusted
+  workspace.
+
+They are not mutually exclusive — running both gives you deterministic
+pre-deploy coverage plus AI-assisted semantic analysis.

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,7 @@ def has_required_failures(path: str) -> bool:
 
 - [Supported Versions](supported_versions.md)
 - [Semver Policy](semver_policy.md)
+- [Comparison vs Official Skill](comparison.md)
 - [Troubleshooting](troubleshooting.md)
 - [FAQ](faq.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
   - Reference:
       - Architecture: architecture.md
       - Supported Versions: supported_versions.md
+      - Comparison vs Official Skill: comparison.md
       - Semver Policy: semver_policy.md
   - Contributing:
       - Development: development.md


### PR DESCRIPTION
## Summary
Adds a positioning/comparison page so users landing via the shared `doctor` name immediately understand what this package is for versus Microsoft's official `azure-functions-skills` doctor skill.

- New `docs/comparison.md` leading with: *"Use this when you need offline, deterministic, source-linked Python compatibility checks before deploy (no AI/cloud dependency required)."*
- Comparison table: this tool vs the official skill (offline/CI-safe, transparency/auditability, Python-specific runtime/deploy depth, no LLM required for the core, runtime/distribution).
- Naming-relationship clarification: independent community PyPI package, **not affiliated with Microsoft**; frames the two as complementary.
- Wired into mkdocs `nav` (Reference section) and the `docs/index.md` documentation map.
- Linked from the **top of the README**.

## Acceptance (#353)
- [x] Comparison page with the required "offline, deterministic, source-linked" lead
- [x] Table covering offline/CI, transparency, Python-specific depth, no-LLM core
- [x] Naming relationship clarified
- [x] Linked from README top

Docs-only change. `check_docs_consistency.py` passes (version 0.19.2, 41 rules); the new page builds cleanly and is in nav.

Closes #353
Part of #341