### PR TITLE
chore(action): default profile to deploy and SHA-pin upload-sarif

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   profile:
     description: "Rule profile: 'minimal' (required checks only), 'deploy' (runtime/hosting/deployment correctness), 'development' (dev-environment checks), or 'full' (all checks)"
     required: false
-    default: "minimal"
+    default: "deploy"
   format:
     description: "Output format: 'json', 'sarif', 'junit', or 'table'"
     required: false
@@ -151,7 +151,7 @@ runs:
 
     - name: Upload SARIF to GitHub Code Scanning
       if: inputs.upload-sarif == 'true' && inputs.format == 'sarif' && always()
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@cdf488f595d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         sarif_file: ${{ inputs.output }}
         category: ${{ inputs.sarif-category }}


### PR DESCRIPTION
## Context

Two Action-level gaps from the latest review:

1. **Default profile `minimal` undersells the product.** `minimal` runs only the six required rules — none of the runtime/hosting/deployment lifecycle, Flex Consumption, binding-connection, `linuxFxVersion`, dev-storage, or unpinned-requirements diagnostics live there. The product is a *pre-deploy health gate*, so the natural default is **`deploy`** (runtime/hosting/deployment correctness).
2. **`github/codeql-action/upload-sarif@v4` was the only major-tag reference** left in the Action, inconsistent with the repo's SHA-pinning hygiene — worth fixing before the Marketplace listing (#325).

## Changes

- `action.yml`: `profile` default `minimal` → `deploy` (description already documents all four profiles since #378).
- `action.yml`: `upload-sarif` pinned to `cdf488f595d6e07e03d4674febd5ab45fa938` (`v4.37.9` — same release already pinned in `codeql.yml`).

## Compatibility note

⚠️ Behavioral change for Action users who relied on the implicit default: they now get the `deploy` ruleset (a superset of `minimal`'s required rules plus the non-gating deploy diagnostics; exit-code semantics unchanged — only required failures gate). The smoke workflows pass `profile` explicitly (`minimal` / `full`), so CI is unaffected. Recommend calling this out in the next release notes.

CLI default remains unchanged (no `--profile` → all rules), per the review's caution.