### PR TITLE
feat(sarif): emit per-finding results and wire line locations

### DIFF
--- a/docs/json_output_contract.md
+++ b/docs/json_output_contract.md
@@ -101,6 +101,7 @@ If `--output` is omitted, JSON is printed to stdout.
 | `last_verified` | string (optional) | ISO date when the catalog fact was last verified against the source. |
 | `catalog_version` | string (optional) | Version of the compatibility catalog the fact came from. |
 | `analysis` | object (optional) | Analysis provenance block; `type` is `deterministic` for every built-in rule. |
+| `locations` | array (optional) | Per-finding locations (`file`/`line`/`end_line`/`column`/`message`). SARIF emits one result per entry instead of collapsing onto the first location; the scalar `file`/`line` fields remain the single-location form. |
 | `hint` | string (optional) | Human-readable remediation guidance. |
 | `hint_url` | string (optional) | Supporting documentation link. |
 

--- a/src/azure_functions_doctor/cli.py
+++ b/src/azure_functions_doctor/cli.py
@@ -371,6 +371,62 @@ def doctor(
         scan_prefix = ""
         if not scan_root_is_absolute and scan_root_norm not in ("", "."):
             scan_prefix = scan_root_norm + "/"
+
+        def _physical_location_for(
+            entry: Mapping[str, object],
+        ) -> tuple[dict[str, object], str, object]:
+            """Build one physicalLocation from an item or per-finding entry.
+
+            Returns ``(physical_location, artifact_uri, loc_line)``. URIs are
+            repo-root-relative per issue #392; entries may carry an absolute
+            path defensively, which is rebased onto the scan root.
+            """
+            loc_file = entry.get("file")
+            artifact_uri = ""
+            loc_line: object = None
+            if loc_file:
+                artifact_uri = str(loc_file).replace("\\", "/")
+                if Path(str(loc_file)).is_absolute():
+                    try:
+                        artifact_uri = str(Path(str(loc_file)).relative_to(Path(path))).replace(
+                            "\\", "/"
+                        )
+                    except ValueError:
+                        artifact_uri = Path(str(loc_file)).name
+                if artifact_uri.startswith("./"):
+                    artifact_uri = artifact_uri[2:]
+                artifact_uri = scan_prefix + artifact_uri
+                physical: dict[str, object] = {
+                    "artifactLocation": {
+                        "uri": artifact_uri,
+                        "uriBaseId": "%SRCROOT%",
+                    }
+                }
+                raw_line = entry.get("line")
+                if isinstance(raw_line, int) and raw_line > 0:
+                    loc_line = raw_line
+                    region: dict[str, object] = {"startLine": raw_line}
+                    raw_end = entry.get("end_line")
+                    if isinstance(raw_end, int) and raw_end > 0:
+                        region["endLine"] = raw_end
+                    raw_col = entry.get("column")
+                    if isinstance(raw_col, int) and raw_col > 0:
+                        region["startColumn"] = raw_col
+                    physical["region"] = region
+                return physical, artifact_uri, loc_line
+            # Rules without a file location point at the scan root in its
+            # repo-root-relative form; absolute roots collapse to "." (#392).
+            return (
+                {
+                    "artifactLocation": {
+                        "uri": scan_prefix if scan_prefix else ".",
+                        "uriBaseId": "%SRCROOT%",
+                    }
+                },
+                scan_prefix if scan_prefix else ".",
+                None,
+            )
+
         for section in results:
             for item in section["items"]:
                 status = item.get("status")
@@ -379,69 +435,25 @@ def doctor(
                     continue
                 rule_id = item.get("rule_id") or item.get("label", "")
                 level = "error" if status == "fail" else "warning"
-                loc_file = item.get("file")
-                artifact_uri = ""
-                loc_line: object = None
-                if loc_file:
-                    artifact_uri = str(loc_file).replace("\\", "/")
-                    if Path(str(loc_file)).is_absolute():
-                        # Defensive: handlers emit scan-root-relative paths; if an
-                        # absolute path ever reaches here, rebase it onto the
-                        # scan root so no filesystem path leaks (#392).
-                        try:
-                            artifact_uri = str(Path(str(loc_file)).relative_to(Path(path))).replace(
-                                "\\", "/"
-                            )
-                        except ValueError:
-                            artifact_uri = Path(str(loc_file)).name
-                    if artifact_uri.startswith("./"):
-                        artifact_uri = artifact_uri[2:]
-                    artifact_uri = scan_prefix + artifact_uri
-                    physical_location: dict[str, object] = {
-                        "artifactLocation": {
-                            "uri": artifact_uri,
-                            "uriBaseId": "%SRCROOT%",
-                        }
-                    }
-                    loc_line = item.get("line")
-                    if isinstance(loc_line, int) and loc_line > 0:
-                        region: dict[str, object] = {"startLine": loc_line}
-                        loc_end_line = item.get("end_line")
-                        if isinstance(loc_end_line, int) and loc_end_line > 0:
-                            region["endLine"] = loc_end_line
-                        loc_column = item.get("column")
-                        if isinstance(loc_column, int) and loc_column > 0:
-                            region["startColumn"] = loc_column
-                        physical_location["region"] = region
-                else:
-                    # Rules without a file location point at the scan root in
-                    # its repo-root-relative form; absolute roots collapse to
-                    # "." so the URI stays a valid relative reference (#392).
-                    physical_location = {
-                        "artifactLocation": {
-                            "uri": scan_prefix if scan_prefix else ".",
-                            "uriBaseId": "%SRCROOT%",
-                        }
-                    }
-                # Stable fingerprint so Code Scanning can match alerts across
-                # runs even when lines shift; without one, most findings share
-                # the same root location and alerts regenerate/duplicate (#392).
-                fingerprint_seed = f"{rule_id}:{artifact_uri}:{loc_line or 0}"
-                sarif_result: dict[str, object] = {
-                    "ruleId": rule_id,
-                    "message": {"text": item.get("value", "")},
-                    "level": level,
-                    "locations": [{"physicalLocation": physical_location}],
-                    "partialFingerprints": {
-                        "primaryLocationLineHash": hashlib.sha256(
-                            fingerprint_seed.encode("utf-8")
-                        ).hexdigest()
-                    },
-                }
+
+                # One SARIF result per finding (issue #395): when a handler
+                # supplies structured ``locations``, each entry becomes its
+                # own result with its own region and message.
+                item_map = cast(Mapping[str, object], item)
+                raw_locations = item_map.get("locations")
+                entries: list[tuple[Mapping[str, object], str]] = []
+                if isinstance(raw_locations, list) and raw_locations:
+                    for raw_entry in raw_locations:
+                        if isinstance(raw_entry, dict):
+                            entry_map = cast(Mapping[str, object], raw_entry)
+                            per_message = str(entry_map.get("message") or item.get("value", ""))
+                            entries.append((entry_map, per_message))
+                if not entries:
+                    entries = [(item_map, str(item.get("value", "")))]
+
                 props: dict[str, object] = {}
                 if item.get("hint"):
                     props["hint"] = item.get("hint", "")
-                item_map = cast(Mapping[str, object], item)
                 for key in FINDING_EVIDENCE_KEYS:
                     val = item_map.get(key)
                     if isinstance(val, str) and val:
@@ -449,9 +461,27 @@ def doctor(
                 analysis = item.get("analysis")
                 if analysis:
                     props["analysis"] = analysis
-                if props:
-                    sarif_result["properties"] = props
-                sarif_results.append(sarif_result)
+
+                for entry, message_text in entries:
+                    physical_location, artifact_uri, loc_line = _physical_location_for(entry)
+                    # Stable fingerprint so Code Scanning can match alerts across
+                    # runs even when lines shift (#392).
+                    line_for_seed = loc_line if isinstance(loc_line, int) else 0
+                    fingerprint_seed = f"{rule_id}:{artifact_uri}:{line_for_seed}"
+                    sarif_result: dict[str, object] = {
+                        "ruleId": rule_id,
+                        "message": {"text": message_text},
+                        "level": level,
+                        "locations": [{"physicalLocation": physical_location}],
+                        "partialFingerprints": {
+                            "primaryLocationLineHash": hashlib.sha256(
+                                fingerprint_seed.encode("utf-8")
+                            ).hexdigest()
+                        },
+                    }
+                    if props:
+                        sarif_result["properties"] = props
+                    sarif_results.append(sarif_result)
 
         sarif_output = {
             "version": "2.1.0",

--- a/src/azure_functions_doctor/doctor.py
+++ b/src/azure_functions_doctor/doctor.py
@@ -104,6 +104,8 @@ class CheckResult(TypedDict, total=False):
     line: int
     end_line: int
     column: int
+    # Per-finding locations (issues #394/#395); SARIF emits one result per entry.
+    locations: list[dict[str, object]]
     # Finding Contract v2 (issue #348): auditable evidence + freshness metadata.
     evidence: str
     expected: str
@@ -484,6 +486,8 @@ class Doctor:
                     item["end_line"] = result["end_line"]
                 if "column" in result:
                     item["column"] = result["column"]
+                if "locations" in result:
+                    item["locations"] = result["locations"]
 
                 section_result["items"].append(item)
 

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -148,6 +148,9 @@ class HandlerResult(TypedDict, total=False):
     line: int
     end_line: int
     column: int
+    # Per-finding locations (issue #394/#395): each entry is a dict with
+    # file/line/end_line/column/message keys; SARIF emits one result per entry.
+    locations: List[Dict[str, object]]
     # Finding Contract v2 (issue #348): optional auditable evidence a handler
     # may emit for date / compatibility findings.
     evidence: str
@@ -584,7 +587,9 @@ def _collect_openapi_version_mixing(path: Path) -> dict[str, set[str]]:
     return signals
 
 
-def _collect_scan_before_spec(path: Path, scan_names: set[str], spec_names: set[str]) -> list[str]:
+def _collect_scan_before_spec(
+    path: Path, scan_names: set[str], spec_names: set[str]
+) -> tuple[list[str], list[tuple[str, int]]]:
     """Return "file:spec_call" labels where a spec build precedes endpoint scan.
 
     For each file, records the line numbers of scan-style calls and spec-style
@@ -592,8 +597,13 @@ def _collect_scan_before_spec(path: Path, scan_names: set[str], spec_names: set[
     precedes the earliest scan call in that file. Additionally, if spec calls
     exist anywhere in the project but no scan call is ever seen, every spec call
     is reported (scanning was skipped entirely).
+
+    Returns ``(labels, located)`` where ``located`` carries ``(label, lineno)``
+    pairs so callers can emit per-line SARIF locations (issue #394).
     """
     violations: list[str] = []
+    located: list[tuple[str, int]] = []
+    all_spec_located: list[tuple[str, int]] = []
     any_scan_seen = False
     spec_labels: list[str] = []
     for py_file, content in _iter_project_py_contents(path):
@@ -614,17 +624,22 @@ def _collect_scan_before_spec(path: Path, scan_names: set[str], spec_names: set[
                 scan_lines.append(node.lineno)
             elif leaf in spec_names:
                 spec_calls.append((node.lineno, leaf))
+        for lineno, leaf in spec_calls:
+            label = f"{py_file.relative_to(path)}:{leaf}"
+            spec_labels.append(label)
+            all_spec_located.append((label, lineno))
         if scan_lines:
             any_scan_seen = True
             first_scan = min(scan_lines)
             for lineno, leaf in spec_calls:
                 if lineno < first_scan:
-                    violations.append(f"{py_file.relative_to(path)}:{leaf}")
-        for lineno, leaf in spec_calls:
-            spec_labels.append(f"{py_file.relative_to(path)}:{leaf}")
+                    label = f"{py_file.relative_to(path)}:{leaf}"
+                    violations.append(label)
+                    located.append((label, lineno))
     if spec_labels and not any_scan_seen:
-        return spec_labels
-    return violations
+        # Scanning was skipped entirely: every spec call is a violation.
+        return spec_labels, all_spec_located
+    return violations, located
 
 
 def _project_imports_langgraph(path: Path) -> bool:
@@ -696,8 +711,8 @@ def _collect_anonymous_auth_routes(path: Path, flag_missing_auth_level: bool = F
     return flagged
 
 
-def _collect_binding_connections(path: Path) -> list[tuple[str, str]]:
-    """Return ``(connection_name, "file:function")`` pairs for v2 binding decorators.
+def _collect_binding_connections(path: Path) -> list[tuple[str, str, int]]:
+    """Return ``(connection_name, "file:function", lineno)`` triples for v2 binding decorators.
 
     Scans decorators applied to a discovered ``FunctionApp``/``Blueprint`` alias for a
     ``connection="..."`` keyword and collects the referenced setting name. Only
@@ -706,7 +721,7 @@ def _collect_binding_connections(path: Path) -> list[tuple[str, str]]:
     Storage, Service Bus, Event Hub, Cosmos DB and any other binding that exposes a
     ``connection`` keyword, without hard-coding a decorator whitelist.
     """
-    references: list[tuple[str, str]] = []
+    references: list[tuple[str, str, int]] = []
     for py_file, content in _iter_project_py_contents(path):
         try:
             tree = ast.parse(content)
@@ -735,7 +750,7 @@ def _collect_binding_connections(path: Path) -> list[tuple[str, str]]:
                         and kw.value.value.strip()
                     ):
                         label = f"{py_file.relative_to(path)}:{node.name}"
-                        references.append((kw.value.value, label))
+                        references.append((kw.value.value, label, dec.lineno))
     return references
 
 
@@ -1145,8 +1160,16 @@ def _create_result(
     line: Optional[int] = None,
     end_line: Optional[int] = None,
     column: Optional[int] = None,
+    locations: Optional[List[Dict[str, object]]] = None,
 ) -> HandlerResult:
-    """Create a standardized result dictionary (status limited to 'pass'/'fail')."""
+    """Create a standardized result dictionary (status limited to 'pass'/'fail').
+
+    ``locations`` (issues #394/#395) carries every individual finding as
+    ``{"file", "line", "end_line", "column", "message"}`` so SARIF output can
+    emit one result per finding instead of collapsing N findings onto the
+    first location. When omitted, the scalar ``file``/``line`` fields are the
+    single-location form.
+    """
     res: HandlerResult = {"status": status, "detail": detail}
     if internal_error:
         res["internal_error"] = "true"
@@ -1158,6 +1181,8 @@ def _create_result(
         res["end_line"] = end_line
     if column is not None:
         res["column"] = column
+    if locations:
+        res["locations"] = locations
     return res
 
 

--- a/src/azure_functions_doctor/handlers/bindings.py
+++ b/src/azure_functions_doctor/handlers/bindings.py
@@ -4,7 +4,7 @@ Split out of handlers/registry.py; registration/dispatch stays there.
 """
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
 from azure_functions_doctor.deploy_config import (
     local_settings_values,
@@ -19,8 +19,19 @@ from azure_functions_doctor.handlers._helpers import (
 )
 
 
+def _normalize_reference(
+    ref: tuple[str, str] | tuple[str, str, int],
+) -> tuple[str, str, int]:
+    """Accept 2-tuples (legacy/tests) and 3-tuples (collector, with lineno)."""
+    if len(ref) == 3:
+        name, label, lineno = ref
+        return name, label, lineno
+    name, label = ref
+    return name, label, 0
+
+
 def _evaluate_binding_connection_resolution(
-    references: list[tuple[str, str]],
+    references: Sequence[tuple[str, str] | tuple[str, str, int]],
     app_settings: dict[str, str],
 ) -> HandlerResult:
     """Resolve v2 binding ``connection`` references against configured settings (#352).
@@ -43,16 +54,17 @@ def _evaluate_binding_connection_resolution(
     def _is_resolved(name: str) -> bool:
         return name in setting_names or name in identity_prefixes
 
-    unresolved: list[tuple[str, str]] = []
+    unresolved: list[tuple[str, str, int]] = []
     seen: set[tuple[str, str]] = set()
-    for name, label in references:
+    for raw_ref in references:
+        name, label, lineno = _normalize_reference(raw_ref)
         if _is_resolved(name):
             continue
         key = (name, label)
         if key in seen:
             continue
         seen.add(key)
-        unresolved.append((name, label))
+        unresolved.append((name, label, lineno))
 
     if not unresolved:
         return _create_result(
@@ -61,18 +73,35 @@ def _evaluate_binding_connection_resolution(
         )
 
     lines = ["Binding connections reference unconfigured settings:"]
-    lines.extend(f"  - {name} ({label})" for name, label in unresolved)
+    lines.extend(f"  - {name} ({label})" for name, label, _ln in unresolved)
     lines.append(
         "Add the missing app setting(s), or configure an identity-based connection "
         "group (<name>__serviceUri / <name>__accountName)."
     )
     detail = "\n".join(lines)
-    result = _create_result("fail", detail)
+    # One location per unresolved reference so each lands on its binding
+    # decorator line in SARIF (issue #394).
+    locations: list[dict[str, object]] = [
+        {
+            "file": label.rsplit(":", 1)[0],
+            "line": lineno if lineno > 0 else None,
+            "message": f"Binding connection '{name}' ({label}) has no matching app setting",
+        }
+        for name, label, lineno in unresolved[:10]
+    ]
+    first = unresolved[0]
+    result = _create_result(
+        "fail",
+        detail,
+        file=first[1].rsplit(":", 1)[0],
+        line=first[2] if first[2] > 0 else None,
+        locations=locations,
+    )
     result["severity"] = "warning"
     result["gate"] = False
     result["expected"] = "Every referenced binding connection has a matching app setting"
     result["actual"] = "Unresolved connections: " + ", ".join(
-        sorted({name for name, _ in unresolved})
+        sorted({name for name, _label, _ln in unresolved})
     )
     return result
 

--- a/src/azure_functions_doctor/handlers/dependencies.py
+++ b/src/azure_functions_doctor/handlers/dependencies.py
@@ -225,7 +225,8 @@ class DependencyHandlers:
         except OSError as exc:
             return _handle_specific_exceptions(f"reading {target}", exc)
         unpinned: list[str] = []
-        for raw in content.splitlines():
+        finding_lines: list[dict[str, object]] = []
+        for line_no, raw in enumerate(content.splitlines(), start=1):
             line = raw.strip()
             if not line or line.startswith("#") or line.startswith("-"):
                 continue
@@ -238,6 +239,13 @@ class DependencyHandlers:
             specifiers = list(requirement.specifier)
             if not specifiers:
                 unpinned.append(f"- {requirement.name} (no version specifier)")
+                finding_lines.append(
+                    {
+                        "file": target,
+                        "line": line_no,
+                        "message": f"{requirement.name} (no version specifier)",
+                    }
+                )
                 continue
             has_upper_bound = any(
                 spec.operator in ("==", "===", "~=", "<", "<=") for spec in specifiers
@@ -245,6 +253,13 @@ class DependencyHandlers:
             if not has_upper_bound:
                 bounds = ",".join(str(spec) for spec in specifiers)
                 unpinned.append(f"- {requirement.name} ({bounds}; no upper bound)")
+                finding_lines.append(
+                    {
+                        "file": target,
+                        "line": line_no,
+                        "message": f"{requirement.name} ({bounds}; no upper bound)",
+                    }
+                )
         if not unpinned:
             return _create_result("pass", f"{target} dependencies are pinned/bounded")
         detail = "\n".join(
@@ -256,4 +271,4 @@ class DependencyHandlers:
                 "keep deployments reproducible.",
             ]
         )
-        return _create_result("fail", detail)
+        return _create_result("fail", detail, file=target, locations=finding_lines[:10])

--- a/src/azure_functions_doctor/handlers/deployment.py
+++ b/src/azure_functions_doctor/handlers/deployment.py
@@ -11,6 +11,7 @@ from typing import Optional
 from azure_functions_doctor.compatibility import Catalog, load_catalog
 from azure_functions_doctor.deploy_config import (
     flex_deployment_storage_shape,
+    local_settings_values,
 )
 from azure_functions_doctor.handlers._helpers import (
     _HOST_JSON_MISSING,
@@ -46,12 +47,12 @@ def _infra_declares_linux_fx_version(path: Path) -> bool:
     for infra in iter_project_files(path, ("*.bicep", "*.json")):
         if infra.name == "local.settings.json":
             continue
-            try:
-                text = infra.read_text(encoding="utf-8")
-            except OSError:
-                continue
-            if _LINUX_FX_KEY_RE.search(text):
-                return True
+        try:
+            text = infra.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if _LINUX_FX_KEY_RE.search(text):
+            return True
     return False
 
 
@@ -185,6 +186,7 @@ def _evaluate_flex_deprecated_settings(
     app_settings: dict[str, str],
     *,
     catalog: Optional[Catalog] = None,
+    local_settings: Optional[dict[str, str]] = None,
 ) -> HandlerResult:
     """Warn on legacy app settings that Flex Consumption ignores (issue #350).
 
@@ -215,7 +217,23 @@ def _evaluate_flex_deprecated_settings(
         "replacement mechanism."
     )
     detail = "\n".join(lines)
-    result = _create_result("fail", detail)
+    # Cite the declaring file when the deprecated setting is visible in
+    # local.settings.json (the common case); infra-only settings stay at the
+    # scan root (issue #394).
+    local_snapshot = local_settings or {}
+    locations: list[dict[str, object]] = [
+        {
+            "file": "local.settings.json" if name in local_snapshot else None,
+            "message": f"Deprecated Flex Consumption app setting: {name}",
+        }
+        for name in present[:10]
+    ]
+    result = _create_result(
+        "fail",
+        detail,
+        file="local.settings.json" if present and present[0] in local_snapshot else None,
+        locations=locations,
+    )
     result["severity"] = "warning"
     result["gate"] = False
     expected = "No deprecated legacy app settings on Flex Consumption"
@@ -370,6 +388,7 @@ class DeploymentHandlers:
         return _evaluate_flex_deprecated_settings(
             target_config.hosting_plan.value,
             target_config.app_settings,
+            local_settings=dict(local_settings_values(path)),
         )
 
     @_rule_handler

--- a/src/azure_functions_doctor/handlers/integrations.py
+++ b/src/azure_functions_doctor/handlers/integrations.py
@@ -53,6 +53,18 @@ class IntegrationHandlers:
         )
         first_label, first_line, first_end_line, first_column = uncovered[0]
         first_file = first_label.rsplit(":", 1)[0]
+        # One location per uncovered route so SARIF emits one result per
+        # finding instead of collapsing onto the first route (issue #395).
+        locations: list[dict[str, object]] = [
+            {
+                "file": label.rsplit(":", 1)[0],
+                "line": line_no,
+                "end_line": end_line,
+                "column": column,
+                "message": f"Route handler missing @validate_http (no endpoint metadata): {label}",
+            }
+            for label, line_no, end_line, column in uncovered[:10]
+        ]
         return _create_result(
             "fail",
             detail,
@@ -60,6 +72,7 @@ class IntegrationHandlers:
             line=first_line,
             end_line=first_end_line,
             column=first_column,
+            locations=locations,
         )
 
     @_rule_handler
@@ -115,7 +128,7 @@ class IntegrationHandlers:
                 "create_spec",
             ]
         )
-        violations = _collect_scan_before_spec(path, scan_names, spec_names)
+        violations, located = _collect_scan_before_spec(path, scan_names, spec_names)
         if not violations:
             return _create_result("pass", "No spec-before-scan ordering issues detected")
         detail = "\n".join(
@@ -126,7 +139,25 @@ class IntegrationHandlers:
                 "Fix: call the endpoint scan/registration before building the spec.",
             ]
         )
-        return _create_result("fail", detail)
+        # The collector already knows the offending lines; pass them through so
+        # SARIF findings land on the exact spec call (#394).
+        locations = [
+            {
+                "file": label.rsplit(":", 1)[0],
+                "line": lineno,
+                "message": f"OpenAPI spec built before endpoints were scanned: {label}",
+            }
+            for label, lineno in located[:10]
+            if label.rsplit(":", 1)[0] in {v.rsplit(":", 1)[0] for v in violations}
+        ]
+        first = located[0] if located else None
+        return _create_result(
+            "fail",
+            detail,
+            file=first[0].rsplit(":", 1)[0] if first else None,
+            line=first[1] if first else None,
+            locations=locations,
+        )
 
     @_rule_handler
     def _handle_langgraph_anonymous_auth(

--- a/tests/test_binding_connection_resolution.py
+++ b/tests/test_binding_connection_resolution.py
@@ -58,9 +58,9 @@ class TestCollectBindingConnections:
     def test_collects_string_literal_connections(self, tmp_path: Path) -> None:
         (tmp_path / "function_app.py").write_text(SAMPLE_APP, encoding="utf-8")
         refs = _collect_binding_connections(tmp_path)
-        names = sorted(name for name, _ in refs)
+        names = sorted(name for name, _label, _ln in refs)
         assert names == ["ServiceBusConnection", "StorageConnection"]
-        labels = {label for _, label in refs}
+        labels = {label for _name, label, _ln in refs}
         assert any("function_app.py:handle_bus" in label for label in labels)
 
     def test_ignores_non_literal_connection(self, tmp_path: Path) -> None:
@@ -99,7 +99,7 @@ class TestCollectBindingConnections:
         )
         (tmp_path / "bp.py").write_text(src, encoding="utf-8")
         refs = _collect_binding_connections(tmp_path)
-        assert [name for name, _ in refs] == ["QueueConnection"]
+        assert [name for name, _l, _n in refs] == ["QueueConnection"]
 
 
 class TestLocalSettingsValues:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -476,6 +476,7 @@ def test_create_result_populates_optional_location_fields() -> None:
     bare = _create_result("pass", "ok")
     assert "file" not in bare and "line" not in bare
 
+
 def test_cli_version_flag_prints_package_version() -> None:
     """--version prints the installed version without running a scan (#396)."""
     from azure_functions_doctor import __version__
@@ -492,3 +493,60 @@ def test_cli_doctor_subcommand_still_works_with_version_flag_present(
     result = runner.invoke(app, ["doctor", "--path", str(tmp_path), "--format", "json"])
     assert result.exit_code in (0, 1)
     assert result.output.startswith("{")
+
+
+def test_cli_sarif_emits_one_result_per_finding(tmp_path: Path) -> None:
+    """Two uncovered routes yield two located endpoint_metadata results (#395)."""
+    (tmp_path / "requirements.txt").write_text(
+        "azure-functions==1.25.0\nazure-functions-validation==0.24.0\n", encoding="utf-8"
+    )
+    (tmp_path / "function_app.py").write_text(
+        "import azure.functions as func\n"
+        "from azure_functions_validation import validate_http\n"
+        "\n"
+        "app = func.FunctionApp()\n"
+        "\n"
+        "\n"
+        "@validate_http\n"
+        '@app.route(route="alpha")\n'
+        "def alpha(req):\n"
+        "    return req\n"
+        "\n"
+        "\n"
+        "@validate_http\n"
+        '@app.route(route="beta")\n'
+        "def beta(req):\n"
+        "    return req\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["doctor", "--path", str(tmp_path), "--format", "sarif"])
+    sarif_results = json.loads(result.output)["runs"][0]["results"]
+    endpoint = [r for r in sarif_results if r["ruleId"] == "check_endpoint_metadata"]
+    assert len(endpoint) == 2, "expected one SARIF result per uncovered route"
+    lines = sorted(r["locations"][0]["physicalLocation"]["region"]["startLine"] for r in endpoint)
+    assert lines == [9, 15]
+    messages = " | ".join(r["message"]["text"] for r in endpoint)
+    assert "alpha" in messages and "beta" in messages
+    # Distinct fingerprints per finding.
+    prints = {r["partialFingerprints"]["primaryLocationLineHash"] for r in endpoint}
+    assert len(prints) == 2
+
+
+def test_cli_sarif_unpinned_requirements_lands_on_lines(tmp_path: Path) -> None:
+    """Each unpinned requirement carries its requirements.txt line (#394)."""
+    (tmp_path / "requirements.txt").write_text(
+        "azure-functions==1.25.0\nrequests>=2.0\nflask\n", encoding="utf-8"
+    )
+    (tmp_path / "function_app.py").write_text(
+        "import azure.functions as func\n\napp = func.FunctionApp()\n", encoding="utf-8"
+    )
+
+    result = runner.invoke(app, ["doctor", "--path", str(tmp_path), "--format", "sarif"])
+    sarif_results = json.loads(result.output)["runs"][0]["results"]
+    unpinned = [r for r in sarif_results if r["ruleId"] == "check_unpinned_requirements"]
+    assert unpinned, "expected unpinned-requirements findings"
+    lines = sorted(r["locations"][0]["physicalLocation"]["region"]["startLine"] for r in unpinned)
+    assert lines == [2, 3]
+    uris = {r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"] for r in unpinned}
+    assert uris == {"requirements.txt"}

--- a/tests/test_toolkit_rule_checks.py
+++ b/tests/test_toolkit_rule_checks.py
@@ -124,7 +124,7 @@ def test_scan_before_spec_spec_before_scan_fails(tmp_path: Path) -> None:
     )
     scan = {"scan"}
     spec = {"build_spec"}
-    assert _collect_scan_before_spec(tmp_path, scan, spec) == ["app.py:build_spec"]
+    assert _collect_scan_before_spec(tmp_path, scan, spec)[0] == ["app.py:build_spec"]
     assert _status("scan_before_spec", tmp_path) == "fail"
 
 
@@ -135,13 +135,13 @@ def test_scan_before_spec_correct_order_passes(tmp_path: Path) -> None:
 
 def test_scan_before_spec_spec_without_scan_fails(tmp_path: Path) -> None:
     _write(tmp_path, "app.py", "build_spec()\n")
-    assert _collect_scan_before_spec(tmp_path, {"scan"}, {"build_spec"}) == ["app.py:build_spec"]
+    assert _collect_scan_before_spec(tmp_path, {"scan"}, {"build_spec"})[0] == ["app.py:build_spec"]
     assert _status("scan_before_spec", tmp_path) == "fail"
 
 
 def test_scan_before_spec_no_spec_passes(tmp_path: Path) -> None:
     _write(tmp_path, "app.py", "scan()\n")
-    assert _collect_scan_before_spec(tmp_path, {"scan"}, {"build_spec"}) == []
+    assert _collect_scan_before_spec(tmp_path, {"scan"}, {"build_spec"})[0] == []
 
 
 def test_scan_before_spec_custom_names(tmp_path: Path) -> None:
@@ -180,13 +180,13 @@ def test_scan_before_spec_real_openapi_names_correct_order_passes(tmp_path: Path
 
 def test_scan_before_spec_skips_syntax_error(tmp_path: Path) -> None:
     _write(tmp_path, "broken.py", "def f(:\n")
-    assert _collect_scan_before_spec(tmp_path, {"scan"}, {"build_spec"}) == []
+    assert _collect_scan_before_spec(tmp_path, {"scan"}, {"build_spec"})[0] == []
 
 
 def test_scan_before_spec_dotted_call_target(tmp_path: Path) -> None:
     # attribute-style call that resolves to a leaf name is still matched
     _write(tmp_path, "app.py", "api.build_spec()\napi.scan()\n")
-    assert _collect_scan_before_spec(tmp_path, {"scan"}, {"build_spec"}) == ["app.py:build_spec"]
+    assert _collect_scan_before_spec(tmp_path, {"scan"}, {"build_spec"})[0] == ["app.py:build_spec"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

Closes #394 and #395 together — they share one mechanism. The review's findings: the location transport was complete end to end, but (a) only 2 of 41 rules fed it while several computed line numbers and dropped them, and (b) multi-finding rules collapsed N findings onto the first location, producing whack-a-mole Code Scanning alerts.

## Changes

**Mechanism**: `_create_result` / `CheckResult` gain a structured `locations` array (`{file, line, end_line, column, message}`); `doctor.py` passes it through; the SARIF emitter emits **one result per entry** (own region, message, fingerprint) and falls back to the scalar single-location form. JSON contract docs updated.

**Wired rules**:
- `check_endpoint_metadata` — every uncovered route gets its own located result (verified: two routes → two results at lines 9/15) (#395)
- `check_unpinned_requirements` — per-requirement `requirements.txt` line numbers (#394)
- `check_scan_before_spec` — the collector already computed `node.lineno` for the label and dropped it; now returned as `(label, lineno)` and emitted (#394)
- `check_binding_connection_resolution` — decorator line captured per `connection=` reference (#394)
- `check_flex_deprecated_settings` — settings visible in `local.settings.json` cite that file (#394)

## Verification

- Reproductions: two uncovered routes → 2 located results; unpinned `requests>=2.0`/`flask` → results at lines 2/3 of `requirements.txt`
- New SARIF tests for both behaviors (distinct fingerprints per finding asserted)
- Full suite pass, coverage **96.90%** (≥95%), style/typecheck/docs-consistency green

Closes #394
Closes #395