### PR TITLE
chore(action): document all four rule profiles in action.yml inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: "."
   profile:
-    description: "Rule profile: 'minimal' (required checks only) or 'full' (all checks)"
+    description: "Rule profile: 'minimal' (required checks only), 'deploy' (runtime/hosting/deployment correctness), 'development' (dev-environment checks), or 'full' (all checks)"
     required: false
     default: "minimal"
   format:


### PR DESCRIPTION
## Context

Part of #325 (Action metadata completeness). The `profile` input description still advertised only `minimal`/`full`; since #356 the CLI supports `minimal`, `deploy`, `development`, and `full`. Mirror that in the Marketplace-facing input metadata.

## Changes

- `action.yml`: `profile` input description now lists all four profiles with one-line semantics. No behavior change (default stays `minimal`, which remains valid).

## Verification

- No code path changed — input metadata only. Action smoke workflows (`Test action on healthy example`, `Test action with SARIF output`) run on this PR.

References #325