### PR TITLE
docs: align JSON contract, architecture, and LLM docs with the shipped code

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -55,7 +55,7 @@ flowchart TD
     CLI["cli.py<br/>Typer CLI"]
     DOC["doctor.py<br/>Diagnostic runner"]
     RULES[("assets/<br/>Rule inventory")]
-    HDLR["handlers.py<br/>Type-based dispatch"]
+    HDLR["handlers/registry.py<br/>Type-based dispatch"]
     TR["target_resolver.py<br/>Version resolution"]
     RES["Structured results<br/>SectionResult + CheckResult"]
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ type-based handler, and aggregates the results into per-section output:
 flowchart LR
     CLI["cli.py<br/>Typer CLI"] --> DOC["doctor.py<br/>Diagnostic runner"]
     DOC --> RULES[("assets/<br/>Rule inventory")]
-    DOC --> HDLR["handlers.py<br/>Type-based dispatch"]
+    DOC --> HDLR["handlers/registry.py<br/>Type-based dispatch"]
     HDLR --> TR["target_resolver.py<br/>Version resolution"]
     DOC --> RES["SectionResult<br/>+ CheckResult"]
     RES --> OUT["table / json<br/>sarif / junit"]
@@ -333,7 +333,7 @@ When working with this codebase, LLM assistants should:
 2. **Refer to `llms-full.txt` for implementation details** — output contracts, rule structure, custom rule patterns, handler types
 3. **Check `src/azure_functions_doctor/cli.py`** — authoritative source for CLI options and validation
 4. **Review `src/azure_functions_doctor/assets/rules/v2.json`** — complete ruleset with check definitions
-5. **Consult `src/azure_functions_doctor/handlers.py`** — diagnostic rule handlers and pattern matchers
+5. **Consult `src/azure_functions_doctor/handlers/registry.py`** — diagnostic rule handlers and pattern matchers (`handlers/_helpers.py` for shared primitives)
 
 For bug reports, feature requests, or documentation improvements, please open an issue or pull request on GitHub.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `path` | `str` | Yes | File system path to the Azure Functions app root. |
