### PR TITLE
ci(release): fast-forward the moving v1 action branch on each release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,10 @@ endif
 	@git push origin HEAD
 	@git tag -a v$(VERSION) -m "Release v$(VERSION)"
 	@git push origin v$(VERSION)
-	@echo "Tagged release v$(VERSION)"
+	# Keep the moving v1 major branch (used by the GitHub Action pin
+	# yeongseon/azure-functions-doctor@v1) fast-forwarded to this release.
+	@git push origin HEAD:refs/heads/v1
+	@echo "Tagged release v$(VERSION) and fast-forwarded the v1 action branch"
 
 .PHONY: release
 release: ensure-hatch


### PR DESCRIPTION
## Context

Marketplace prep for #325: README/docs advertise `yeongseon/azure-functions-doctor@v1`, but no `v1` ref existed (users copying the README would hit `unable to resolve action`). The `v1` branch now exists at the current release HEAD; this PR keeps it current automatically.

## Changes

- `make tag-release` (used by every `release-*` target) additionally pushes `HEAD:refs/heads/v1`, fast-forwarding the moving major pin for the Action with each release.

References #325