### PR TITLE
fix(ci): exclude machine-level rules from the soak baseline comparison

### DIFF
--- a/scripts/cookbook_soak_baseline.json
+++ b/scripts/cookbook_soak_baseline.json
@@ -5,9 +5,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/ai-and-agents/durable_ai_pipeline": [
     "check_app_insights",
@@ -16,9 +14,7 @@
     "check_durabletask_config",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/ai-and-agents/embedding_vector_search": [
     "check_app_insights",
@@ -26,9 +22,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/ai-and-agents/knowledge_notion_search": [
     "check_app_insights",
@@ -36,9 +30,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/ai-and-agents/langgraph_agent": [
     "check_app_insights",
@@ -46,9 +38,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/ai-and-agents/langgraph_rag_agent": [
     "check_app_insights",
@@ -56,9 +46,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/ai-and-agents/langgraph_tool_use": [
     "check_app_insights",
@@ -66,19 +54,15 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/ai-and-agents/mcp_server_example": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/ai-and-agents/openai_direct_chat": [
     "check_app_insights",
@@ -86,9 +70,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/ai-and-agents/rag_knowledge_api": [
     "check_app_insights",
@@ -96,9 +78,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/ai-and-agents/streaming_ai_response": [
     "check_app_insights",
@@ -106,9 +86,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/apis-and-ingress/apim_function_backend": [
     "check_app_insights",
@@ -116,39 +94,31 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/apis-and-ingress/auth_easyauth": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/apis-and-ingress/auth_jwt_validation": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/apis-and-ingress/auth_multitenant": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/apis-and-ingress/bff_facade_api": [
     "check_app_insights",
@@ -158,9 +128,7 @@
     "check_extension_bundle_v4",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/apis-and-ingress/full_stack_crud_api": [
     "check_app_insights",
@@ -168,39 +136,31 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/apis-and-ingress/hello_http_minimal": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/apis-and-ingress/http_auth_levels": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/apis-and-ingress/http_routing_query_body": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/apis-and-ingress/scaffold_walkthrough_app": [
     "check_app_insights",
@@ -210,20 +170,16 @@
     "check_extension_bundle",
     "check_extension_bundle_v4",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/apis-and-ingress/webhook_github": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/async-apis-and-jobs/async_http_polling": [
     "check_app_insights",
@@ -232,9 +188,7 @@
     "check_durabletask_config",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/async-apis-and-jobs/callback_completion": [
     "check_app_insights",
@@ -242,9 +196,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/async-apis-and-jobs/queue_backed_job": [
     "check_app_insights",
@@ -252,9 +204,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/blob-and-file-triggers/blob_csv_to_table": [
     "check_app_insights",
@@ -262,19 +212,15 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/blob-and-file-triggers/blob_eventgrid_trigger": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/blob-and-file-triggers/blob_thumbnail_generator": [
     "check_app_insights",
@@ -282,19 +228,15 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/blob-and-file-triggers/blob_upload_processor": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/data-and-pipelines/change_feed_processor": [
     "check_app_insights",
@@ -302,10 +244,8 @@
     "check_azure_functions_worker",
     "check_binding_connection_resolution",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/data-and-pipelines/cqrs_read_projection": [
     "check_app_insights",
@@ -314,9 +254,7 @@
     "check_binding_connection_resolution",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/data-and-pipelines/db_input_output": [
     "check_app_insights",
@@ -324,9 +262,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/data-and-pipelines/etl_enrichment": [
     "check_app_insights",
@@ -335,9 +271,7 @@
     "check_binding_connection_resolution",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/data-and-pipelines/file_processing_pipeline": [
     "check_app_insights",
@@ -346,9 +280,7 @@
     "check_binding_connection_resolution",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/data-and-pipelines/sqlalchemy_rest_pagination": [
     "check_app_insights",
@@ -356,19 +288,15 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/guides/local_run_and_direct_invoke": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/messaging-and-pubsub/claim_check_pattern": [
     "check_app_insights",
@@ -377,9 +305,7 @@
     "check_binding_connection_resolution",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/messaging-and-pubsub/eventgrid_domain_events": [
     "check_app_insights",
@@ -387,9 +313,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/messaging-and-pubsub/eventgrid_router": [
     "check_app_insights",
@@ -397,9 +321,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/messaging-and-pubsub/queue_consumer": [
     "check_app_insights",
@@ -407,10 +329,8 @@
     "check_azure_functions_worker",
     "check_binding_connection_resolution",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/messaging-and-pubsub/queue_producer": [
     "check_app_insights",
@@ -418,10 +338,8 @@
     "check_azure_functions_worker",
     "check_binding_connection_resolution",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/messaging-and-pubsub/servicebus_dlq_replay": [
     "check_app_insights",
@@ -429,9 +347,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/messaging-and-pubsub/servicebus_sessions": [
     "check_app_insights",
@@ -440,9 +356,7 @@
     "check_binding_connection_resolution",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/messaging-and-pubsub/servicebus_topic_fanout": [
     "check_app_insights",
@@ -451,9 +365,7 @@
     "check_binding_connection_resolution",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/messaging-and-pubsub/servicebus_worker": [
     "check_app_insights",
@@ -461,10 +373,8 @@
     "check_azure_functions_worker",
     "check_binding_connection_resolution",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/orchestration-and-workflows/async_job_lifecycle": [
     "check_app_insights",
@@ -473,9 +383,7 @@
     "check_durabletask_config",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/orchestration-and-workflows/durable_determinism_gotchas": [
     "check_app_insights",
@@ -483,10 +391,8 @@
     "check_azure_functions_worker",
     "check_durabletask_config",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/orchestration-and-workflows/durable_entity_counter": [
     "check_app_insights",
@@ -494,10 +400,8 @@
     "check_azure_functions_worker",
     "check_durabletask_config",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/orchestration-and-workflows/durable_fan_out_fan_in": [
     "check_app_insights",
@@ -505,10 +409,8 @@
     "check_azure_functions_worker",
     "check_durabletask_config",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/orchestration-and-workflows/durable_graph_fan_out": [
     "check_app_insights",
@@ -517,10 +419,8 @@
     "check_durabletask_config",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_scan_before_spec",
-    "check_venv"
+    "check_scan_before_spec"
   ],
   "examples/orchestration-and-workflows/durable_hello_sequence": [
     "check_app_insights",
@@ -528,10 +428,8 @@
     "check_azure_functions_worker",
     "check_durabletask_config",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/orchestration-and-workflows/durable_human_interaction": [
     "check_app_insights",
@@ -539,10 +437,8 @@
     "check_azure_functions_worker",
     "check_durabletask_config",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/orchestration-and-workflows/durable_retry_pattern": [
     "check_app_insights",
@@ -550,10 +446,8 @@
     "check_azure_functions_worker",
     "check_durabletask_config",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/orchestration-and-workflows/durable_singleton_monitor": [
     "check_app_insights",
@@ -562,9 +456,7 @@
     "check_durabletask_config",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/orchestration-and-workflows/durable_unit_testing": [
     "check_app_insights",
@@ -572,10 +464,8 @@
     "check_azure_functions_worker",
     "check_durabletask_config",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/orchestration-and-workflows/saga_compensation": [
     "check_app_insights",
@@ -584,9 +474,7 @@
     "check_durabletask_config",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/orchestration-and-workflows/sub_orchestration": [
     "check_app_insights",
@@ -595,9 +483,7 @@
     "check_durabletask_config",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/realtime/websocket_proxy": [
     "check_app_insights",
@@ -605,9 +491,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/reliability/circuit_breaker": [
     "check_app_insights",
@@ -615,9 +499,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/reliability/outbox_pattern": [
     "check_app_insights",
@@ -626,9 +508,7 @@
     "check_binding_connection_resolution",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/reliability/poison_message_handling": [
     "check_app_insights",
@@ -637,9 +517,7 @@
     "check_binding_connection_resolution",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/reliability/rate_limiting": [
     "check_app_insights",
@@ -647,9 +525,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/reliability/retry_and_idempotency": [
     "check_app_insights",
@@ -657,20 +533,16 @@
     "check_azure_functions_worker",
     "check_binding_connection_resolution",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/runtime-and-ops/blueprint_modular_app": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/runtime-and-ops/cold_start_mitigation": [
     "check_app_insights",
@@ -678,9 +550,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/runtime-and-ops/concurrency_tuning": [
     "check_app_insights",
@@ -688,20 +558,16 @@
     "check_azure_functions_worker",
     "check_binding_connection_resolution",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/runtime-and-ops/doctor_diagnostics_endpoint": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/runtime-and-ops/host_json_tuning": [
     "check_app_insights",
@@ -709,10 +575,8 @@
     "check_azure_functions_worker",
     "check_host_json_log_level_conflict",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/runtime-and-ops/observability_tracing": [
     "check_app_insights",
@@ -720,9 +584,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/runtime-and-ops/output_binding_vs_sdk": [
     "check_app_insights",
@@ -730,10 +592,8 @@
     "check_azure_functions_worker",
     "check_binding_connection_resolution",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/scheduled-and-background/durable_timer_reminder": [
     "check_app_insights",
@@ -742,9 +602,7 @@
     "check_durabletask_config",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/scheduled-and-background/queue_scheduled_dispatch": [
     "check_app_insights",
@@ -753,19 +611,15 @@
     "check_binding_connection_resolution",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/scheduled-and-background/timer_cron_job": [
     "check_app_insights",
     "check_azure_functions_library",
     "check_azure_functions_worker",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/security-and-tenancy/managed_identity_servicebus": [
     "check_app_insights",
@@ -773,10 +627,8 @@
     "check_azure_functions_worker",
     "check_binding_connection_resolution",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/security-and-tenancy/managed_identity_storage": [
     "check_app_insights",
@@ -784,10 +636,8 @@
     "check_azure_functions_worker",
     "check_binding_connection_resolution",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ],
   "examples/security-and-tenancy/secretless_keyvault": [
     "check_app_insights",
@@ -795,9 +645,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/security-and-tenancy/tenant_isolation": [
     "check_app_insights",
@@ -805,9 +653,7 @@
     "check_azure_functions_worker",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/streams-and-telemetry/eventhub_batch_window": [
     "check_app_insights",
@@ -816,9 +662,7 @@
     "check_binding_connection_resolution",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/streams-and-telemetry/eventhub_checkpoint_replay": [
     "check_app_insights",
@@ -827,9 +671,7 @@
     "check_binding_connection_resolution",
     "check_funcignore",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
-    "check_requirements_txt",
-    "check_venv"
+    "check_requirements_txt"
   ],
   "examples/streams-and-telemetry/eventhub_consumer": [
     "check_app_insights",
@@ -837,9 +679,7 @@
     "check_azure_functions_worker",
     "check_binding_connection_resolution",
     "check_local_settings",
-    "check_python_runtime_lifecycle",
     "check_requirements_txt",
-    "check_unused_files",
-    "check_venv"
+    "check_unused_files"
   ]
 }

--- a/scripts/soak_cookbook.py
+++ b/scripts/soak_cookbook.py
@@ -32,6 +32,22 @@ from typing import Any
 BASELINE_PATH = Path(__file__).resolve().parent / "cookbook_soak_baseline.json"
 DOCTOR_BIN = shutil.which("azure-functions-doctor")
 
+# Machine-level rules depend on the HOST (func CLI, venv, interpreter), not the
+# project: they legitimately differ between a developer laptop and the CI
+# runner (first real run flagged every project with check_func_cli). The
+# contract documents them as environment-dependent; exclude from the baseline
+# comparison while still health/contract-checking their output.
+MACHINE_LEVEL_RULES = frozenset(
+    {
+        "check_venv",
+        "check_python_executable",
+        "check_python_version",
+        "check_python_runtime_lifecycle",
+        "check_func_cli",
+        "check_func_core_tools_version",
+    }
+)
+
 
 def discover_projects(examples_dir: Path) -> list[Path]:
     """Every cookbook example directory that ships a function_app.py."""
@@ -99,7 +115,7 @@ def main() -> int:
             failures.append(f"{name}: rc={rc} {error}")
             continue
         found = findings(data)
-        rule_ids = sorted({rule for rule, _file in found})
+        rule_ids = sorted({rule for rule, _file in found if rule not in MACHINE_LEVEL_RULES})
         next_baseline[name] = rule_ids
         for rule, file_ref in found:
             if file_ref.startswith("/"):


### PR DESCRIPTION
References #428. First real run caught host-dependence (func CLI present on the baseline machine, absent on runners) — machine-level rules (dev-env + interpreter-coupled) are now excluded from the comparison, matching the contract's environment-dependent semantics; health/contract checks still cover them. Baseline regenerated; gate passes locally against PyPI 0.20.0.