### PR TITLE
docs: correct stale rule counts and widen the drift guard for 0.20.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,31 @@ All notable changes to this project will be documented in this file.
 
 ## Full Version History
 
+### v0.20.0 (2026-09-06)
+
+**Migration notes** (read before upgrading pinned `@v1` Action usage):
+
+1. **GitHub Action default profile is now `deploy`** (was `minimal`). Pinned
+   `yeongseon/azure-functions-doctor@v1` users receive this automatically on
+   release: the run grows from 6 required rules to 19 (6 required + 13
+   optional deploy-correctness rules). The exit-code contract is unchanged —
+   the added rules only warn and `fail-on-warn` defaults to `false` — but
+   expect more Code Scanning alerts. Pin `profile: minimal` explicitly to
+   keep the previous behavior.
+2. **SARIF now emits one result per finding** (was one per rule). Rules that
+   report multiple findings (e.g. uncovered routes, unpinned requirements)
+   produce one located result each, compounding the alert-count increase
+   above with more precise locations.
+3. **`check_unsupported_metadata_version` was removed.** `[tool.azure-functions-doctor].ignore`
+   entries naming this rule ID are now dangling; remove them.
+
+Other highlights: SARIF artifactLocation URIs are repo-root-relative with
+`partialFingerprints` (was: absolute paths in some branches); all file
+traversal honors the shared exclusion helper and the user's `exclude` globs
+(no more venv/node_modules false positives); `--version` flag; the `doctor`
+subcommand is optional; reference examples pass their own pinning rule.
+
+
 ### v0.16.2 (2026-03-29)
 - Fix 6 confirmed bugs: #95, #96, #97, #98, #99, #100 (#101)
 - Update README with Azure Functions Python DX Toolkit branding

--- a/docs/minimal_profile.md
+++ b/docs/minimal_profile.md
@@ -42,7 +42,7 @@ These represent the minimum structural requirements for a valid Azure Functions 
 | Dimension | `full` profile | `minimal` profile |
 | --- | --- | --- |
 | Rule scope | Required + optional | Required only |
-| Built-in count | 29 rules | 6 rules |
+| Built-in count | 41 rules | 6 rules |
 | Warning volume | Higher | Lower |
 | CI suitability | Useful for report artifacts | Best for hard gating |
 | Local guidance depth | High | Baseline only |

--- a/docs/semver_policy.md
+++ b/docs/semver_policy.md
@@ -12,7 +12,7 @@ Every built-in rule has one of three stability states:
 | **Experimental** | Under evaluation. May change behavior or be removed in a minor release. False positives are documented as known limitations. |
 | **Deprecated** | Scheduled for removal. Announced in the changelog and removed in the next major release. |
 
-All 29 current built-in rules are **stable**.
+All 41 current built-in rules are **stable**.
 
 ## State Transitions
 
@@ -69,4 +69,4 @@ The `minimal` profile runs only rules marked `required: true`. Because CI pipeli
 
 ## Current Rule Status
 
-All 29 rules in `v2.json` are **stable**. See the [Rule Inventory](rule_inventory.md) for the complete list.
+All 41 rules in `v2.json` are **stable**. See the [Rule Inventory](rule_inventory.md) for the complete list.

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -118,12 +118,51 @@ def _check_readme_rule_count() -> list[str]:
     return []
 
 
+# Historical/hand-maintained docs that legitimately cite old counts.
+_DOC_COUNT_EXEMPT = {
+    "changelog.md",  # per-release history (counts at the time of writing)
+}
+
+
+def _check_doc_rule_counts() -> list[str]:
+    """Assert every "N rules" count in docs/ matches the shipped ruleset.
+
+    Catches the drift class where README's count is verified but sibling docs
+    (semver policy, profile comparisons) silently keep an old total (issue:
+    three stale "29 rules" mentions survived a verified guard because the
+    guard only looked at README).
+    """
+    actual = len(_rule_ids_from_json())
+    errors: list[str] = []
+    patterns = (
+        # "All 41 current built-in rules" / "All 41 rules in `v2.json`"
+        re.compile(r"All (\d+) (?:current built-in )?rules"),
+        # Comparison tables: "| Built-in count | 41 rules | 6 rules |"
+        re.compile(r"\|\s*Built-in count\s*\|\s*(\d+) rules\s*\|"),
+    )
+    for doc in sorted((ROOT / "docs").glob("*.md")):
+        if doc.name in _DOC_COUNT_EXEMPT:
+            continue
+        content = doc.read_text(encoding="utf-8")
+        for pattern in patterns:
+            for match in pattern.finditer(content):
+                documented = int(match.group(1))
+                if documented != actual:
+                    errors.append(
+                        f"docs/{doc.name}: rule count '{documented}' "
+                        f'(near "{match.group(0)}") does not match the '
+                        f"{actual} rules in v2.json."
+                    )
+    return errors
+
+
 def main() -> int:
     version = _read_version()
     errors = (
         _check_version_refs(version)
         + _check_rule_inventory()
         + _check_readme_rule_count()
+        + _check_doc_rule_counts()
     )
     if errors:
         print("Documentation consistency check FAILED:")


### PR DESCRIPTION
## Context

Pre-release prep for 0.20.0 (external re-review findings): three docs still cited **29** built-in rules (semver_policy.md ×2, minimal_profile.md ×1) while v2.json ships **41**. They survived because `check_docs_consistency.py` only verified README's `**N diagnostic checks**` count — the existence of a guard made the unguarded spots feel safe.

## Changes

- The three stale counts corrected to 41.
- **Drift guard widened**: `check_docs_consistency.py` now scans `docs/*.md` (changelog history exempt) for `All N rules` mentions and `| Built-in count | N rules |` table cells, verified against the live v2.json count. Injected-drift test: fails with a precise file+context message.
- **`docs/changelog.md`**: v0.20.0 migration notes added ahead of the release — (1) Action default profile `minimal` → `deploy` (exit-code contract unchanged; 6 → 19 rules; more Code Scanning alerts; explicit `profile: minimal` opt-out), (2) SARIF per-finding results, (3) removed `check_unsupported_metadata_version` → dangling `.ignore` entries.

## Verification

- Consistency check passes (0.19.2, 41 rules) and demonstrably fails on an injected stale count.
- mkdocs build: no new warnings.

Release-blocking for 0.20.0.