### PR TITLE
fix(sarif): emit repo-root-relative artifactLocation URIs in every branch

### DIFF
--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -337,6 +338,19 @@ def doctor(
             driver_rules.append(driver_rule)
 
         sarif_results = []
+        # SARIF artifactLocation URIs paired with %SRCROOT% must be relative
+        # references (SARIF 2.1.0 §3.4.4), so the scan root is normalized once
+        # (#392): a relative --path (e.g. "services/api" in a monorepo) becomes
+        # the repo-root prefix for every URI; an absolute --path cannot be
+        # related to the runner's checkout root, so URIs stay scan-root-relative
+        # and never leak filesystem paths into the report.
+        scan_root_norm = path.replace("\\", "/").rstrip("/")
+        scan_root_is_absolute = scan_root_norm.startswith("/") or (
+            len(scan_root_norm) > 1 and scan_root_norm[1] == ":"
+        )
+        scan_prefix = ""
+        if not scan_root_is_absolute and scan_root_norm not in ("", "."):
+            scan_prefix = scan_root_norm + "/"
         for section in results:
             for item in section["items"]:
                 status = item.get("status")
@@ -346,10 +360,23 @@ def doctor(
                 rule_id = item.get("rule_id") or item.get("label", "")
                 level = "error" if status == "fail" else "warning"
                 loc_file = item.get("file")
+                artifact_uri = ""
+                loc_line: object = None
                 if loc_file:
                     artifact_uri = str(loc_file).replace("\\", "/")
+                    if Path(str(loc_file)).is_absolute():
+                        # Defensive: handlers emit scan-root-relative paths; if an
+                        # absolute path ever reaches here, rebase it onto the
+                        # scan root so no filesystem path leaks (#392).
+                        try:
+                            artifact_uri = str(Path(str(loc_file)).relative_to(Path(path))).replace(
+                                "\\", "/"
+                            )
+                        except ValueError:
+                            artifact_uri = Path(str(loc_file)).name
                     if artifact_uri.startswith("./"):
                         artifact_uri = artifact_uri[2:]
+                    artifact_uri = scan_prefix + artifact_uri
                     physical_location: dict[str, object] = {
                         "artifactLocation": {
                             "uri": artifact_uri,
@@ -367,17 +394,29 @@ def doctor(
                             region["startColumn"] = loc_column
                         physical_location["region"] = region
                 else:
+                    # Rules without a file location point at the scan root in
+                    # its repo-root-relative form; absolute roots collapse to
+                    # "." so the URI stays a valid relative reference (#392).
                     physical_location = {
                         "artifactLocation": {
-                            "uri": path.replace("\\", "/").rstrip("/") + "/",
+                            "uri": scan_prefix if scan_prefix else ".",
                             "uriBaseId": "%SRCROOT%",
                         }
                     }
+                # Stable fingerprint so Code Scanning can match alerts across
+                # runs even when lines shift; without one, most findings share
+                # the same root location and alerts regenerate/duplicate (#392).
+                fingerprint_seed = f"{rule_id}:{artifact_uri}:{loc_line or 0}"
                 sarif_result: dict[str, object] = {
                     "ruleId": rule_id,
                     "message": {"text": item.get("value", "")},
                     "level": level,
                     "locations": [{"physicalLocation": physical_location}],
+                    "partialFingerprints": {
+                        "primaryLocationLineHash": hashlib.sha256(
+                            fingerprint_seed.encode("utf-8")
+                        ).hexdigest()
+                    },
                 }
                 props: dict[str, object] = {}
                 if item.get("hint"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,7 @@ def test_cli_sarif_output() -> None:
     expected_exit = 1 if has_error else 0
     assert result.exit_code == expected_exit
 
+
 def test_cli_sarif_ruleid_propagates_from_rule_id() -> None:
     """SARIF ``ruleId`` comes from the result's ``rule_id``, matching driver rule ids."""
     result = runner.invoke(
@@ -115,6 +116,7 @@ def test_cli_sarif_ruleid_propagates_from_rule_id() -> None:
         rule_id = finding["ruleId"]
         assert rule_id, "every SARIF finding must carry a ruleId"
         assert rule_id in driver_ids, f"ruleId {rule_id!r} must match a driver rule id"
+
 
 def test_cli_junit_output() -> None:
     """Test CLI outputs JUnit format."""
@@ -240,6 +242,7 @@ def test_cli_deployment_mode_local_end_to_end() -> None:
     )
     data = json.loads(result.output)
     assert data["metadata"]["deployment_mode"] == "local"
+
 
 def test_cli_json_output_includes_target_python_override() -> None:
     """Test JSON metadata includes target_python override."""
@@ -385,7 +388,11 @@ def _write_sarif_location_fixture(root: Path) -> int:
 
 def test_cli_sarif_output_emits_per_file_and_per_line_locations(tmp_path: Path) -> None:
     """SARIF results carry per-file locations for a file-based rule and per-line
-    locations (with region) for an AST-based rule."""
+    "locations (with region) for an AST-based rule.
+
+    Absolute scan roots must never leak into the document: URIs pair with
+    %SRCROOT%, so they stay scan-root-relative (issue #392).
+    """
     handler_line = _write_sarif_location_fixture(tmp_path)
 
     result = runner.invoke(app, ["doctor", "--path", str(tmp_path), "--format", "sarif"])
@@ -395,10 +402,18 @@ def test_cli_sarif_output_emits_per_file_and_per_line_locations(tmp_path: Path) 
     def _uri(res: Any) -> str:
         return str(res["locations"][0]["physicalLocation"]["artifactLocation"]["uri"])
 
+    # No absolute filesystem path leaks into any URI.
+    assert all(str(tmp_path) not in _uri(r) for r in sarif_results)
+    assert all(not _uri(r).startswith("/") for r in sarif_results)
+
     # File-based rule: missing host.json is reported against the offending file.
     host_json_results = [r for r in sarif_results if _uri(r) == "host.json"]
     assert host_json_results, "expected a SARIF result located at host.json"
     assert "region" not in host_json_results[0]["locations"][0]["physicalLocation"]
+
+    # Rules without a file location collapse to the scan-root-relative root.
+    fallback_results = [r for r in sarif_results if _uri(r) == "."]
+    assert fallback_results, "expected fallback results located at '.'"
 
     # AST-based rule: the flagged route carries a per-line region.
     ast_results = [r for r in sarif_results if _uri(r) == "function_app.py"]
@@ -411,6 +426,41 @@ def test_cli_sarif_output_emits_per_file_and_per_line_locations(tmp_path: Path) 
     assert region["startLine"] == handler_line
     assert region["endLine"] >= region["startLine"]
     assert region["startColumn"] >= 1
+
+    # Every finding carries a stable fingerprint for Code Scanning matching.
+    for res in sarif_results:
+        fp = res.get("partialFingerprints", {}).get("primaryLocationLineHash")
+        assert isinstance(fp, str) and fp
+
+
+def test_cli_sarif_rebases_relative_scan_root_in_both_branches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A relative --path prefixes BOTH branches' URIs (issue #392).
+
+    Monorepo scenario: scanning ``services/api`` must emit
+    ``services/api/host.json`` from the file branch AND ``services/api/`` from
+    the fallback branch - never a bare ``host.json``.
+    """
+    services = tmp_path / "services" / "api"
+    services.mkdir(parents=True)
+    _write_sarif_location_fixture(services)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["doctor", "--path", "services/api", "--format", "sarif"])
+    # The fixture intentionally fails required checks (exit 1 is expected).
+    sarif_results = json.loads(result.output)["runs"][0]["results"]
+
+    uris = {
+        str(r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]) for r in sarif_results
+    }
+    # File branch keeps the repo-root prefix.
+    assert "services/api/host.json" in uris
+    assert "services/api/function_app.py" in uris
+    # Fallback branch points at the prefixed scan root, not a bare name.
+    assert "services/api/" in uris
+    assert "host.json" not in uris
+    assert "function_app.py" not in uris
 
 
 def test_create_result_populates_optional_location_fields() -> None:


### PR DESCRIPTION
## Context

Closes #392 (P0 from the external review of 0.19.2). Verified by reproduction before the fix:

- `--path /tmp/p4` → `uri: '/tmp/p4/'` with `%SRCROOT%` (absolute leak)
- `--path services/api` → fallback branch `services/api/` but file branch bare `host.json` (rebase split)
- test only asserted the file branch with an absolute scan root

## Changes

`cli.py` SARIF emission:
- Scan root normalized once: a relative `--path` becomes the repo-root prefix for **every** URI; an absolute `--path` cannot be related to the runner's checkout root, so URIs stay scan-root-relative and the fallback collapses to `.` — no filesystem path ever leaks.
- File branch (`item.file`): URI = prefix + handler-relative path, with a defensive `relative_to` rebasing for stray absolute paths.
- Fallback branch: URI = prefixed scan root (`services/api/`) or `.`.
- **`partialFingerprints.primaryLocationLineHash`** added to every result (sha256 of rule:uri:line) so Code Scanning alerts stop regenerating/duplicating when most findings share the root location.

Tests:
- Existing per-file/per-line test extended: no-absolute-leak assertions for every URI, fallback `.` assertion, fingerprint presence on every result.
- New monorepo test (`--path services/api` via `monkeypatch.chdir`): asserts **both** branches carry the prefix (`services/api/host.json`, `services/api/function_app.py`, `services/api/`) and bare names never appear.

## Verification

- Both original reproductions now emit correct URIs (verified locally before/after).
- Full suite pass, coverage **96.87%** (≥95%), style/typecheck clean.

Closes #392