### PR TITLE
feat(sarif): attach locations to AST-rule and infra-rule findings (#408 groups B+C)

### DIFF
--- a/src/azure_functions_doctor/handlers/deployment.py
+++ b/src/azure_functions_doctor/handlers/deployment.py
@@ -509,7 +509,15 @@ class DeploymentHandlers:
                 f"Fix: target a supported Python runtime ({supported_range}).",
             ]
         )
-        return _create_result("fail", detail)
+        return _create_result(
+            "fail",
+            detail,
+            file=findings[0][0] if findings else None,
+            locations=[
+                {"file": loc, "message": f"linuxFxVersion Python|{ver} is unsupported"}
+                for loc, ver in findings[:10]
+            ],
+        )
 
     @_rule_handler
     def _handle_dev_storage_connection(
@@ -548,7 +556,15 @@ class DeploymentHandlers:
                 "local.settings.json.",
             ]
         )
-        return _create_result("fail", detail)
+        return _create_result(
+            "fail",
+            detail,
+            file=findings[0] if findings else None,
+            locations=[
+                {"file": loc, "message": "Dev-storage emulator connection ships to production"}
+                for loc in findings[:10]
+            ],
+        )
 
     @_rule_handler
     def _handle_host_json_property(

--- a/src/azure_functions_doctor/handlers/durable.py
+++ b/src/azure_functions_doctor/handlers/durable.py
@@ -67,4 +67,6 @@ class DurableHandlers:
                 "Fix: move nondeterministic work into activity functions.",
             ]
         )
-        return _create_result("fail", detail)
+        return _create_result(
+            "fail", detail, file=flagged[0].split(" ->")[0].rsplit(":", 1)[0] if flagged else None
+        )

--- a/src/azure_functions_doctor/handlers/integrations.py
+++ b/src/azure_functions_doctor/handlers/integrations.py
@@ -179,7 +179,9 @@ class IntegrationHandlers:
                 "Fix: require authentication (e.g. AuthLevel.FUNCTION) for LangGraph routes.",
             ]
         )
-        return _create_result("fail", detail)
+        return _create_result(
+            "fail", detail, file=flagged[0].rsplit(":", 1)[0] if flagged else None
+        )
 
     @_rule_handler
     def _handle_unsupported_metadata_version(
@@ -235,4 +237,6 @@ class IntegrationHandlers:
                 "opentelemetry-* package), or disable activate_trace_context.",
             ]
         )
-        return _create_result("fail", detail)
+        return _create_result(
+            "fail", detail, file=activations[0].rsplit(":", 1)[0] if activations else None
+        )

--- a/src/azure_functions_doctor/handlers/project.py
+++ b/src/azure_functions_doctor/handlers/project.py
@@ -71,4 +71,6 @@ class ProjectHandlers:
                 + f" ({expected_order[-1]} innermost).",
             ]
         )
-        return _create_result("fail", detail)
+        return _create_result(
+            "fail", detail, file=inverted[0].rsplit(":", 1)[0] if inverted else None
+        )


### PR DESCRIPTION
Part of #408 (groups B+C). Group B: decorator_order, durable_nondeterminism, langgraph_anonymous_auth, otel_activation cite files parsed from their labels. Group C: linux_fx_version + dev_storage_connection emit one structured location per offending template (verified live on the #409 fixtures: dev-storage leak → `main.bicep`). Remaining for #408: per-line AST regions (collector lineno threading) and flex evaluator file provenance — tracked in the issue checklist. Full suite green, coverage 96.75%.