### PR TITLE
test(catalog): add a hosting-plan x Python verdict matrix

### DIFF
--- a/.github/workflows/v1-consumer-smoke.yml
+++ b/.github/workflows/v1-consumer-smoke.yml
@@ -1,0 +1,161 @@
+name: v1 Consumer Smoke
+
+# Post-release verification of the EXISTING-USER consumer path (issue #410):
+# every other smoke uses `uses: ./` (local composite action); nothing else
+# proves that pinning yeongseon/azure-functions-doctor@v1 resolves and behaves
+# after a release — new deploy default profile, per-finding SARIF with
+# repo-root-relative URIs and partialFingerprints, and PyPI parity.
+#
+# Code Scanning upload is deliberately NOT performed here (the main repo's
+# alert stream must stay clean); SARIF artifacts are asserted structurally
+# and uploaded as plain workflow artifacts instead.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily, off-round minute. Catches @v1 drift within a day of a release.
+    - cron: "17 4 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  v1-consumer-smoke:
+    name: Consume the published action as an external user
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (frozen example projects come from here)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Differential assertion, part 1: the DEFAULT profile. Runs the v1
+      # moving branch exactly as a pinned user would, with no explicit profile.
+      - name: Run @v1 with the default profile
+        id: v1-default
+        continue-on-error: true
+        uses: yeongseon/azure-functions-doctor@v1 # pin-exempt: the product under test — this smoke exists to verify the moving @v1 ref itself
+        with:
+          path: examples/v2/http-trigger
+          format: json
+          output: v1-default.json
+          upload-artifact: "false"
+          fail-on-warn: "false"
+
+      # Differential assertion, part 2: the same run with an EXPLICIT deploy
+      # profile. Identical exit-code/pass/fail/warn counts prove the default
+      # is `deploy` (a minimal default would produce different counts).
+      - name: Run @v1 with an explicit deploy profile
+        id: v1-deploy
+        continue-on-error: true
+        uses: yeongseon/azure-functions-doctor@v1 # pin-exempt: the product under test — this smoke exists to verify the moving @v1 ref itself
+        with:
+          path: examples/v2/http-trigger
+          profile: deploy
+          format: json
+          output: v1-deploy.json
+          upload-artifact: "false"
+          fail-on-warn: "false"
+
+      # Exit-code contract on a failing fixture: a required-rule violation
+      # must exit 1 through @v1 exactly as it does locally.
+      - name: Run @v1 on a broken fixture (expect exit 1)
+        id: v1-broken
+        continue-on-error: true
+        uses: yeongseon/azure-functions-doctor@v1 # pin-exempt: the product under test — this smoke exists to verify the moving @v1 ref itself
+        with:
+          path: examples/v2/broken-missing-host-json
+          profile: minimal
+          format: json
+          output: v1-broken.json
+          upload-artifact: "false"
+          fail-on-warn: "false"
+
+      # SARIF contract through @v1: relative URIs only, uriBaseId on every
+      # location, partialFingerprints on every result, per-finding regions.
+      - name: Run @v1 in SARIF mode for contract assertions
+        id: v1-sarif
+        continue-on-error: true
+        uses: yeongseon/azure-functions-doctor@v1 # pin-exempt: the product under test — this smoke exists to verify the moving @v1 ref itself
+        with:
+          path: examples/v2/broken-missing-host-json
+          profile: full
+          format: sarif
+          output: v1.sarif
+          upload-artifact: "false"
+          upload-sarif: "false"
+
+      - name: Verify the @v1 consumer contract
+        run: |
+          python3 - <<'PY'
+          import json, sys
+
+          default = json.load(open("v1-default.json"))
+          deploy = json.load(open("v1-deploy.json"))
+          broken = json.load(open("v1-broken.json"))
+
+          # 1) Default profile == deploy (differential on counts + exit code).
+          for key in ("schema_version",):
+              assert default[key] == deploy[key] == "2.0", key
+          d_items = [i for s in default["results"] for i in s["items"]]
+          p_items = [i for s in deploy["results"] for i in s["items"]]
+          d_counts = {st: sum(1 for i in d_items if i["status"] == st)
+                      for st in ("pass", "warn", "fail", "skip")}
+          p_counts = {st: sum(1 for i in p_items if i["status"] == st)
+                      for st in ("pass", "warn", "fail", "skip")}
+          assert d_counts == p_counts, f"default profile is not deploy: {d_counts} != {p_counts}"
+          assert d_counts["pass"] > 6, "deploy default should run more than the required-only ruleset"
+
+          # 2) Exit-code contract: required failure => failed > 0 and rc 1.
+          b_items = [i for s in broken["results"] for i in s["items"]]
+          assert sum(1 for i in b_items if i["status"] == "fail") >= 1
+
+          print("default==deploy counts:", d_counts)
+          PY
+          test "${{ steps.v1-default.outputs.exit-code }}" = "0" || exit 1
+          test "${{ steps.v1-broken.outputs.exit-code }}" = "1" || exit 1
+
+      - name: Assert the SARIF artifact contract
+        run: |
+          python3 - <<'PY'
+          import json
+
+          sarif = json.load(open("v1.sarif"))
+          assert sarif["version"] == "2.1.0"
+          results = sarif["runs"][0]["results"]
+          assert results, "expected findings in SARIF output"
+
+          for r in results:
+              loc = r["locations"][0]["physicalLocation"]["artifactLocation"]
+              # Relative references only: no absolute filesystem paths may leak
+              # into the security artifact (issue #392 contract).
+              assert not loc["uri"].startswith("/"), f"absolute URI leaked: {loc['uri']}"
+              assert not loc["uri"].startswith("file:"), loc["uri"]
+              assert loc.get("uriBaseId") == "%SRCROOT%"
+              # Stable fingerprints on every result (issue #392/#405 contract).
+              fp = r.get("partialFingerprints", {}).get("primaryLocationLineHash")
+              assert isinstance(fp, str) and fp, "missing primaryLocationLineHash"
+
+          located = [r for r in results
+                     if "region" in r["locations"][0]["physicalLocation"]]
+          assert located, "expected at least one per-finding region"
+          print(f"SARIF contract OK: {len(results)} results, {len(located)} located")
+          PY
+
+      - name: PyPI parity (fresh install matches the published latest)
+        run: |
+          python3 -m venv /tmp/pypi-check
+          /tmp/pypi-check/bin/pip install --quiet --upgrade pip
+          /tmp/pypi-check/bin/pip install --quiet azure-functions-doctor
+          INSTALLED=$(/tmp/pypi-check/bin/azure-functions-doctor --version)
+          LATEST=$(curl -s https://pypi.org/pypi/azure-functions-doctor/json \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])")
+          echo "installed=$INSTALLED pypi_latest=$LATEST"
+          test "$INSTALLED" = "$LATEST"
+          /tmp/pypi-check/bin/azure-functions-doctor doctor \
+            --path examples/v2/http-trigger --profile minimal --format json > pypi.json
+          python3 -c "
+          import json
+          d = json.load(open('pypi.json'))
+          assert d['schema_version'] == '2.0'
+          assert d['metadata']['tool_version'] == '$INSTALLED'
+          print('PyPI parity OK')
+          "

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,15 @@ What problem this issue addresses and why now. Note the target release (e.g. vX.
 
 When splitting a large piece of work into focused issues, keep the umbrella open as a tracker that links each child issue with a checkbox; close it once every child is closed or explicitly deferred.
 
+### Project management model
+
+This repository is **issue-based, not milestone-based**. Track and group work using issues plus the existing label taxonomy — do **not** introduce parallel structures.
+
+- Plan and group multi-issue efforts with an **umbrella tracker issue** (see above) plus the existing `priority:p0` / `priority:p1` / `priority:p2` labels. Do **not** create GitHub Milestones — none exist by design, and their absence is an intentional signal, not an oversight.
+- Do **not** invent new label taxonomies (e.g. `epic:*`, `vNext`, release-tag labels) to group work. Reuse `priority:*`, `area:*` (only where they already exist), and the umbrella issue. Propose any new label in discussion and wait for explicit approval before creating it.
+- Treat optional or tentative suggestions ("we could…", "it might be nice to…", "~해도 괜찮아") as **discussion, not a directive**. Confirm intent before making any structural change to how work is tracked (milestones, labels, project boards, issue hierarchies).
+- Before adding any organizational structure, check whether the repository already has an established convention. A category being empty or unused (zero milestones, no `epic:*` labels) is evidence to follow the existing pattern, not to introduce a new one.
+
 ## Validation
 - `make test`
 - `make lint`

--- a/docs/json_output_contract.md
+++ b/docs/json_output_contract.md
@@ -57,6 +57,18 @@ If `--output` is omitted, JSON is printed to stdout.
 
 ## Field reference
 
+### Machine-readable schema
+
+The contract ships as a JSON Schema in the wheel: [`schemas/output-contract-2.0.schema.json`](https://github.com/yeongseon/azure-functions-doctor-python/blob/main/src/azure_functions_doctor/schemas/output-contract-2.0.schema.json) (draft-07). Consumers validate with `jsonschema`:
+
+```python
+import json, jsonschema
+schema = json.load(open("output-contract-2.0.schema.json"))
+jsonschema.validate(json.load(open("doctor-report.json")), schema)
+```
+
+Strict on identity and semantics (rule_id shape, status/severity/tier enums); permissive on additive fields for 0.x evolution. Field *meaning* changes require a migration note per the [semver policy](semver_policy.md).
+
 ### Top level
 
 | Field | Type | Description |

--- a/src/azure_functions_doctor/schemas/output-contract-2.0.schema.json
+++ b/src/azure_functions_doctor/schemas/output-contract-2.0.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/yeongseon/azure-functions-doctor-python/blob/main/src/azure_functions_doctor/schemas/output-contract-2.0.schema.json",
+  "title": "azure-functions-doctor JSON output contract",
+  "description": "Machine-readable contract for `azure-functions-doctor doctor --format json` output (schema_version 2.0). Strict on finding identity and status/severity semantics; additive evolution is allowed in 0.x (additionalProperties true) but any field meaning change requires a migration note per docs/semver_policy.md.",
+  "type": "object",
+  "required": ["schema_version", "metadata", "results"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": { "const": "2.0" },
+    "metadata": {
+      "type": "object",
+      "required": ["tool_version", "generated_at", "target_path", "programming_model"],
+      "additionalProperties": true,
+      "properties": {
+        "tool_version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$" },
+        "generated_at": { "type": "string", "format": "date-time" },
+        "target_path": { "type": "string" },
+        "programming_model": {
+          "enum": ["v2", "mixed", "unsupported_v1", "unknown"]
+        },
+        "target_python": { "type": ["string", "null"] },
+        "deployment_mode": {
+          "enum": ["remote-build", "local", "local-prebuilt", "container"]
+        },
+        "hosting_plan": { "type": ["string", "null"] }
+      }
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["title", "category", "status", "items"],
+        "additionalProperties": true,
+        "properties": {
+          "title": { "type": "string" },
+          "category": { "type": "string" },
+          "status": { "enum": ["pass", "warn", "fail", "skip"] },
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/finding" }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "finding": {
+      "type": "object",
+      "required": ["rule_id", "label", "value", "status", "severity", "tier"],
+      "additionalProperties": true,
+      "properties": {
+        "rule_id": { "type": "string", "pattern": "^check_[a-z0-9_]+$" },
+        "label": { "type": "string" },
+        "value": { "type": "string" },
+        "status": { "enum": ["pass", "warn", "fail", "skip"] },
+        "severity": { "enum": ["error", "warning", "info"] },
+        "tier": { "enum": ["core", "extended", "experimental"] },
+        "hint": { "type": "string" },
+        "hint_url": { "type": "string", "format": "uri" },
+        "file": { "type": "string" },
+        "line": { "type": "integer", "minimum": 1 },
+        "end_line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 },
+        "evidence": { "type": "string" },
+        "expected": { "type": "string" },
+        "actual": { "type": "string" },
+        "source_url": { "type": "string", "format": "uri" },
+        "last_verified": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+        "catalog_version": { "type": "string" },
+        "analysis": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": { "const": "deterministic" }
+          },
+          "additionalProperties": true
+        },
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["file"],
+            "additionalProperties": true,
+            "properties": {
+              "file": { "type": "string" },
+              "line": { "type": ["integer", "null"], "minimum": 1 },
+              "end_line": { "type": ["integer", "null"], "minimum": 1 },
+              "column": { "type": ["integer", "null"], "minimum": 1 },
+              "message": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_catalog_verdict_matrix.py
+++ b/tests/test_catalog_verdict_matrix.py
@@ -1,0 +1,193 @@
+"""Catalog-derived verdict matrix (issue #412).
+
+Asserts that the lifecycle evaluators honor the version-controlled catalog
+exhaustively: every (hosting plan x Python version) pair resolves through the
+plan matrix, and every lifecycle verdict flips exactly at the catalog's
+published boundary dates (retiring-soon window entry, end-of-support day, and
+the day after). Expectations are *derived from the catalog*, not hardcoded,
+so the matrix stays correct as the catalog rolls forward.
+"""
+
+from datetime import date, timedelta
+from typing import Optional
+
+import pytest
+
+from azure_functions_doctor.compatibility import Catalog, SupportEnd, load_catalog
+from azure_functions_doctor.handlers.runtime import (
+    HOSTING_PLAN_RETIRING_SOON_WINDOW_DAYS,
+    PYTHON_RETIRING_SOON_WINDOW_DAYS,
+    _evaluate_functions_runtime_lifecycle,
+    _evaluate_hosting_plan_lifecycle,
+    _evaluate_python_lifecycle,
+)
+from azure_functions_doctor.target_resolver import is_supported_python_for_plan
+
+
+@pytest.fixture(scope="module")
+def catalog() -> Catalog:
+    return load_catalog()
+
+
+def _last_day(support_end: SupportEnd) -> date:
+    """The last calendar day the source guarantees (precision-widened)."""
+    end = support_end.end_date()
+    assert end is not None, support_end.value
+    return end
+
+
+class TestPlanPythonMatrix:
+    """Every catalog (plan, version) pair resolves exactly per the matrix."""
+
+    def test_known_plans_match_matrix_membership(self, catalog: Catalog) -> None:
+        matrix = catalog.hosting_plan_matrix()
+        versions = catalog.known_python_versions()
+        assert matrix and versions
+        for plan, allowed in matrix.items():
+            for version in versions:
+                expected = version in allowed
+                assert is_supported_python_for_plan(version, plan) is expected, (
+                    f"{plan} x {version}: expected supported={expected}"
+                )
+
+    def test_unknown_plan_falls_back_to_plan_agnostic_support(self, catalog: Catalog) -> None:
+        for version in catalog.supported_python_versions():
+            assert is_supported_python_for_plan(version, "does-not-exist") is True
+        assert is_supported_python_for_plan("3.7", "does-not-exist") is False
+
+
+class TestPythonLifecycleBoundaries:
+    """Verdicts flip exactly at the catalog's published end-of-support dates."""
+
+    def test_every_supported_version_is_supported_or_retiring_today(self, catalog: Catalog) -> None:
+        """No supported version is ever past EOS on the current date."""
+        today = date(2026, 9, 7)
+        for version in catalog.supported_python_versions(as_of=today):
+            result = _evaluate_python_lifecycle(version, today=today)
+            # Raw evaluator contract: pass/info outside the window,
+            # fail/warning (gate False -> canonical "warn") inside it.
+            assert (result["status"], result.get("severity")) in (
+                ("pass", "info"),
+                ("fail", "warning"),
+            ), (version, result["status"], result.get("severity"))
+            assert result.get("gate") is not True, version
+
+    def test_boundary_dates_for_each_fact(self, catalog: Catalog) -> None:
+        today = date(2026, 9, 7)
+        checked = 0
+        for version in catalog.supported_python_versions(as_of=today):
+            eos = catalog.python_eos(version)
+            if eos is None:
+                continue
+            checked += 1
+            last_day = _last_day(eos)
+            window_start = last_day - timedelta(days=PYTHON_RETIRING_SOON_WINDOW_DAYS)
+
+            before = _evaluate_python_lifecycle(version, today=window_start - timedelta(days=1))
+            assert (before["status"], before.get("severity")) == ("pass", "info"), (
+                version,
+                "before window",
+                before,
+            )
+
+            inside = _evaluate_python_lifecycle(version, today=window_start + timedelta(days=1))
+            assert (inside["status"], inside.get("severity")) == ("fail", "warning"), (
+                version,
+                "inside window",
+                inside,
+            )
+            assert inside.get("gate") is False  # canonical "warn", never gating
+
+            after = _evaluate_python_lifecycle(version, today=last_day + timedelta(days=1))
+            assert (after["status"], after.get("severity")) == ("fail", "error"), (
+                version,
+                "past eos",
+                after,
+            )
+            assert after.get("gate") is True
+
+        assert checked >= 5, "expected every supported Python to carry an EOS fact"
+
+
+class TestHostingPlanLifecycleBoundaries:
+    """Plan verdicts flip at the catalog's retirement dates."""
+
+    def test_plan_boundaries(self, catalog: Catalog) -> None:
+        matrix = catalog.hosting_plan_matrix()
+        checked = 0
+        for plan in matrix:
+            fact = catalog.hosting_plan_lifecycle_fact(plan)
+            if fact is None or fact.support_end is None:
+                # No published retirement: the plan must never fail on dates.
+                result = _evaluate_hosting_plan_lifecycle(plan, today=date(2030, 1, 1))
+                assert result["status"] in ("pass", "warn", "skip"), (plan, result)
+                continue
+            checked += 1
+            last_day = _last_day(fact.support_end)
+            window_start = last_day - timedelta(days=HOSTING_PLAN_RETIRING_SOON_WINDOW_DAYS)
+            before = _evaluate_hosting_plan_lifecycle(plan, today=window_start - timedelta(days=1))
+            assert (before["status"], before.get("severity")) == ("pass", "info"), (plan, before)
+
+            inside = _evaluate_hosting_plan_lifecycle(plan, today=window_start + timedelta(days=1))
+            assert (inside["status"], inside.get("severity")) == ("fail", "warning"), (plan, inside)
+            assert inside.get("gate") is False
+
+            after = _evaluate_hosting_plan_lifecycle(plan, today=last_day + timedelta(days=1))
+            assert (after["status"], after.get("severity")) == ("fail", "error"), (plan, after)
+            assert after.get("gate") is True
+
+        assert checked >= 1, "expected at least one plan with a retirement date"
+
+
+class TestFunctionsRuntimeVerdicts:
+    """Runtime verdicts match the catalog's per-runtime facts."""
+
+    @pytest.mark.parametrize(
+        ("runtime", "expected_status", "expected_severity"),
+        [
+            ("~1", "fail", "error"),  # incompatible with Python
+            ("~2", "fail", "error"),  # out of support
+            ("~3", "fail", "error"),  # out of support
+            ("4", "pass", "info"),  # pinned forms normalize to 4.x
+            ("~4", "pass", "info"),
+        ],
+    )
+    def test_runtime_verdicts(
+        self,
+        catalog: Catalog,
+        runtime: str,
+        expected_status: str,
+        expected_severity: str,
+    ) -> None:
+        result = _evaluate_functions_runtime_lifecycle(
+            runtime,
+            None,
+            today=date(2026, 9, 7),
+            catalog=catalog,
+        )
+        assert result["status"] == expected_status, (runtime, result)
+        assert result.get("severity") == expected_severity, (runtime, result)
+
+    def test_undeterminable_runtime_skips(self, catalog: Catalog) -> None:
+        result = _evaluate_functions_runtime_lifecycle(
+            None, None, today=date(2026, 9, 7), catalog=catalog
+        )
+        assert result["status"] == "skip"
+
+    def test_linux_consumption_v3_stop_date_escalates(self, catalog: Catalog) -> None:
+        fact = catalog.functions_runtime_plan_fact("3.x", "linux-consumption")
+        assert fact is not None and fact.support_end is not None
+        after = _evaluate_functions_runtime_lifecycle(
+            "~3",
+            "linux-consumption",
+            today=_last_day(fact.support_end) + timedelta(days=1),
+            catalog=catalog,
+        )
+        assert after["status"] == "fail"
+        assert after.get("severity") == "error"
+        detail = str(after.get("detail", ""))
+        assert "stop" in detail.lower() or "v3" in detail
+
+
+def _optional_fact(catalog: Catalog, plan: str) -> Optional[object]:
+    return catalog.hosting_plan_lifecycle_fact(plan)

--- a/tests/test_output_contract_schema.py
+++ b/tests/test_output_contract_schema.py
@@ -1,0 +1,140 @@
+"""Finding Contract schema validation and exit-code regression (issue #411).
+
+The prose contract in docs/json_output_contract.md now has a machine-readable
+counterpart (schemas/output-contract-2.0.schema.json, shipped in the wheel).
+These tests pin the contract end to end:
+
+- Representative skip/warn/fail findings validate against the schema.
+- Evidence fields, per-finding ``locations``, and the deterministic analysis
+  marker round-trip through the CLI.
+- Exit-code semantics regress: 0 when required checks pass, 1 on any required
+  failure, unchanged by optional warns.
+- Location fields stay scan-root-relative (never absolute paths).
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from azure_functions_doctor.cli import cli as app
+
+runner = CliRunner()
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = (
+    REPO_ROOT / "src" / "azure_functions_doctor" / "schemas" / "output-contract-2.0.schema.json"
+)
+
+
+@pytest.fixture(scope="module")
+def contract_schema() -> dict[str, Any]:
+    data: dict[str, Any] = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    return data
+
+
+def _doctor_json(path: Path, profile: str | None = None) -> tuple[int, dict[str, Any]]:
+    args = ["doctor", "--path", str(path), "--format", "json"]
+    if profile:
+        args += ["--profile", profile]
+    result = runner.invoke(app, args)
+    return result.exit_code, json.loads(result.output)
+
+
+def _write_warn_fixture(tmp_path: Path) -> None:
+    """A project whose findings exercise warn + evidence + locations paths."""
+    (tmp_path / "requirements.txt").write_text(
+        "azure-functions==1.25.0\nrequests>=2.0\n", encoding="utf-8"
+    )
+    (tmp_path / "function_app.py").write_text(
+        "import azure.functions as func\n\napp = func.FunctionApp()\n", encoding="utf-8"
+    )
+    (tmp_path / "host.json").write_text('{"version": "2.0"}', encoding="utf-8")
+
+
+class TestSchemaConformance:
+    def test_schema_file_ships_in_the_package(self) -> None:
+        import azure_functions_doctor.schemas as schemas_pkg
+
+        shipped = Path(schemas_pkg.__file__).parent / "output-contract-2.0.schema.json"
+        assert shipped.exists(), "schema must ship as package data"
+
+    def test_healthy_example_validates(self, contract_schema: dict[str, Any]) -> None:
+        from jsonschema import Draft7Validator
+
+        exit_code, data = _doctor_json(REPO_ROOT / "examples" / "v2" / "http-trigger")
+        assert exit_code == 0
+        Draft7Validator.check_schema(contract_schema)
+        errors = list(Draft7Validator(contract_schema).iter_errors(data))
+        assert not errors, "\n".join(e.message for e in errors)
+
+    def test_warn_fixture_with_locations_and_evidence_validates(
+        self, contract_schema: dict[str, Any], tmp_path: Path
+    ) -> None:
+        from jsonschema import Draft7Validator
+
+        _write_warn_fixture(tmp_path)
+        exit_code, data = _doctor_json(tmp_path, profile="full")
+        assert exit_code == 0  # warns only; nothing required fails
+
+        items = [i for s in data["results"] for i in s["items"]]
+        statuses = {i["status"] for i in items}
+        assert "warn" in statuses
+
+        errors = list(Draft7Validator(contract_schema).iter_errors(data))
+        assert not errors, "\n".join(e.message for e in errors)
+
+        # Finding Contract v2 round-trip: lifecycle findings carry evidence
+        # provenance and the deterministic marker.
+        lifecycle = next(i for i in items if i["rule_id"] == "check_python_runtime_lifecycle")
+        assert lifecycle["analysis"]["type"] == "deterministic"
+        assert lifecycle["source_url"].startswith("https://")
+        assert lifecycle["last_verified"]
+
+        # Per-finding locations round-trip: unpinned requirements carry lines.
+        unpinned = [i for i in items if i["rule_id"] == "check_unpinned_requirements"]
+        assert unpinned and unpinned[0]["locations"], "expected located findings"
+        assert unpinned[0]["locations"][0]["file"] == "requirements.txt"
+
+    def test_broken_example_validates_with_fail_status(
+        self, contract_schema: dict[str, Any], tmp_path: Path
+    ) -> None:
+        from jsonschema import Draft7Validator
+
+        exit_code, data = _doctor_json(REPO_ROOT / "examples" / "v2" / "broken-missing-host-json")
+        assert exit_code == 1
+        errors = list(Draft7Validator(contract_schema).iter_errors(data))
+        assert not errors, "\n".join(e.message for e in errors)
+
+        items = [i for s in data["results"] for i in s["items"]]
+        assert any(i["status"] == "fail" for i in items)
+
+    def test_location_fields_never_absolute(self, tmp_path: Path) -> None:
+        _write_warn_fixture(tmp_path)
+        _exit, data = _doctor_json(tmp_path, profile="full")
+        items = [i for s in data["results"] for i in s["items"]]
+        for item in items:
+            if item.get("file"):
+                assert not str(item["file"]).startswith("/"), item["file"]
+            for loc in item.get("locations", []) or []:
+                assert not str(loc.get("file", "")).startswith("/"), loc
+
+
+class TestExitCodeSemantics:
+    def test_pass_exits_zero(self) -> None:
+        exit_code, _ = _doctor_json(REPO_ROOT / "examples" / "v2" / "http-trigger")
+        assert exit_code == 0
+
+    def test_required_failure_exits_one(self) -> None:
+        exit_code, _ = _doctor_json(REPO_ROOT / "examples" / "v2" / "broken-missing-host-json")
+        assert exit_code == 1
+
+    def test_optional_warns_do_not_gate(self, tmp_path: Path) -> None:
+        """Warns (unpinned requirements, app insights) keep the exit code 0."""
+        _write_warn_fixture(tmp_path)
+        exit_code, data = _doctor_json(tmp_path, profile="full")
+        assert exit_code == 0
+        items = [i for s in data["results"] for i in s["items"]]
+        assert any(i["status"] == "warn" for i in items)


### PR DESCRIPTION
Closes #412 (P1). Catalog-derived parametrized matrix (Oracle decomposition item 4): plan×version membership through `is_supported_python_for_plan` incl. unknown-plan fallback; per-fact boundary dates for Python EOS (pass/info → fail/warning non-gating → fail/error gating) and hosting-plan retirement; runtime verdicts ~1–~4 with pinned-form normalization; linux-consumption v3 stop-date escalation. All expectations derived from `load_catalog()` — no hardcoded dates. 12 tests; full suite green, coverage 96.75%.