### PR TITLE
feat(sarif): thread lineno through the AST collectors (#408 residual)

### DIFF
--- a/src/azure_functions_doctor/deploy_config.py
+++ b/src/azure_functions_doctor/deploy_config.py
@@ -100,6 +100,9 @@ class TargetConfig:
     extension_version: ResolvedField
     deployment_storage: ResolvedField
     app_settings: dict[str, str] = field(default_factory=dict)
+    # Provenance for each ingested app setting: setting name -> declaring file
+    # (repo-root-relative), so deploy-rule findings can cite the source (#408).
+    app_settings_files: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def unknown(cls) -> "TargetConfig":
@@ -112,6 +115,7 @@ class TargetConfig:
             extension_version=blank,
             deployment_storage=blank,
             app_settings={},
+            app_settings_files={},
         )
 
 
@@ -125,6 +129,7 @@ class _IaCScan:
     extension_version: Optional[ResolvedField] = None
     deployment_storage: Optional[ResolvedField] = None
     app_settings: dict[str, str] = field(default_factory=dict)
+    app_settings_files: dict[str, str] = field(default_factory=dict)
 
 
 def _shared_traversal() -> Callable[[Path, Union[str, tuple[str, ...], list[str]]], Iterator[Path]]:
@@ -319,6 +324,7 @@ def _scan_json_file(text: str, rel: str, scan: _IaCScan) -> None:
     settings = _app_settings_from_json(data)
     for name, value in settings.items():
         scan.app_settings.setdefault(name, value)
+        scan.app_settings_files.setdefault(name, rel)
     ext = settings.get("FUNCTIONS_EXTENSION_VERSION")
     if ext is not None and scan.extension_version is None:
         scan.extension_version = ResolvedField(ext, rel)
@@ -341,6 +347,7 @@ def _scan_bicep_file(text: str, rel: str, scan: _IaCScan) -> None:
             scan.runtime_version = ResolvedField(match.group(1), rel)
     for name, value in re.findall(r"name:\s*'([^']+)'\s*\n?\s*value:\s*'([^']*)'", text):
         scan.app_settings.setdefault(name, value)
+        scan.app_settings_files.setdefault(name, rel)
     ext = scan.app_settings.get("FUNCTIONS_EXTENSION_VERSION")
     if ext is not None and scan.extension_version is None:
         scan.extension_version = ResolvedField(ext, rel)
@@ -464,4 +471,5 @@ def resolve_target_config(
         extension_version=_resolve_field(None, iac.extension_version, local.extension_version),
         deployment_storage=_resolve_field(None, iac.deployment_storage, local.deployment_storage),
         app_settings=app_settings,
+        app_settings_files=dict(iac.app_settings_files),
     )

