### PR TITLE
fix(rules): skip scan_before_spec without an azure-functions-openapi dependency

### DIFF
--- a/src/azure_functions_doctor/handlers/_helpers.py
+++ b/src/azure_functions_doctor/handlers/_helpers.py
@@ -416,6 +416,21 @@ def _collect_inverted_decorator_order(
     return inverted
 
 
+def _project_declares_openapi_dep(path: Path) -> bool:
+    """Return True when ``azure-functions-openapi`` is declared in
+    ``requirements.txt``. Missing/unreadable file counts as not declared; the
+    scan-before-spec and version-mixing rules are meaningless without it
+    (generic ``build``/``create_spec`` call names belong to other libraries).
+    """
+    req_path = path / "requirements.txt"
+    if not req_path.exists():
+        return False
+    content = _read_project_python_file(req_path)
+    if content is None:
+        return False
+    return canonicalize_name("azure-functions-openapi") in _parse_requirements_names(content)
+
+
 def _project_declares_validation_dep(path: Path) -> bool:
     """Return True when ``azure-functions-validation`` is declared in
     ``requirements.txt``. Missing or unreadable file counts as not declared.

--- a/src/azure_functions_doctor/handlers/integrations.py
+++ b/src/azure_functions_doctor/handlers/integrations.py
@@ -17,6 +17,7 @@ from azure_functions_doctor.handlers._helpers import (
     _collect_unsupported_metadata_versions,
     _create_result,
     _project_activates_trace_context,
+    _project_declares_openapi_dep,
     _project_declares_opentelemetry,
     _project_declares_validation_dep,
     _project_imports_langgraph,
@@ -102,6 +103,11 @@ class IntegrationHandlers:
         self, rule: Rule, path: Path, context: Optional[RuleContext] = None
     ) -> HandlerResult:
         """Detect when the OpenAPI spec is built before endpoints are scanned."""
+        if not _project_declares_openapi_dep(path):
+            return _create_result(
+                "skip",
+                "azure-functions-openapi not declared; scan-before-spec check skipped",
+            )
         condition = rule.get("condition", {}) or {}
         scan_names = set(
             condition.get("scan_names")

--- a/tests/test_toolkit_rule_checks.py
+++ b/tests/test_toolkit_rule_checks.py
@@ -117,6 +117,7 @@ def test_openapi_version_mixing_skips_syntax_error(tmp_path: Path) -> None:
 
 
 def test_scan_before_spec_spec_before_scan_fails(tmp_path: Path) -> None:
+    _write(tmp_path, "requirements.txt", "azure-functions-openapi==0.24.0\n")
     _write(
         tmp_path,
         "app.py",
@@ -129,11 +130,13 @@ def test_scan_before_spec_spec_before_scan_fails(tmp_path: Path) -> None:
 
 
 def test_scan_before_spec_correct_order_passes(tmp_path: Path) -> None:
+    _write(tmp_path, "requirements.txt", "azure-functions-openapi==0.24.0\n")
     _write(tmp_path, "app.py", "scan()\nbuild_spec()\n")
     assert _status("scan_before_spec", tmp_path) == "pass"
 
 
 def test_scan_before_spec_spec_without_scan_fails(tmp_path: Path) -> None:
+    _write(tmp_path, "requirements.txt", "azure-functions-openapi==0.24.0\n")
     _write(tmp_path, "app.py", "build_spec()\n")
     assert _collect_scan_before_spec(tmp_path, {"scan"}, {"build_spec"})[0] == ["app.py:build_spec"]
     assert _status("scan_before_spec", tmp_path) == "fail"
@@ -145,6 +148,7 @@ def test_scan_before_spec_no_spec_passes(tmp_path: Path) -> None:
 
 
 def test_scan_before_spec_custom_names(tmp_path: Path) -> None:
+    _write(tmp_path, "requirements.txt", "azure-functions-openapi==0.24.0\n")
     _write(tmp_path, "app.py", "make_spec()\ndiscover()\n")
     assert (
         _status(
@@ -156,10 +160,18 @@ def test_scan_before_spec_custom_names(tmp_path: Path) -> None:
     )
 
 
+def test_scan_before_spec_skips_without_openapi_dependency(tmp_path: Path) -> None:
+    """Non-OpenAPI build() calls (e.g. durable-graph .build()) must not trip (#426)."""
+    _write(tmp_path, "app.py", "graph = GraphBuilder(nodes).build()\n")
+    _write(tmp_path, "requirements.txt", "azure-functions-durable-graph==0.3.0\n")
+    assert _status("scan_before_spec", tmp_path) == "skip"
+
+
 def test_scan_before_spec_real_openapi_names_default_condition(tmp_path: Path) -> None:
     # Regression (#248): the real azure-functions-openapi call names must be
     # recognised by the built-in default names baked into the handler, so the
     # rule fires even though v2.json's condition does not re-list them.
+    _write(tmp_path, "requirements.txt", "azure-functions-openapi==0.24.0\n")
     _write(
         tmp_path,
         "app.py",
@@ -170,6 +182,7 @@ def test_scan_before_spec_real_openapi_names_default_condition(tmp_path: Path) -
 
 def test_scan_before_spec_real_openapi_names_correct_order_passes(tmp_path: Path) -> None:
     # Regression (#248): scanning before building the spec passes with defaults.
+    _write(tmp_path, "requirements.txt", "azure-functions-openapi==0.24.0\n")
     _write(
         tmp_path,
         "app.py",


### PR DESCRIPTION
Closes #426 (from the 80-project cookbook soak). Adds the sibling-style dependency gate; durable-graph `.build()` shape regression-tested to skip; handler tests updated to declare the dep. Soak rerun: FP gone, 0 crashes / 0 contract violations across all 80 real projects.