-| `profile` | `str | None` | No | `"full"` (default behavior) or `"minimal"` (required checks only). |
+| `profile` | `str \| None` | No | Rule profile: `"minimal"` (required checks only), `"deploy"` (runtime/hosting/deployment correctness), `"development"` (dev-environment checks), or `"full"` (default behavior: all rules). |
 | `rules_path` | `pathlib.Path | None` | No | Optional path to a custom rules file matching the rules schema. |
 | `target_python` | `str | None` | No | Override target Python runtime version (e.g. `"3.12"`). Defaults to `None` (use tool runtime). |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,9 +118,9 @@ CI pipelines can rely on these codes directly. See [JSON Output Contract](json_o
 
 Profiles allow subsets of rules:
 
-- Profile is a string selector (`minimal` or `full`), not a file-based system. `minimal` keeps only rules where `required=True` in the rule asset; `full` (the default) runs all rules.
-- `--profile minimal` restricts the scan to required rules only.
-- Custom profile names raise `ValueError`; only `minimal` and `full` are accepted.
+- Profile is a string selector, not a file-based system. Four profiles are accepted: `minimal` (only rules with `required=True`), `deploy` (core-group rules minus dev-environment checks — runtime/hosting/deployment correctness), `development` (dev-environment checks: venv, Python executable, Core Tools, local.settings), and `full` (default when omitted: all rules).
+- Membership is computed in `azure_functions_doctor.profiles` from rule metadata (single source of truth shared with the generated rule inventory).
+- Custom profile names raise `ValueError`; only the four names above are accepted.
 
 See [Configuration](configuration.md) and [Minimal Profile](minimal_profile.md).
 
@@ -140,7 +140,7 @@ The `handlers/` package (`registry.py`) maintains a `HandlerRegistry` that maps 
 
 ### 4. String-based profile selection
 
-Profiles are not file-based. The `--profile` flag accepts `minimal` or `full` (default). `minimal` filters rules to those where `required=True` in the rule asset (`Doctor.run_all_checks()`). This avoids external profile file management while covering the common use case of gating CI on required rules only.
+Profiles are not file-based. The `--profile` flag accepts `minimal`, `deploy`, `development`, or `full` (default when the flag is omitted: all rules). Membership is computed from rule metadata in `azure_functions_doctor.profiles` (`Doctor.run_all_checks()` filters with it). This avoids external profile file management while covering the common cases: gating CI on required rules (`minimal`) or on deployment correctness (`deploy`).
 
 ### 5. Typer CLI framework
 

--- a/docs/json_output_contract.md
+++ b/docs/json_output_contract.md
@@ -16,13 +16,15 @@ If `--output` is omitted, JSON is printed to stdout.
 
 ```json
 {
+  "schema_version": "2.0",
   "metadata": {
-    "tool_version": "0.19.1",
-    "generated_at": "2026-03-14T10:40:20.731Z",
+    "tool_version": "0.19.2",
+    "generated_at": "2026-09-06T10:40:20.731Z",
     "target_path": "/absolute/path/to/project",
     "programming_model": "v2",
     "target_python": null,
-    "deployment_mode": "remote-build"
+    "deployment_mode": "remote-build",
+    "hosting_plan": null
   },
   "results": [
     {
@@ -31,14 +33,21 @@ If `--output` is omitted, JSON is printed to stdout.
       "status": "fail",
       "items": [
         {
-          "rule_id": "check_python_version",
-          "label": "Python version",
-          "value": "Python 3.9.18 (tool runtime, >=3.10) — unsupported target; Azure Functions supports Python 3.10–3.14",
-          "status": "fail",
-          "severity": "error",
+          "rule_id": "check_python_runtime_lifecycle",
+          "label": "Python runtime lifecycle",
+          "value": "Python 3.10.12 support is expected to end in October 2026; plan an upgrade to a newer supported Python (e.g. 3.14) before then.",
+          "status": "warn",
+          "severity": "warning",
           "tier": "core",
-          "hint": "Target a Python version supported by Azure Functions: 3.10, 3.11, 3.12, 3.13, or 3.14.",
-          "hint_url": "https://learn.microsoft.com/..."
+          "evidence": "Python 3.10.12 support is expected to end in October 2026; plan an upgrade to a newer supported Python (e.g. 3.14) before then.",
+          "expected": "A supported Azure Functions Python runtime",
+          "actual": "Python 3.10.12 (support ends October 2026)",
+          "source_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages",
+          "last_verified": "2026-09-06",
+          "catalog_version": "1.0.0",
+          "analysis": { "type": "deterministic" },
+          "hint": "Target a Python version with a long support runway. Upgrade a retiring runtime before its Azure Functions end-of-support date.",
+          "hint_url": "https://learn.microsoft.com/azure/azure-functions/supported-languages"
         }
       ]
     }
@@ -47,6 +56,12 @@ If `--output` is omitted, JSON is printed to stdout.
 ```
 
 ## Field reference
+
+### Top level
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `schema_version` | string | Machine-output schema version (Finding Contract). Current: `"2.0"`. Independent of the SARIF schema version (`"2.1.0"`). |
 
 ### `metadata`
 
@@ -58,6 +73,7 @@ If `--output` is omitted, JSON is printed to stdout.
 | `programming_model` | string | Detected Azure Functions programming model (`v2`, `mixed`, `unsupported_v1`, or `unknown`). |
 | `target_python` | string \| null | Target Python version requested via `--target-python`, or `null` when not set. |
 | `deployment_mode` | string | Deployment mode used for dependency checks: `remote-build` (default) or `local`. |
+| `hosting_plan` | string \| null | Resolved hosting plan (e.g. `flex-consumption`) when determinable from deploy config, else `null`. |
 
 ### `results[]`
 
@@ -75,9 +91,16 @@ If `--output` is omitted, JSON is printed to stdout.
 | `rule_id` | string | Stable machine-oriented rule identifier (matches the rule `id` in the ruleset). Used directly as the SARIF `ruleId`. |
 | `label` | string | Check display label. |
 | `value` | string | Diagnostic detail text from handler execution. |
-| `status` | `pass` \| `warn` \| `fail` | Canonical item-level status. |
+| `status` | `pass` \| `warn` \| `fail` \| `skip` | Canonical item-level status. `skip` means the rule legitimately did not apply (e.g. not a Flex Consumption app); it is not an error. |
 | `severity` | `error` \| `warning` \| `info` | Runtime severity of the rule. A failing `error` rule maps to `fail`; otherwise it maps to `warn`. |
 | `tier` | `core` \| `extended` \| `experimental` | Rule maturity/tier classification. |
+| `evidence` | string (optional) | Auditable human-readable statement backing the finding (Finding Contract v2). |
+| `expected` | string (optional) | What the configuration should be, per the compatibility catalog or platform contract. |
+| `actual` | string (optional) | What was actually observed. |
+| `source_url` | string (optional) | Upstream source (e.g. Microsoft Learn) the verdict is pinned to. |
+| `last_verified` | string (optional) | ISO date when the catalog fact was last verified against the source. |
+| `catalog_version` | string (optional) | Version of the compatibility catalog the fact came from. |
+| `analysis` | object (optional) | Analysis provenance block; `type` is `deterministic` for every built-in rule. |
 | `hint` | string (optional) | Human-readable remediation guidance. |
 | `hint_url` | string (optional) | Supporting documentation link. |
 
@@ -88,6 +111,9 @@ Use the following contract expectations when writing parsers.
 | Field | Stability | Guidance |
 | --- | --- | --- |
 | `metadata.tool_version` | Stable | Safe for telemetry and compatibility checks. |
+| `schema_version` | Stable | Machine-output schema version; bump only on contract-breaking change. |
+| `results[].items[].evidence` / `expected` / `actual` | Stable | Finding Contract v2 auditable fields; absent on findings without catalog backing. |
+| `results[].items[].source_url` / `last_verified` / `catalog_version` | Stable | Freshness/source pinning for catalog-backed findings. |
 | `metadata.generated_at` | Stable | Safe for run timestamp tracking. |
 | `metadata.target_path` | Stable | Safe for target correlation. |
 | `metadata.programming_model` | Stable | Safe for detecting v1/v2/mixed project state. |
@@ -114,6 +140,7 @@ Item status rules:
 - `pass`: check succeeded
 - `fail`: required rule failed
 - `warn`: optional rule failed
+- `skip`: rule legitimately did not apply (e.g. not a Flex Consumption app, or a suppressed rule); not an error and never gates
 
 Section status rules:
 
@@ -139,13 +166,13 @@ from pathlib import Path
 def parse_doctor(path: str) -> dict:
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
 
-    summary = {"pass": 0, "warn": 0, "fail": 0}
+    summary: dict[str, int] = {}
     failures: list[dict[str, str]] = []
 
     for section in payload["results"]:
         for item in section["items"]:
             status = item["status"]
-            summary[status] += 1
+            summary[status] = summary.get(status, 0) + 1
             if status == "fail":
                 failures.append(
                     {
@@ -201,7 +228,8 @@ jq -r '.results[] as $s | $s.items[] | "[\($s.category)] \(.status) - \(.label):
 ## Common parser mistakes
 
 - Assuming warnings fail builds
-- Treating missing optional fields (`hint`, `hint_url`) as schema errors
+- Assuming `pass`/`warn`/`fail` are the only statuses — `skip` is a first-class status and must not crash counters
+- Treating missing optional fields (`hint`, `hint_url`, and the evidence fields) as schema errors
 - Parsing output from non-JSON format
 - Ignoring process exit code and relying only on string matching
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -67,10 +67,12 @@ azure-functions-doctor doctor [OPTIONS]
 #### Rule Configuration
 
 - `--profile TEXT` (optional)
-  - Rule profile: `minimal` or `full`
+  - Rule profile: `minimal`, `deploy`, `development`, or `full`
   - **minimal**: Load only required rules (required=true). Faster, focused on blockers.
+  - **deploy**: Runtime/hosting/deployment correctness — core-group rules minus dev-environment checks.
+  - **development**: Dev-environment checks (venv, Python executable, Core Tools, local.settings).
   - **full** (default): Load all rules including recommended best practices
-  - Example: `--profile minimal` for required checks only
+  - Example: `--profile deploy` for a pre-deploy gate, `--profile minimal` for required checks only
 
 - `--rules PATH` (optional)
   - Path to custom rules JSON file (overrides built-in rules)

--- a/llms.txt
+++ b/llms.txt
@@ -33,7 +33,7 @@ Main entry points (all aliases):
 - `--path <PATH>` — Path to the Azure Functions app (default: current directory)
 - `--format <FORMAT>` — Output format: table (default), json, sarif, junit
 - `--output <PATH>` — Save output to file
-- `--profile <PROFILE>` — Rule profile: minimal (required only) or full (default)
+- `--profile <PROFILE>` — Rule profile: minimal (required only), deploy (runtime/hosting/deployment correctness), development (dev-environment checks), or full (all rules; default when omitted)
 - `--rules <PATH>` — Custom rules file (JSON)
 - `--summary-json <PATH>` — Write JSON summary (passed/warned/failed counts)
 - `--verbose` — Show detailed hints for failed checks
@@ -80,8 +80,10 @@ azure-functions-doctor --format junit --output test-results.xml
 - **Triggers** — Proper HTTP/Timer/Storage trigger usage and configuration
 - **Core Tools** — Local Azure Functions Core Tools availability
 
-Rules support two profiles:
+Rules support four profiles:
 - **minimal** — Required checks only
+- **deploy** — Runtime/hosting/deployment correctness (core group, minus dev-environment checks)
+- **development** — Dev-environment checks (venv, Python executable, Core Tools, local.settings)
 - **full** — All checks including recommended best practices
 
 ## Documentation


### PR DESCRIPTION
## Context

Review follow-up (P1): documentation lagged the code in three places that matter for parser authors, agents, and LLM discoverability.

## Changes

### 1. `docs/json_output_contract.md` — Finding Contract v2 alignment
- Top-level example now matches real CLI output: `schema_version: "2.0"` first key, `metadata.hosting_plan`, and an evidence-bearing item (`evidence`/`expected`/`actual`/`source_url`/`last_verified`/`catalog_version`, `analysis.type: deterministic`).
- Field reference gained rows for `schema_version`, `hosting_plan`, the evidence block, and `analysis`.
- `status` now documents **`skip`** as a first-class status everywhere (field reference, status semantics, parser mistakes).
- Python parser example no longer raises `KeyError` on `skip` items.
- Stability table: schema_version and the evidence fields are Stable.

### 2. `handlers.py` drift
- README mermaid diagram, README "For AI Coding Assistants" step 5, and the DESIGN.md diagram now point at `handlers/registry.py` (+ `_helpers.py`) instead of the historical single file.

### 3. Four-profile docs
- `docs/api.md`, `docs/architecture.md` (×2 sections), `llms.txt`, `llms-full.txt` described only `minimal`/`full`; now document `minimal`/`deploy`/`development`/`full` and that membership is computed in `azure_functions_doctor.profiles`.

## Verification

- `check_docs_consistency.py` / `gen_rule_inventory.py --check` pass (0.19.2, 41 rules)
- `mkdocs build` — no new warnings (only the pre-existing `ci_integration.md` one)

Part of #341 follow-ups