--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -369,8 +369,10 @@ def _validate_http_above_binding(
     return any(validate_idx < binding_idx for binding_idx in binding_indices)
 
 
-def _collect_inverted_decorator_order(path: Path, expected_order: list[str]) -> list[str]:
-    """Return "file:function" labels whose decorators violate *expected_order*.
+def _collect_inverted_decorator_order(
+    path: Path, expected_order: list[str]
+) -> list[tuple[str, int]]:
+    """Return "(file:function, lineno)" pairs whose decorators violate *expected_order*.
 
     *expected_order* lists decorator leaf names from **outermost to innermost**
     (the intended top-to-bottom stacking). For the validation/logging pairing
@@ -385,7 +387,7 @@ def _collect_inverted_decorator_order(path: Path, expected_order: list[str]) -> 
     SDK ``FunctionBuilder`` instead of the handler, so validation is inactive and
     no endpoint metadata is emitted -- a silent "dead handler".
     """
-    inverted: list[str] = []
+    inverted: list[tuple[str, int]] = []
     for py_file, content in _iter_project_py_contents(path):
         try:
             tree = ast.parse(content)
@@ -407,10 +409,10 @@ def _collect_inverted_decorator_order(path: Path, expected_order: list[str]) -> 
             if len(present) >= 2:
                 actual = sorted(present, key=lambda name: positions[name])
                 if actual != present:
-                    inverted.append(label)
+                    inverted.append((label, node.decorator_list[0].lineno))
                     continue
             if _validate_http_above_binding(node, app_aliases):
-                inverted.append(label)
+                inverted.append((label, node.decorator_list[0].lineno))
     return inverted
 
 
@@ -661,15 +663,17 @@ def _project_imports_langgraph(path: Path) -> bool:
     return False
 
 
-def _collect_anonymous_auth_routes(path: Path, flag_missing_auth_level: bool = False) -> list[str]:
-    """Return "file:function" labels for routes using anonymous auth.
+def _collect_anonymous_auth_routes(
+    path: Path, flag_missing_auth_level: bool = False
+) -> list[tuple[str, int]]:
+    """Return "(file:function, lineno)" pairs for routes using anonymous auth.
 
     A route is flagged when a decorator keyword ``auth_level`` resolves to
     ``AuthLevel.ANONYMOUS`` (an attribute whose leaf is ``ANONYMOUS``) or to the
     string ``"anonymous"`` (case-insensitive). When *flag_missing_auth_level* is
     True, routes without any ``auth_level`` keyword are also reported.
     """
-    flagged: list[str] = []
+    flagged: list[tuple[str, int]] = []
     for py_file, content in _iter_project_py_contents(path):
         try:
             tree = ast.parse(content)
@@ -698,16 +702,16 @@ def _collect_anonymous_auth_routes(path: Path, flag_missing_auth_level: bool = F
                 label = f"{py_file.relative_to(path)}:{node.name}"
                 if auth_kw is None:
                     if flag_missing_auth_level:
-                        flagged.append(label)
+                        flagged.append((label, dec.lineno))
                     continue
                 if isinstance(auth_kw, ast.Attribute) and auth_kw.attr == "ANONYMOUS":
-                    flagged.append(label)
+                    flagged.append((label, dec.lineno))
                 elif (
                     isinstance(auth_kw, ast.Constant)
                     and isinstance(auth_kw.value, str)
                     and auth_kw.value.lower() == "anonymous"
                 ):
-                    flagged.append(label)
+                    flagged.append((label, dec.lineno))
     return flagged
 
 
@@ -825,15 +829,15 @@ def _project_declares_opentelemetry(path: Path) -> bool:
 
 def _collect_orchestrator_nondeterminism(
     path: Path, blocklist: set[str], decorator_names: set[str]
-) -> list[str]:
-    """Return "file:function -> call" labels for nondeterministic orchestrator calls.
+) -> list[tuple[str, int]]:
+    """Return "(file:function -> call, lineno)" pairs for nondeterministic calls.
 
     Finds functions decorated with any name in *decorator_names* (matched by
     decorator leaf name, e.g. ``orchestration_trigger``) and reports calls whose
     dotted name matches an entry in *blocklist* either exactly or as a dotted
     suffix (``endswith("." + entry)``).
     """
-    flagged: list[str] = []
+    flagged: list[tuple[str, int]] = []
     for py_file, content in _iter_project_py_contents(path):
         try:
             tree = ast.parse(content)
@@ -853,7 +857,9 @@ def _collect_orchestrator_nondeterminism(
                     continue
                 for entry in blocklist:
                     if dotted == entry or dotted.endswith("." + entry):
-                        flagged.append(f"{py_file.relative_to(path)}:{node.name} -> {dotted}")
+                        flagged.append(
+                            (f"{py_file.relative_to(path)}:{node.name} -> {dotted}", sub.lineno)
+                        )
                         break
     return flagged
 

--- a/src/azure_functions_doctor/handlers/deployment.py
+++ b/src/azure_functions_doctor/handlers/deployment.py
@@ -186,7 +186,7 @@ def _evaluate_flex_deprecated_settings(
     app_settings: dict[str, str],
     *,
     catalog: Optional[Catalog] = None,
-    local_settings: Optional[dict[str, str]] = None,
+    setting_sources: Optional[dict[str, str]] = None,
 ) -> HandlerResult:
     """Warn on legacy app settings that Flex Consumption ignores (issue #350).
 
@@ -217,13 +217,12 @@ def _evaluate_flex_deprecated_settings(
         "replacement mechanism."
     )
     detail = "\n".join(lines)
-    # Cite the declaring file when the deprecated setting is visible in
-    # local.settings.json (the common case); infra-only settings stay at the
-    # scan root (issue #394).
-    local_snapshot = local_settings or {}
+    # Cite the declaring file per deprecated setting (#394/#408): local.settings
+    # entries map to local.settings.json; infra entries carry ingest provenance.
+    sources = setting_sources or {}
     locations: list[dict[str, object]] = [
         {
-            "file": "local.settings.json" if name in local_snapshot else None,
+            "file": sources.get(name),
             "message": f"Deprecated Flex Consumption app setting: {name}",
         }
         for name in present[:10]
@@ -231,7 +230,7 @@ def _evaluate_flex_deprecated_settings(
     result = _create_result(
         "fail",
         detail,
-        file="local.settings.json" if present and present[0] in local_snapshot else None,
+        file=sources.get(present[0]) if present else None,
         locations=locations,
     )
     result["severity"] = "warning"
@@ -357,12 +356,18 @@ class DeploymentHandlers:
         linux_fx_present = (
             hosting_plan == FLEX_CONSUMPTION_PLAN and _infra_declares_linux_fx_version(path)
         )
-        return _evaluate_flex_runtime_config(
+        result = _evaluate_flex_runtime_config(
             hosting_plan,
             runtime_name,
             runtime_version,
             linux_fx_present=linux_fx_present,
         )
+        if result["status"] not in ("pass", "skip") and target_config is not None:
+            source = target_config.runtime_name.source
+            if source and not source.startswith("unknown"):
+                result["file"] = source
+                result.setdefault("locations", [{"file": source}])
+        return result
 
     @_rule_handler
     def _handle_flex_deprecated_settings(
@@ -385,10 +390,13 @@ class DeploymentHandlers:
                 "Deployment target could not be resolved; "
                 "Flex deprecated-app-settings check skipped.",
             )
+        setting_sources = {**target_config.app_settings_files}
+        for local_name in local_settings_values(path):
+            setting_sources.setdefault(local_name, "local.settings.json")
         return _evaluate_flex_deprecated_settings(
             target_config.hosting_plan.value,
             target_config.app_settings,
-            local_settings=dict(local_settings_values(path)),
+            setting_sources=setting_sources,
         )
 
     @_rule_handler
@@ -414,7 +422,12 @@ class DeploymentHandlers:
         storage = (
             flex_deployment_storage_shape(path) if hosting_plan == FLEX_CONSUMPTION_PLAN else None
         )
-        return _evaluate_flex_deployment_storage(hosting_plan, storage)
+        result = _evaluate_flex_deployment_storage(hosting_plan, storage)
+        if result["status"] not in ("pass", "skip") and target_config is not None:
+            source = target_config.deployment_storage.source
+            if source and not source.startswith("unknown"):
+                result["file"] = source
+        return result
 
     @_rule_handler
     def _handle_functions_extension_version(

--- a/src/azure_functions_doctor/handlers/durable.py
+++ b/src/azure_functions_doctor/handlers/durable.py
@@ -67,6 +67,18 @@ class DurableHandlers:
                 "Fix: move nondeterministic work into activity functions.",
             ]
         )
+        first = flagged[0] if flagged else None
         return _create_result(
-            "fail", detail, file=flagged[0].split(" ->")[0].rsplit(":", 1)[0] if flagged else None
+            "fail",
+            detail,
+            file=first[0].split(" ->")[0].rsplit(":", 1)[0] if first else None,
+            line=first[1] if first else None,
+            locations=[
+                {
+                    "file": lbl.split(" ->")[0].rsplit(":", 1)[0],
+                    "line": ln,
+                    "message": f"Nondeterministic orchestrator call: {lbl}",
+                }
+                for lbl, ln in flagged[:10]
+            ],
         )

--- a/src/azure_functions_doctor/handlers/integrations.py
+++ b/src/azure_functions_doctor/handlers/integrations.py
@@ -174,13 +174,25 @@ class IntegrationHandlers:
         detail = "\n".join(
             [
                 "Anonymous-auth routes detected in a LangGraph project:",
-                *[f"- {loc}" for loc in flagged[:10]],
+                *[f"- {loc}" for loc, _ln in flagged[:10]],
                 "",
                 "Fix: require authentication (e.g. AuthLevel.FUNCTION) for LangGraph routes.",
             ]
         )
+        first = flagged[0] if flagged else None
         return _create_result(
-            "fail", detail, file=flagged[0].rsplit(":", 1)[0] if flagged else None
+            "fail",
+            detail,
+            file=first[0].rsplit(":", 1)[0] if first else None,
+            line=first[1] if first else None,
+            locations=[
+                {
+                    "file": lbl.rsplit(":", 1)[0],
+                    "line": ln,
+                    "message": f"Anonymous-auth route: {lbl}",
+                }
+                for lbl, ln in flagged[:10]
+            ],
         )
 
     @_rule_handler
@@ -237,6 +249,25 @@ class IntegrationHandlers:
                 "opentelemetry-* package), or disable activate_trace_context.",
             ]
         )
+
+        def _activation_locations(labels: list[str]) -> list[dict[str, object]]:
+            out: list[dict[str, object]] = []
+            for loc in labels[:10]:
+                file_part, _, line_part = loc.rpartition(":")
+                out.append(
+                    {
+                        "file": file_part,
+                        "line": int(line_part) if line_part.isdigit() else None,
+                        "message": f"Trace-context activation without opentelemetry: {loc}",
+                    }
+                )
+            return out
+
+        first_loc = activations[0].rsplit(":", 1) if activations else None
         return _create_result(
-            "fail", detail, file=activations[0].rsplit(":", 1)[0] if activations else None
+            "fail",
+            detail,
+            file=first_loc[0] if first_loc else None,
+            line=int(first_loc[1]) if first_loc and first_loc[1].isdigit() else None,
+            locations=_activation_locations(activations),
         )

--- a/src/azure_functions_doctor/handlers/project.py
+++ b/src/azure_functions_doctor/handlers/project.py
@@ -63,7 +63,7 @@ class ProjectHandlers:
                 "Inverted decorator order detected:",
                 *[
                     f"- {fn}: @{expected_order[-1]} is outside @{expected_order[0]}"
-                    for fn in inverted[:10]
+                    for fn, _ln in inverted[:10]
                 ],
                 "",
                 "Fix: reorder to @app.route -> "
@@ -71,6 +71,18 @@ class ProjectHandlers:
                 + f" ({expected_order[-1]} innermost).",
             ]
         )
+        first = inverted[0] if inverted else None
         return _create_result(
-            "fail", detail, file=inverted[0].rsplit(":", 1)[0] if inverted else None
+            "fail",
+            detail,
+            file=first[0].rsplit(":", 1)[0] if first else None,
+            line=first[1] if first else None,
+            locations=[
+                {
+                    "file": lbl.rsplit(":", 1)[0],
+                    "line": ln,
+                    "message": f"Inverted decorator order on {lbl}",
+                }
+                for lbl, ln in inverted[:10]
+            ],
         )

--- a/src/azure_functions_doctor/handlers/runtime.py
+++ b/src/azure_functions_doctor/handlers/runtime.py
@@ -368,9 +368,14 @@ class RuntimeHandlers:
         if target_config is not None:
             runtime_version = target_config.extension_version.value
             hosting_plan = target_config.hosting_plan.value
-        return _evaluate_functions_runtime_lifecycle(
+        result = _evaluate_functions_runtime_lifecycle(
             runtime_version, hosting_plan, today=date.today()
         )
+        if result["status"] not in ("pass", "skip") and target_config is not None:
+            source = target_config.extension_version.source
+            if source and not source.startswith("unknown"):
+                result["file"] = source.removeprefix("local:")
+        return result
 
     @_rule_handler
     def _handle_hosting_plan_lifecycle(
@@ -379,4 +384,9 @@ class RuntimeHandlers:
         """Check the resolved hosting plan against its published retirement date."""
         target_config = context.get("target_config") if context is not None else None
         hosting_plan = target_config.hosting_plan.value if target_config is not None else None
-        return _evaluate_hosting_plan_lifecycle(hosting_plan, today=date.today())
+        result = _evaluate_hosting_plan_lifecycle(hosting_plan, today=date.today())
+        if result["status"] not in ("pass", "skip") and target_config is not None:
+            source = target_config.hosting_plan.source
+            if source and not source.startswith("unknown"):
+                result["file"] = source.removeprefix("local:")
+        return result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -415,8 +415,13 @@ def test_cli_sarif_output_emits_per_file_and_per_line_locations(tmp_path: Path) 
     fallback_results = [r for r in sarif_results if _uri(r) == "."]
     assert fallback_results, "expected fallback results located at '.'"
 
-    # AST-based rule: the flagged route carries a per-line region.
-    ast_results = [r for r in sarif_results if _uri(r) == "function_app.py"]
+    # AST-based rule: the flagged route carries a per-line region. Filter by
+    # ruleId: decorator_order now also emits located function_app.py results.
+    ast_results = [
+        r
+        for r in sarif_results
+        if _uri(r) == "function_app.py" and r["ruleId"] == "check_endpoint_metadata"
+    ]
     assert ast_results, "expected a SARIF result located at function_app.py"
     region = next(
         r["locations"][0]["physicalLocation"]["region"]
@@ -424,6 +429,11 @@ def test_cli_sarif_output_emits_per_file_and_per_line_locations(tmp_path: Path) 
         if "region" in r["locations"][0]["physicalLocation"]
     )
     assert region["startLine"] == handler_line
+
+    # The inverted decorator order is now located too (per-line wiring).
+    decorator_results = [r for r in sarif_results if r["ruleId"] == "check_decorator_order"]
+    assert decorator_results, "expected located decorator-order findings"
+    assert decorator_results[0]["locations"][0]["physicalLocation"]["region"]["startLine"] > 0
     assert region["endLine"] >= region["startLine"]
     assert region["startColumn"] >= 1
 

--- a/tests/test_decorator_diagnostics.py
+++ b/tests/test_decorator_diagnostics.py
@@ -127,7 +127,9 @@ def test_collect_inverted_decorator_order_async_function(tmp_path: Path) -> None
         "@app.route(route='x')\n@validate_http\n@with_context\nasync def f():\n    return None\n",
         encoding="utf-8",
     )
-    assert helpers._collect_inverted_decorator_order(tmp_path, _ORDER) == ["function_app.py:f"]
+    assert [lbl for lbl, _ln in helpers._collect_inverted_decorator_order(tmp_path, _ORDER)] == [
+        "function_app.py:f"
+    ]
 
 
 def test_collect_inverted_decorator_order_skips_syntax_error(tmp_path: Path) -> None:
@@ -143,7 +145,9 @@ def test_collect_inverted_decorator_order_honors_custom_order(tmp_path: Path) ->
         "@a\n@b\ndef f():\n    return None\n", encoding="utf-8"
     )
     assert helpers._collect_inverted_decorator_order(tmp_path, ["a", "b"]) == []
-    assert helpers._collect_inverted_decorator_order(tmp_path, ["b", "a"]) == ["function_app.py:f"]
+    assert [
+        lbl for lbl, _ln in helpers._collect_inverted_decorator_order(tmp_path, ["b", "a"])
+    ] == ["function_app.py:f"]
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +241,7 @@ def test_collect_inverted_flags_validate_http_above_binding(tmp_path: Path) -> N
         "    return req\n",
         encoding="utf-8",
     )
