### PR TITLE
docs(rules): add per-rule reference pages for the deploy-risk rule group

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,7 @@ def has_required_failures(path: str) -> bool:
 - [Diagnostics](diagnostics.md)
 - [Rules](rules.md)
 - [Rule Inventory](rule_inventory.md)
+- [Deploy-Risk Rule Pages](rules/check_python_runtime_lifecycle.md) — one page per runtime/deployment rule; error messages land on the rule
 - [Minimal Profile](minimal_profile.md)
 - [JSON Output Contract](json_output_contract.md)
 - [Handlers](handlers.md)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -391,6 +391,24 @@ Found unwanted files: ['tests/', '.venv']
 - **Severity:** Warning only (`required: false`).
 
 
+## Deploy-risk rule reference
+
+The runtime/hosting/deployment-correctness rules also have individual reference pages under `docs/rules/`. Each page shows the exact finding text, so searching for an error message lands directly on the rule:
+
+- [Python runtime lifecycle](rules/check_python_runtime_lifecycle.md)
+- [Functions runtime lifecycle](rules/check_functions_runtime_lifecycle.md)
+- [Hosting plan lifecycle](rules/check_hosting_plan_lifecycle.md)
+- [Flex Consumption runtime config](rules/check_flex_runtime_config.md)
+- [Flex Consumption deprecated app settings](rules/check_flex_deprecated_settings.md)
+- [Flex Consumption deployment storage](rules/check_flex_deployment_storage.md)
+- [Binding connection resolution](rules/check_binding_connection_resolution.md)
+- [Functions extension version](rules/check_functions_extension_version.md)
+- [Linux runtime (linuxFxVersion)](rules/check_linux_fx_version.md)
+- [Dev-storage emulator connection](rules/check_dev_storage_connection.md)
+- [Pinned requirements](rules/check_unpinned_requirements.md)
+
+Experimental-tier and integration-group rules are intentionally not given per-rule pages yet (see [#326](https://github.com/yeongseon/azure-functions-doctor-python/issues/326)).
+
 ## Rule authoring template
 
 ```json

--- a/docs/rules/check_binding_connection_resolution.md
+++ b/docs/rules/check_binding_connection_resolution.md
@@ -1,0 +1,38 @@
+# Binding connection resolution
+
+> Rule ID: `check_binding_connection_resolution` · Category: configuration · Section: runtime
+> Severity: warning (non-gating) · Profiles: `deploy`, `full` · Tier: core
+
+## What it checks
+
+`connection=` references in v2 trigger/binding decorators — Storage, Service Bus, Event Hub, Cosmos DB, and any binding exposing a `connection` keyword — and resolves each against:
+
+1. `local.settings.json` `Values`, and
+2. app settings ingested from deploy config (infra bicep/ARM).
+
+A referenced connection with no corresponding configuration warns. **Identity-based connection groups** (`<name>__serviceUri`, `<name>__accountName`, …) are treated as configured.
+
+## Why it matters
+
+A trigger or binding that references `connection="Name"` fails to bind at runtime when no matching app setting or identity-based connection group is configured; catching this before deploy avoids a cold-start failure discovered only in production logs.
+
+## Symptoms
+
+A binding references a connection name that has no corresponding app setting, so the function fails to start or the trigger never fires after deployment.
+
+## Example finding
+
+```text
+Binding connections reference unconfigured settings:
+  - MyStorage (function_app.py:work)
+Add the missing app setting(s), or configure an identity-based connection
+group (<name>__serviceUri / <name>__accountName).
+```
+
+## How to fix
+
+Add the missing app setting for each referenced connection, or configure an identity-based connection group (`<name>__serviceUri` / `<name>__accountName`).
+
+## Reference
+
+- [Azure Functions — Connections (binding connection resolution)](https://learn.microsoft.com/azure/azure-functions/functions-reference#connections)

--- a/docs/rules/check_dev_storage_connection.md
+++ b/docs/rules/check_dev_storage_connection.md
@@ -1,0 +1,34 @@
+# Dev-storage emulator connection
+
+> Rule ID: `check_dev_storage_connection` · Category: configuration · Section: runtime
+> Severity: warning (non-gating) · Profiles: `deploy`, `full`
+
+## What it checks
+
+`AzureWebJobsStorage=UseDevelopmentStorage=true` in **deployable infra config** (bicep/ARM). That value points at the local Azurite emulator and must never ship to a deployed app. The same value in `local.settings.json` is fine — only deployable templates are flagged.
+
+## Why it matters
+
+The dev-storage emulator connection is unreachable from Azure; shipping it in provisioned app settings makes the deployed Functions host fail to start.
+
+## Symptoms
+
+Deployed app fails health checks; host cannot reach storage; triggers never fire in the cloud.
+
+## Example finding
+
+```text
+Dev-storage emulator connection in deployable config (ships to production):
+- main.bicep
+
+Fix: provision a real storage account connection for AzureWebJobsStorage in
+deployment templates; keep UseDevelopmentStorage=true only in local.settings.json.
+```
+
+## How to fix
+
+Provision a real storage account connection for `AzureWebJobsStorage` in deployment templates; keep `UseDevelopmentStorage=true` only in `local.settings.json`.
+
+## Reference
+
+- [App settings reference — AzureWebJobsStorage](https://learn.microsoft.com/azure/azure-functions/functions-app-settings#azurewebjobsstorage)

--- a/docs/rules/check_flex_deployment_storage.md
+++ b/docs/rules/check_flex_deployment_storage.md
@@ -1,0 +1,41 @@
+# Flex Consumption deployment storage
+
+> Rule ID: `check_flex_deployment_storage` · Category: configuration · Section: runtime
+> Severity: warning (non-gating) · Profiles: `deploy`, `full` · Tier: core
+
+## What it checks
+
+For a **Flex Consumption** app, the deployment storage shape declared under `functionAppConfig.deployment.storage`:
+
+- A **container URL** (`value`) must be specified.
+- **Authentication** must be configured — a managed identity or a named storage account connection string (`storageAccountConnectionStringName`).
+
+A Flex app whose infra declares no deployment storage block skips gracefully (the block may be managed elsewhere). This is a static shape check only; the storage account is never contacted. Non-Flex apps skip.
+
+## Why it matters
+
+Flex Consumption deploys from a blob container declared under `functionAppConfig.deployment.storage`; a missing container or unconfigured authentication produces a deployment that cannot fetch its package.
+
+## Symptoms
+
+A Flex app with no deployment container or no authentication configured fails to deploy or cannot fetch its package at scale-out.
+
+## Example finding
+
+```text
+Flex Consumption deployment storage is misconfigured:
+  - no deployment container is specified
+    (functionAppConfig.deployment.storage.value)
+  - no authentication is configured; use a managed identity or a storage
+    account connection string
+Declare a blob container under functionAppConfig.deployment.storage with
+a value URL and authentication (managed identity or connection string).
+```
+
+## How to fix
+
+Declare a blob container under `functionAppConfig.deployment.storage` with a `value` URL and authentication (managed identity or a named connection string).
+
+## Reference
+
+- [Azure Functions — Flex Consumption plan (`functionAppConfig.deployment.storage`)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)

--- a/docs/rules/check_flex_deprecated_settings.md
+++ b/docs/rules/check_flex_deprecated_settings.md
@@ -1,0 +1,48 @@
+# Flex Consumption deprecated app settings
+
+> Rule ID: `check_flex_deprecated_settings` · Category: configuration · Section: runtime
+> Severity: warning (non-gating) · Profiles: `deploy`, `full` · Tier: core
+
+## What it checks
+
+For a **Flex Consumption** app, whether legacy app settings that Flex **ignores** are declared. Each flagged setting cites its replacement mechanism:
+
+| Deprecated setting | Replacement |
+| --- | --- |
+| `FUNCTIONS_WORKER_RUNTIME` | `name` under `functionAppConfig.runtime` |
+| `FUNCTIONS_WORKER_RUNTIME_VERSION` | `version` under `functionAppConfig.runtime` |
+| `FUNCTIONS_WORKER_PROCESS_COUNT` | Not valid on Flex; per-instance concurrency is platform-managed |
+| `SCM_DO_BUILD_DURING_DEPLOYMENT` | `remoteBuild` parameter when deploying to Flex |
+| `ENABLE_ORYX_BUILD` | `remoteBuild` parameter when deploying to Flex |
+| `WEBSITE_CONTENTSHARE` | `functionAppConfig`'s deployment section |
+| `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING` | `functionAppConfig`'s deployment section |
+| `WEBSITE_RUN_FROM_PACKAGE` and VNet route-all settings | Site networking properties |
+
+`linuxFxVersion` and `FUNCTIONS_EXTENSION_VERSION` are owned by [`check_flex_runtime_config`](check_flex_runtime_config.md) and [`check_functions_extension_version`](check_functions_extension_version.md) respectively, so this rule never emits a duplicate finding for them. Non-Flex apps skip.
+
+## Why it matters
+
+Flex Consumption ignores a set of legacy app settings; leaving them in place is a configuration smell that masks the correct `functionAppConfig`-based configuration and can confuse deployments.
+
+## Symptoms
+
+Deprecated app settings are silently ignored on Flex Consumption, so settings such as `FUNCTIONS_WORKER_RUNTIME` or `WEBSITE_RUN_FROM_PACKAGE` have no effect and hide the real configuration.
+
+## Example finding
+
+```text
+Deprecated app settings declared on a Flex Consumption app:
+  - FUNCTIONS_WORKER_RUNTIME: replaced by 'name' under functionAppConfig.runtime.
+  - SCM_DO_BUILD_DURING_DEPLOYMENT: replaced by the remoteBuild parameter
+    when deploying to Flex Consumption.
+Flex Consumption ignores these settings; remove them and use the listed
+replacement mechanism.
+```
+
+## How to fix
+
+Remove legacy app settings on Flex Consumption; configure the runtime, deployment, scaling, and networking through `functionAppConfig` and site networking properties instead.
+
+## Reference
+
+- [Azure Functions — App settings reference (Flex Consumption plan deprecations)](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)

--- a/docs/rules/check_flex_runtime_config.md
+++ b/docs/rules/check_flex_runtime_config.md
@@ -1,0 +1,46 @@
+# Flex Consumption runtime config
+
+> Rule ID: `check_flex_runtime_config` · Category: configuration · Section: runtime
+> Severity: error (gating) on an unsupported runtime, warning on a legacy `linuxFxVersion` · Profiles: `deploy`, `full` · Tier: core
+
+## What it checks
+
+For a **Flex Consumption** app, the runtime declared under `functionAppConfig.runtime` (`name`/`version`):
+
+- A non-Python or undeclared runtime **skips**.
+- An unsupported Python version **fails** against the Flex hosting-plan matrix (Flex supports Python 3.10–3.14).
+- A legacy `linuxFxVersion` declaration **warns** — Flex ignores it.
+
+Non-Flex apps skip.
+
+## Why it matters
+
+Flex Consumption resolves its runtime from `functionAppConfig.runtime` and ignores `linuxFxVersion`; a misdeclared or unsupported runtime version fails to deploy or run.
+
+## Symptoms
+
+A Flex app with only `linuxFxVersion` set has no effective runtime declaration; an unsupported Python version is rejected at deploy time.
+
+## Example findings
+
+Unsupported runtime version:
+
+```text
+Flex Consumption runtime Python 3.9 is not supported; target a supported
+Python runtime (3.10–3.14).
+```
+
+Legacy `linuxFxVersion` on a Flex app:
+
+```text
+linuxFxVersion is declared on a Flex Consumption app, which ignores it;
+declare the runtime under functionAppConfig.runtime (name/version) instead.
+```
+
+## How to fix
+
+Declare the Flex Consumption runtime under `functionAppConfig.runtime` (`name`/`version`); do not use `linuxFxVersion`.
+
+## Reference
+
+- [Azure Functions — Flex Consumption plan (`functionAppConfig.runtime`)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)

--- a/docs/rules/check_functions_extension_version.md
+++ b/docs/rules/check_functions_extension_version.md
@@ -1,0 +1,41 @@
+# Functions extension version
+
+> Rule ID: `check_functions_extension_version` · Category: configuration · Section: runtime
+> Severity: warning (non-gating) · Profiles: `deploy`, `full`
+
+## What it checks
+
+`FUNCTIONS_EXTENSION_VERSION` in `local.settings.json`. A missing, legacy (`~1`/`~2`/`~3`), or otherwise non-`~4` value is flagged so the app targets the supported v4 Azure Functions runtime. Flex Consumption apps skip — on Flex the runtime is owned by [`check_flex_runtime_config`](check_flex_runtime_config.md) via `functionAppConfig.runtime`.
+
+## Why it matters
+
+Legacy Azure Functions runtimes (`~1`/`~2`/`~3`) are retired; deploying against them causes host startup failures and unsupported-runtime errors.
+
+## Symptoms
+
+Host fails to start; deployment rejected with unsupported runtime version; functions never come online.
+
+## Example findings
+
+Missing value:
+
+```text
+FUNCTIONS_EXTENSION_VERSION is not set in local.settings.json;
+pin it to '~4' for the current Azure Functions runtime.
+```
+
+Legacy value:
+
+```text
+FUNCTIONS_EXTENSION_VERSION is '~3', expected '~4'. Legacy runtimes
+(~1/~2/~3) are retired; target the v4 runtime.
+```
+
+## How to fix
+
+Set `FUNCTIONS_EXTENSION_VERSION` to `~4` in `local.settings.json`; the v1/v2/v3 runtimes are retired.
+
+## Reference
+
+- [Azure Functions runtime versions overview](https://learn.microsoft.com/azure/azure-functions/functions-versions)
+- Related rule: [`check_functions_runtime_lifecycle`](check_functions_runtime_lifecycle.md) applies the catalog's lifecycle dates to the resolved runtime

--- a/docs/rules/check_functions_runtime_lifecycle.md
+++ b/docs/rules/check_functions_runtime_lifecycle.md
@@ -1,0 +1,41 @@
+# Functions runtime lifecycle
+
+> Rule ID: `check_functions_runtime_lifecycle` · Category: configuration · Section: runtime
+> Severity: error (gating) on v1/v2/v3 · Profiles: `deploy`, `full` · Tier: core
+
+## What it checks
+
+The Azure Functions runtime major version (`FUNCTIONS_EXTENSION_VERSION`) for a Python app:
+
+| Runtime | Verdict |
+| --- | --- |
+| v1 | Incompatible with Python — fails outright |
+| v2 / v3 | Out of support — fails |
+| v3 on Linux Consumption | Out of support **and** stops running on a published date — emphasized failure |
+| v4 | Current GA runtime — passes |
+| Undeterminable | Skips |
+
+The runtime is resolved from infra config / app settings via the deploy-config ingestion pipeline; lifecycle dates come from the version-controlled compatibility catalog.
+
+## Why it matters
+
+Running on a legacy or out-of-support Azure Functions runtime loses security updates and eventually the ability to run; runtime v1 cannot host a Python app at all.
+
+## Symptoms
+
+Host fails to start on an unsupported runtime; v3 Linux Consumption apps stop running after the published date; v1 rejects Python apps outright.
+
+## Example finding
+
+```text
+Azure Functions runtime v3 is out of support; migrate to runtime v4.
+```
+
+## How to fix
+
+Target the v4 Azure Functions runtime (`FUNCTIONS_EXTENSION_VERSION=~4`). The v1/v2/v3 runtimes are legacy or out of support; v1 does not support Python at all.
+
+## Reference
+
+- [Azure Functions — Compare runtime versions](https://learn.microsoft.com/azure/azure-functions/functions-versions)
+- Related rule: [`check_functions_extension_version`](check_functions_extension_version.md) validates the value declared in `local.settings.json`

--- a/docs/rules/check_hosting_plan_lifecycle.md
+++ b/docs/rules/check_hosting_plan_lifecycle.md
@@ -1,0 +1,40 @@
+# Hosting plan lifecycle
+
+> Rule ID: `check_hosting_plan_lifecycle` · Category: configuration · Section: runtime
+> Severity: info (distant), warning (retiring soon), error (retired) · Profiles: `deploy`, `full` · Tier: core
+
+## What it checks
+
+The resolved hosting plan against its **published retirement date**. The plan is resolved from infra config (bicep/ARM) and deploy-config ingestion; dates come from the compatibility catalog.
+
+| Plan state | Status |
+| --- | --- |
+| Retirement far away | `pass` (info) |
+| Inside the retiring-soon window | `warn` |
+| Already retired | `fail` |
+| Plan undeterminable | `skip` |
+
+## Why it matters
+
+Hosting plans retire on a published schedule; an app left on a retiring plan must eventually migrate or stop running.
+
+## Symptoms
+
+Apps on a retiring hosting plan keep running until the retirement date, then must migrate; migrations left too late force a rushed move.
+
+## Example finding
+
+```text
+The 'linux-consumption' hosting plan is supported; it retires on September 30, 2028.
+Consider Flex Consumption for new workloads.
+```
+
+The finding carries auditable evidence (Finding Contract v2): `expected`, `actual`, `source_url`, `last_verified`, and `catalog_version`.
+
+## How to fix
+
+Linux Consumption is retiring; consider Flex Consumption for new Python workloads. See the [plan choosing guide](../choose-a-plan.md) for the decision matrix.
+
+## Reference
+
+- [Azure Functions — Migrate Consumption to Flex Consumption](https://learn.microsoft.com/azure/azure-functions/migrate-plan-consumption-to-flex)

--- a/docs/rules/check_linux_fx_version.md
+++ b/docs/rules/check_linux_fx_version.md
@@ -1,0 +1,35 @@
+# Linux runtime (linuxFxVersion)
+
+> Rule ID: `check_linux_fx_version` · Category: configuration · Section: runtime
+> Severity: warning (non-gating) · Profiles: `deploy`, `full`
+
+## What it checks
+
+Any Python `linuxFxVersion` declared in **infra config** (bicep/ARM, including nested `infra/` directories), so Flex Consumption / Linux plan apps target a supported Python runtime. Infra files are scanned for `linuxFxVersion` declarations such as `linuxFxVersion: 'Python|3.12'`; no declaration skips.
+
+## Why it matters
+
+An unsupported Python runtime encoded in `linuxFxVersion` causes deployment or cold-start failures on Linux Consumption, Flex Consumption, Premium, and Dedicated plans.
+
+## Symptoms
+
+Deployment fails; app stuck in a restart loop; "runtime not supported" errors in the platform logs.
+
+## Example finding
+
+```text
+```text
+Unsupported Python linuxFxVersion runtime(s) in infra config:
+- main.bicep: Python|3.9
+
+Fix: target a supported Python runtime (3.10–3.14).
+```
+
+## How to fix
+
+Set `linuxFxVersion` to a supported Python runtime (e.g. `Python|3.12`) in your infrastructure templates.
+
+## Reference
+
+- [Azure Functions Python developer guide — Supported Python versions](https://learn.microsoft.com/azure/azure-functions/functions-reference-python#supported-python-versions)
+- On Flex Consumption, `linuxFxVersion` is ignored — see [`check_flex_runtime_config`](check_flex_runtime_config.md)

--- a/docs/rules/check_python_runtime_lifecycle.md
+++ b/docs/rules/check_python_runtime_lifecycle.md
@@ -1,0 +1,35 @@
+# Python runtime lifecycle
+
+> Rule ID: `check_python_runtime_lifecycle` · Category: environment · Section: python_env
+> Severity: warning inside the retiring window, error past end-of-support · Profiles: `deploy`, `full` · Tier: core
+
+## What it checks
+
+The target Python version against its **published Azure Functions end-of-support date**. The check warns when the target runtime is retiring and fails once it is past end-of-support.
+
+The target version is resolved the same way as [`check_python_version`](../rules.md#3-check_python_version): from `--target-python` when supplied, otherwise the interpreter running the doctor.
+
+## Why it matters
+
+Azure Functions retires Python runtimes on a published schedule. Deploying on a runtime at or past end-of-support risks losing security updates and, eventually, the ability to deploy at all.
+
+## Symptoms
+
+Deployments on a retiring runtime keep working until the end-of-support date, then fail or lose patching; upgrades left too late force a rushed migration.
+
+## Example finding
+
+```text
+Python 3.10.12 support is expected to end in October 2026; plan an upgrade
+to a newer Python (3.12+) before then.
+```
+
+The finding carries auditable evidence (Finding Contract v2): `expected`, `actual`, `source_url`, `last_verified`, and `catalog_version` from the version-controlled compatibility catalog.
+
+## How to fix
+
+Target a Python version with a long support runway (3.12+). Upgrade a retiring runtime before its Azure Functions end-of-support date.
+
+## Reference
+
+- [Azure Functions — Supported languages (Python runtime lifecycle)](https://learn.microsoft.com/azure/azure-functions/supported-languages)

--- a/docs/rules/check_unpinned_requirements.md
+++ b/docs/rules/check_unpinned_requirements.md
@@ -1,0 +1,35 @@
+# Pinned requirements
+
+> Rule ID: `check_unpinned_requirements` · Category: dependencies · Section: dependencies
+> Severity: warning (non-gating) · Profiles: `deploy`, `full`
+
+## What it checks
+
+`requirements.txt` for dependencies declared with **no version specifier** or an **unbounded lower bound** (`>=` without an upper bound).
+
+## Why it matters
+
+Azure remote build resolves `requirements.txt` at deploy time; unpinned dependencies let a new upstream release change or break a deployment without any code change.
+
+## Symptoms
+
+A deployment that previously worked suddenly fails or behaves differently; irreproducible builds across environments.
+
+## Example finding
+
+```text
+Unpinned or unbounded dependencies in requirements.txt:
+- azure-functions (no version specifier)
+- requests (>=2.0; no upper bound)
+
+Fix: pin versions (e.g. 'package==1.2.3') or add an upper bound to keep
+deployments reproducible.
+```
+
+## How to fix
+
+Pin dependency versions (e.g. `package==1.2.3`) or add an upper bound to keep deployments reproducible.
+
+## Reference
+
+- [Azure Functions Python developer guide — Package management](https://learn.microsoft.com/azure/azure-functions/functions-reference-python#package-management)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,18 @@ nav:
       - Deprecated Aliases: deprecated-aliases.md
       - Diagnostics: diagnostics.md
       - Rules: rules.md
+      - Deploy-Risk Rule Pages:
+          - Python runtime lifecycle: rules/check_python_runtime_lifecycle.md
+          - Functions runtime lifecycle: rules/check_functions_runtime_lifecycle.md
+          - Hosting plan lifecycle: rules/check_hosting_plan_lifecycle.md
+          - Flex runtime config: rules/check_flex_runtime_config.md
+          - Flex deprecated app settings: rules/check_flex_deprecated_settings.md
+          - Flex deployment storage: rules/check_flex_deployment_storage.md
+          - Binding connection resolution: rules/check_binding_connection_resolution.md
+          - Functions extension version: rules/check_functions_extension_version.md
+          - Linux runtime (linuxFxVersion): rules/check_linux_fx_version.md
+          - Dev-storage emulator connection: rules/check_dev_storage_connection.md
+          - Pinned requirements: rules/check_unpinned_requirements.md
       - Rule Inventory: rule_inventory.md
       - Minimal Profile: minimal_profile.md
       - JSON Output Contract: json_output_contract.md


### PR DESCRIPTION
## Context

Part of #326 (backlog item #15). Rules are defined centrally in `v2.json`; for search/support leverage, each deploy-risk rule gets its own documentation page so **the error message becomes a search landing**.

## Changes

- **11 new pages** under `docs/rules/<rule_id>.md` for the deploy-risk group:
  - `check_python_runtime_lifecycle`, `check_functions_runtime_lifecycle`, `check_hosting_plan_lifecycle`
  - `check_flex_runtime_config`, `check_flex_deprecated_settings`, `check_flex_deployment_storage`
  - `check_binding_connection_resolution`, `check_functions_extension_version`, `check_linux_fx_version`, `check_dev_storage_connection`, `check_unpinned_requirements`
- Each page: rule metadata (id/category/severity/profiles/tier), what it checks, why it matters, symptoms, **the exact finding text** (captured from the real handler outputs, not paraphrased), how to fix, and the MS Learn reference.
- Wired into `mkdocs.yml` nav (User Guide → Deploy-Risk Rule Pages), `docs/rules.md` (new "Deploy-risk rule reference" section), and `docs/index.md` documentation map.
- Experimental-tier and integration-group rules intentionally excluded per the issue (avoid doc toil on unstable rules). Rule IDs in this group are stable (all shipped in #289/#343/#344/#345/#346/#350/#351/#352).

## Verification

- `mkdocs build` — no new warnings (only the pre-existing `ci_integration.md` one)
- `scripts/check_docs_consistency.py` — pass (41 rules)
- Docs-only change; no code paths touched

Closes #326