### PR TITLE
fix(action): restore the full upload-sarif commit SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -151,7 +151,7 @@ runs:
 
     - name: Upload SARIF to GitHub Code Scanning
       if: inputs.upload-sarif == 'true' && inputs.format == 'sarif' && always()
-      uses: github/codeql-action/upload-sarif@cdf488f595d6e07e03d4674febd5ab45fa938 # v4.37.9
+      uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         sarif_file: ${{ inputs.output }}
         category: ${{ inputs.sarif-category }}


### PR DESCRIPTION
Hotfix for a regression from #384: the upload-sarif pin dropped three hex characters, making `github/codeql-action` unresolvable and failing both action-integration smoke jobs on main (`Unable to resolve action ... unable to find version cdf488f595d6e0...`). Restores the exact 40-char v4.37.9 SHA used in `codeql.yml`.