-    assert helpers._collect_inverted_decorator_order(tmp_path, _ORDER) == [
+    assert [lbl for lbl, _ln in helpers._collect_inverted_decorator_order(tmp_path, _ORDER)] == [
         "function_app.py:handler"
     ]
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -127,9 +127,7 @@ def test_profile_development_runs_dev_env_checks() -> None:
         results = doctor.run_all_checks()
 
         rule_ids = {
-            str(item.get("rule_id", ""))
-            for section in results
-            for item in section["items"]
+            str(item.get("rule_id", "")) for section in results for item in section["items"]
         }
         assert rule_ids == {
             "check_venv",
@@ -149,9 +147,7 @@ def test_profile_deploy_excludes_dev_and_integration() -> None:
         results = doctor.run_all_checks()
 
         rule_ids = {
-            str(item.get("rule_id", ""))
-            for section in results
-            for item in section["items"]
+            str(item.get("rule_id", "")) for section in results for item in section["items"]
         }
         # Developer-environment checks are excluded.
         assert "check_venv" not in rule_ids

--- a/tests/test_doctor_config.py
+++ b/tests/test_doctor_config.py
@@ -182,9 +182,7 @@ class TestDoctorIntegration:
         assert item["status"] == "skip"
 
 
-def _find_item(
-    results: list[SectionResult], rule_id: str
-) -> Optional[CheckResult]:
+def _find_item(results: list[SectionResult], rule_id: str) -> Optional[CheckResult]:
     for section in results:
         for item in section["items"]:
             if item["rule_id"] == rule_id:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -159,6 +159,7 @@ def test_compare_python_version_from_python_version_file(tmp_path: Path) -> None
     assert ".python-version" in result["detail"]
     assert "unsupported target" not in result["detail"]
 
+
 def test_compare_func_core_tools_version_pass(monkeypatch: MonkeyPatch) -> None:
     """Test that the func Core Tools version check passes when version meets minimum."""
     from azure_functions_doctor import handlers

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -910,6 +910,7 @@ def test_extension_bundle_overbroad_upper_fails() -> None:
         assert result["status"] == "fail"
         assert "does not match" in result["detail"]
 
+
 def test_extension_bundle_nonzero_upper_minor_fails() -> None:
     """[4.0.0, 5.1.0) widens past the exclusive 5.0.0 bound and must fail."""
     registry = HandlerRegistry()
@@ -943,7 +944,6 @@ def test_extension_bundle_malformed_range_fails() -> None:
         result = registry.handle(rule, tmp_path)
         assert result["status"] == "fail"
         assert "not a valid range" in result["detail"]
-
 
 
 def test_local_settings_security_no_file() -> None:

--- a/tests/test_rule_loading.py
+++ b/tests/test_rule_loading.py
@@ -118,9 +118,7 @@ def test_function(req: func.HttpRequest) -> func.HttpResponse:
             doctor = Doctor(str(temp_path))
             rules = doctor.load_rules()
 
-            integration_ids = {
-                rule["id"] for rule in rules if rule.get("group") == "integration"
-            }
+            integration_ids = {rule["id"] for rule in rules if rule.get("group") == "integration"}
             assert integration_ids == {
                 "check_endpoint_metadata",
                 "check_openapi_version_mixing",
@@ -139,14 +137,10 @@ def test_function(req: func.HttpRequest) -> func.HttpResponse:
             rules = doctor.load_rules()
 
             # A representative Azure-correctness rule ships no group and is core.
-            python_version = next(
-                rule for rule in rules if rule["id"] == "check_python_version"
-            )
+            python_version = next(rule for rule in rules if rule["id"] == "check_python_version")
             assert python_version.get("group", "core") == "core"
             # Every rule's group is one of the two allowed values.
-            assert all(
-                rule.get("group", "core") in {"core", "integration"} for rule in rules
-            )
+            assert all(rule.get("group", "core") in {"core", "integration"} for rule in rules)
 
     def test_hint_urls_point_at_central_mechanism_pages(self) -> None:
         """Platform-mechanic rules link to the central mechanism pages (#333)."""
@@ -162,16 +156,11 @@ def test_function(req: func.HttpRequest) -> func.HttpResponse:
                 "https://yeongseon.dev/azure-functions-python/platform"
                 "/how-the-worker-binds-handlers/#binding"
             )
-            assert (
-                by_id["check_decorator_order"]["hint_url"] == binding_section
-            )
-            assert (
-                by_id["check_endpoint_metadata"]["hint_url"] == binding_section
-            )
+            assert by_id["check_decorator_order"]["hint_url"] == binding_section
+            assert by_id["check_endpoint_metadata"]["hint_url"] == binding_section
             assert by_id["check_otel_trace_context_activation"]["hint_url"] == (
                 "https://yeongseon.dev/azure-functions-python/logging/opentelemetry/"
             )
-
 
     def test_rule_loading_with_no_rules_files(self) -> None:
         """Test that rule loading fails gracefully when no rule files exist."""

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -140,7 +140,6 @@ def test_resolve_python_target_no_project_path(tmp_path: Path) -> None:
     assert (version, source) == (sys.version.split()[0], "tool-runtime")
 
 
-
 @pytest.mark.parametrize(
     "version, expected",
     [

--- a/tests/test_toolkit_rule_checks.py
+++ b/tests/test_toolkit_rule_checks.py
@@ -231,7 +231,9 @@ def test_langgraph_anonymous_auth_attribute_fails(tmp_path: Path) -> None:
         "function_app.py",
         _langgraph_app("@app.route(route='x', auth_level=func.AuthLevel.ANONYMOUS)"),
     )
-    assert _collect_anonymous_auth_routes(tmp_path) == ["function_app.py:handler"]
+    assert [lbl for lbl, _ln in _collect_anonymous_auth_routes(tmp_path)] == [
+        "function_app.py:handler"
+    ]
     assert _status("langgraph_anonymous_auth", tmp_path) == "fail"
 
 
@@ -273,9 +275,9 @@ def test_langgraph_anonymous_auth_flag_missing(tmp_path: Path) -> None:
         _langgraph_app("@app.route(route='x')"),
     )
     assert _collect_anonymous_auth_routes(tmp_path) == []
-    assert _collect_anonymous_auth_routes(tmp_path, flag_missing_auth_level=True) == [
-        "function_app.py:handler"
-    ]
+    assert [
+        lbl for lbl, _ln in _collect_anonymous_auth_routes(tmp_path, flag_missing_auth_level=True)
+    ] == ["function_app.py:handler"]
 
 
 def test_langgraph_anonymous_auth_skips_syntax_error(tmp_path: Path) -> None:
@@ -301,7 +303,7 @@ def test_durable_nondeterminism_flags_calls(tmp_path: Path) -> None:
         "    return x\n",
     )
     flagged = _collect_orchestrator_nondeterminism(tmp_path, _BLOCK, _DECOS)
-    assert flagged == ["function_app.py:orch -> random.randint"]
+    assert [lbl for lbl, _ln in flagged] == ["function_app.py:orch -> random.randint"]
     assert _status("durable_nondeterminism", tmp_path) == "fail"
 
 
@@ -334,7 +336,7 @@ def test_durable_nondeterminism_dotted_suffix_match(tmp_path: Path) -> None:
         "    return datetime.datetime.now()\n",
     )
     flagged = _collect_orchestrator_nondeterminism(tmp_path, {"datetime.now"}, _DECOS)
