### PR TITLE
ci(test): run each matrix cell on its real interpreter

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,10 +10,52 @@ permissions:
   contents: read
 
 jobs:
+  # Lint, type-check, docs-consistency and security run once on a single
+  # pinned interpreter (Python 3.10, matching the mypy/ruff target-version in
+  # pyproject). These checks are interpreter-agnostic, so fanning them across
+  # the test matrix would only duplicate work (#382).
+  quality:
+    name: Lint, type-check, docs & security (Py 3.10)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Install package with dev extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint workflows (pin hygiene + release-gate canonical SHAs)
+        run: |
+          python tools/lint_release_workflows.py
+          python tools/lint_workflow_pins.py
+
+      - name: Ruff style check
+        run: ruff check src tests
+
+      - name: Type check (mypy, strict)
+        run: mypy src tests
+
+      - name: Security scan (bandit)
+        run: python -m bandit -r src
+
+      - name: Check documentation consistency
+        run: |
+          python scripts/gen_rule_inventory.py --check
+          python scripts/check_docs_consistency.py
+
   test:
+    name: Test (Py ${{ matrix.python-version }})
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         # Python 3.14 is stable and required in this matrix (not allow-fail).
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -27,19 +69,34 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Hatch and dependencies via Makefile
+      - name: Assert the runtime interpreter matches the matrix cell
+        # Tests must run on the interpreter this cell claims to exercise.
+        # Before #382 the whole matrix ran through the Python-3.10-pinned
+        # hatch env, so 3.11-3.14 were never actually tested. This guard
+        # fails loudly if the running interpreter ever drifts from
+        # matrix.python-version again.
+        env:
+          EXPECTED: ${{ matrix.python-version }}
         run: |
-          pip install hatch
-          make install
+          python - <<'PY'
+          import os, sys
+          expected = tuple(int(p) for p in os.environ["EXPECTED"].split("."))
+          actual = sys.version_info[: len(expected)]
+          assert actual == expected, f"interpreter {actual} != matrix {expected}"
+          print(f"interpreter OK: {sys.version.split()[0]}")
+          PY
 
-      - name: Run full quality checks
-        run: make check-all
-
-      - name: Check documentation consistency
-        if: matrix.python-version == '3.10'
+      - name: Install package with dev extras (on the matrix interpreter)
         run: |
-          python scripts/gen_rule_inventory.py --check
-          python scripts/check_docs_consistency.py
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests on the matrix interpreter
+        # Raw pytest on the interpreter provisioned above (NOT through the
+        # Python-3.10-pinned hatch env). The repo pytest config enables
+        # --cov with fail_under=95; coverage.xml is produced on every cell
+        # but only uploaded once (from the 3.10 cell) to avoid duplicates.
+        run: pytest
 
       - name: Verify coverage output
         run: ls -lh coverage.xml


### PR DESCRIPTION
## Context

Closes #382. `[tool.hatch.envs.default]` pins `python = "3.10"`, and the CI matrix ran everything through `make check-all` (Hatch), so **every matrix cell actually executed on Python 3.10** — the per-version status claims were false. Mirrors the fleet-wide fix from yeongseon/azure-functions-openapi-python#554 / PR #555.

## Changes

`ci-test.yml` split into two jobs:

1. **`quality`** (single Py 3.10): workflow-pin lint (`tools/lint_*.py`), ruff, mypy, bandit, and the docs-consistency scripts (moved here from the 3.10 matrix cell so they run exactly once).
2. **`test`** (matrix 3.10–3.14): `setup-python` → **interpreter guard** (`assert sys.version_info[:2] == matrix.python-version`) → `pip install -e ".[dev]"` → raw `pytest` on the provisioned interpreter (never through the 3.10-pinned hatch env).

No separate wheel lane is needed here (unlike openapi-python): doctor's runtime deps (`jsonschema`, `packaging`, `rich`, `typer`) are pure-Python wheels that install and test on all five versions; `azure.functions` is only an optional test import guarded by skipif.

Coverage stays enforced per cell (`fail_under=95` in pytest addopts); the Codecov upload remains single (3.10 cell).

## Verification

- YAML parsed; `tools/lint_release_workflows.py` + `tools/lint_workflow_pins.py` pass locally with the reused canonical SHAs.
- The interpreter guard pattern is the same one validated in openapi-python PR #555.
- Post-merge, this PR's own checks are the first genuine per-version runs (esp. 3.13/3.14).

Closes #382