### PR TITLE
fix(runtime): derive the Python upgrade recommendation from the catalog

### DIFF
--- a/src/azure_functions_doctor/assets/rules/v2.json
+++ b/src/azure_functions_doctor/assets/rules/v2.json
@@ -63,7 +63,7 @@
     "condition": {
       "target": "python"
     },
-    "hint": "Target a Python version with a long support runway (3.12+). Upgrade a retiring runtime before its Azure Functions end-of-support date.",
+    "hint": "Target a Python version with a long support runway. Upgrade a retiring runtime before its Azure Functions end-of-support date.",
     "hint_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
     "source_type": "ms_learn",
     "source_title": "Azure Functions \u2014 Supported languages (Python runtime lifecycle)",

--- a/src/azure_functions_doctor/handlers/registry.py
+++ b/src/azure_functions_doctor/handlers/registry.py
@@ -109,17 +109,25 @@ def _evaluate_python_lifecycle(
     end = eos.end_date()
     last_verified = fact.last_verified or cat.last_verified
 
+    # Recommendation is derived from the catalog (single source of truth for
+    # Azure version knowledge), never hardcoded in this handler: point at the
+    # newest still-supported Python so the advice stays correct as the
+    # catalog rolls forward.
+    supported = cat.supported_python_versions(as_of=today)
+    recommended = supported[-1] if supported else None
+    target_hint = f" (e.g. {recommended})" if recommended else ""
+
     if end is not None and today > end:
         status, severity, gate = "fail", "error", True
         detail = (
             f"Python {version} is past Azure Functions end-of-support "
-            f"(ended {rendered}); upgrade to a supported Python (3.12+)."
+            f"(ended {rendered}); upgrade to a newer supported Python{target_hint}."
         )
     elif end is not None and (end - today).days <= PYTHON_RETIRING_SOON_WINDOW_DAYS:
         status, severity, gate = "fail", "warning", False
         detail = (
             f"Python {version} support is expected to end in {rendered}; "
-            f"plan an upgrade to a newer Python (3.12+) before then."
+            f"plan an upgrade to a newer supported Python{target_hint} before then."
         )
     else:
         status, severity, gate = "pass", "info", False
@@ -132,7 +140,7 @@ def _evaluate_python_lifecycle(
     result["severity"] = severity
     result["gate"] = gate
     result["evidence"] = detail
-    result["expected"] = "A supported Azure Functions Python runtime (3.12+)"
+    result["expected"] = "A supported Azure Functions Python runtime"
     result["actual"] = f"Python {version} (support ends {rendered})"
     if fact.source_url:
         result["source_url"] = fact.source_url

--- a/tests/test_python_runtime_lifecycle.py
+++ b/tests/test_python_runtime_lifecycle.py
@@ -56,6 +56,21 @@ class TestEvaluatePythonLifecycle:
         assert "past Azure Functions end-of-support" in result["detail"]
         assert "October 2026" in result["detail"]
 
+    def test_upgrade_recommendation_is_catalog_derived(self) -> None:
+        """The recommendation names the catalog's newest supported Python (#382 review)."""
+        catalog = load_catalog()
+        newest = catalog.supported_python_versions(as_of=BEFORE_ANY_EOS)[-1]
+
+        retiring = _evaluate_python_lifecycle("3.10", today=BEFORE_ANY_EOS)
+        assert f"(e.g. {newest})" in retiring["detail"]
+        # No Azure version knowledge is hardcoded in the handler strings.
+        assert "3.12+" not in retiring["detail"]
+        assert retiring["expected"] == "A supported Azure Functions Python runtime"
+
+        unsupported = _evaluate_python_lifecycle("3.10", today=AFTER_310_EOS)
+        assert f"(e.g. {newest})" in unsupported["detail"]
+        assert "3.12+" not in unsupported["detail"]
+
     def test_unknown_version_is_neutral(self) -> None:
         result = _evaluate_python_lifecycle("3.15", today=BEFORE_ANY_EOS)
         assert result["status"] == "pass"


### PR DESCRIPTION
## Context

Review follow-up (P1): the Python lifecycle handler leaked catalog-adjacent knowledge by hardcoding `3.12+` into three strings (`registry.py`) and the rule hint (`v2.json`). Correct today; wrong in 2028, when it would tell Python 3.12 users to "upgrade to 3.12+". The design rule: Azure version knowledge flows only through `catalog.json → compatibility.py → handlers`.

## Changes

- `_evaluate_python_lifecycle` now computes the recommendation from `catalog.supported_python_versions(as_of=today)` and names the newest still-supported Python in the message: `upgrade to a newer supported Python (e.g. 3.14).`
- `expected` field: `A supported Azure Functions Python runtime (3.12+)` → `A supported Azure Functions Python runtime` (version detail lives in the message, driven by the catalog).
- `v2.json` hint drops the hardcoded `(3.12+)`.
- New regression test `test_upgrade_recommendation_is_catalog_derived` asserts the message contains the catalog-derived `(e.g. <newest>)` and never `3.12+`.

## Verification

- Full suite pass, coverage **97%** (≥95%)
- style / typecheck / inventory --check / docs-consistency all pass

Part of #341 follow-ups