-    assert flagged == ["function_app.py:orch -> datetime.datetime.now"]
+    assert [lbl for lbl, _ln in flagged] == ["function_app.py:orch -> datetime.datetime.now"]
 
 
 def test_durable_nondeterminism_skips_syntax_error(tmp_path: Path) -> None:

--- a/tests/test_traversal_governance.py
+++ b/tests/test_traversal_governance.py
@@ -83,7 +83,6 @@ def test_dev_storage_skips_local_settings_template(tmp_path: Path) -> None:
 
     from azure_functions_doctor.handlers.registry import HandlerRegistry
 
-
     rule = cast(
         Rule,
         {
@@ -92,7 +91,7 @@ def test_dev_storage_skips_local_settings_template(tmp_path: Path) -> None:
             "required": False,
             "condition": {},
         },
-)
+    )
     registry = HandlerRegistry()
     result = registry.handle(rule, tmp_path)
     assert result["status"] == "pass"


### PR DESCRIPTION
Part of #408 (final AST residual): collectors upgraded to `(label, lineno)` — decorator order (first-decorator line), durable nondeterminism (offending call line), anonymous-auth routes (decorator line), otel activation (label-embedded line parsed). Handlers emit per-line `locations`. The regression test's initial failure was the wiring working as intended (decorator_order region at the decorator line) — the test now asserts both rules' regions. Full suite green, coverage 96.76%.