### PR TITLE
ci: add hatch-matrix hygiene lint to guard the CI matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ check: ensure-hatch
 lint-workflows: ensure-hatch
 	@$(HATCH) run python tools/lint_release_workflows.py
 	@$(HATCH) run python tools/lint_workflow_pins.py
+	@$(HATCH) run python tools/lint_hatch_matrix.py
 
 .PHONY: check-all
 check-all: ensure-hatch

--- a/tests/test_hatch_matrix_lint.py
+++ b/tests/test_hatch_matrix_lint.py
@@ -1,0 +1,131 @@
+"""Regression guard for the hatch-pin / CI-matrix conflict lint.
+
+Ported from azure-functions-openapi-python (origin fix: #554 / PR #555);
+tracked for this repo in #432.
+
+Exercises tools/lint_hatch_matrix.py against this repo (must be clean -- the
+test matrix runs directly on the interpreter and adds a version guard) and
+against synthetic buggy configs (must be caught).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LINT_PATH = _REPO_ROOT / "tools" / "lint_hatch_matrix.py"
+
+_spec = importlib.util.spec_from_file_location("lint_hatch_matrix", _LINT_PATH)
+assert _spec and _spec.loader
+lint_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lint_mod)
+
+
+_PINNED = {"default": "3.10"}
+
+_MATRIX_INLINE = """
+jobs:
+  test:
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - run: pip install hatch
+      - run: make check-all
+"""
+
+_MATRIX_BLOCK = """
+jobs:
+  test:
+    strategy:
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+    steps:
+      - run: hatch run pytest
+"""
+
+
+def test_repo_is_clean() -> None:
+    """This repo's committed workflows must pass -- the fix is in place."""
+    assert lint_mod.lint() == []
+
+
+def test_parses_default_env_pin() -> None:
+    text = '[tool.hatch.envs.default]\npython = "3.10"\n'
+    assert lint_mod.parse_pinned_hatch_envs(text) == {"default": "3.10"}
+
+
+def test_matrix_value_is_not_a_pin() -> None:
+    # A hatch env whose python is a list/matrix is not a single-interpreter pin.
+    text = '[tool.hatch.envs.default]\npython = ["3.10", "3.11"]\n'
+    assert lint_mod.parse_pinned_hatch_envs(text) == {}
+
+
+def test_section_boundary_ends_env_scope() -> None:
+    text = '[tool.hatch.envs.default]\n[tool.other]\npython = "3.10"\n'
+    assert lint_mod.parse_pinned_hatch_envs(text) == {}
+
+
+def test_inline_matrix_versions_parsed() -> None:
+    assert lint_mod.matrix_python_versions(_MATRIX_INLINE) == ["3.10", "3.11", "3.12"]
+
+
+def test_block_matrix_versions_parsed() -> None:
+    assert lint_mod.matrix_python_versions(_MATRIX_BLOCK) == ["3.10", "3.11"]
+
+
+def test_matrix_reference_is_not_a_declaration() -> None:
+    text = "        python-version: ${{ matrix.python-version }}\n"
+    assert lint_mod.matrix_python_versions(text) == []
+
+
+def test_hatch_run_is_flagged() -> None:
+    errors = lint_mod.check_workflow(_MATRIX_BLOCK, "ci.yml", _PINNED)
+    assert errors and "runs tests through Hatch" in errors[0]
+
+
+def test_make_check_all_is_flagged() -> None:
+    errors = lint_mod.check_workflow(_MATRIX_INLINE, "ci.yml", _PINNED)
+    assert errors and "every matrix cell" in errors[0]
+
+
+def test_no_pin_is_clean() -> None:
+    assert lint_mod.check_workflow(_MATRIX_INLINE, "ci.yml", {}) == []
+
+
+def test_single_version_matrix_is_clean() -> None:
+    text = _MATRIX_INLINE.replace('["3.10", "3.11", "3.12"]', '["3.10"]')
+    assert lint_mod.check_workflow(text, "ci.yml", _PINNED) == []
+
+
+def test_direct_pytest_is_clean() -> None:
+    # Runs on the matrix interpreter directly -- no hatch routing, so safe.
+    text = """
+jobs:
+  test:
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - run: python -m pip install -e .[dev]
+      - run: python -m pytest
+"""
+    assert lint_mod.check_workflow(text, "ci.yml", _PINNED) == []
+
+
+def test_interpreter_guard_makes_it_clean() -> None:
+    # Routes through hatch but proves the interpreter matches the matrix cell.
+    text = (
+        _MATRIX_BLOCK
+        + """
+      - name: Assert interpreter matches matrix
+        env:
+          EXPECTED: ${{ matrix.python-version }}
+        run: python -c "import sys; assert '.'.join(map(str, sys.version_info[:2]))"
+        # version_info guard tied to matrix.python-version
+"""
+    )
+    assert lint_mod.check_workflow(text, "ci.yml", _PINNED) == []

--- a/tools/lint_hatch_matrix.py
+++ b/tools/lint_hatch_matrix.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Guard against the fleet-wide "hatch default-env pin hides the CI matrix" bug.
+
+Ported from azure-functions-openapi-python (origin fix:
+azure-functions-openapi-python#554 / PR #555; fleet deployment audit in #576).
+Tracked for this repo in #432.
+
+The failure mode this lint catches: a repo pins its Hatch *default* env to a
+single interpreter --
+
+    [tool.hatch.envs.default]
+    python = "3.10"
+
+-- while its CI declares a *multi-version* ``python-version`` matrix that then
+installs and runs the test suite **through Hatch** (``hatch run ...`` directly,
+or ``make install`` / ``make check-all`` targets that route through Hatch).
+Because ``hatch run`` re-resolves to the pinned interpreter regardless of what
+``actions/setup-python`` provisioned, *every* matrix cell secretly executes on
+the pinned version. The per-version status/coverage badges are then false: the
+matrix looks green across 3.11/3.12/3.13 but nothing ever ran there.
+
+Rule -- a workflow is flagged when ALL of the following hold:
+
+1. ``pyproject.toml`` pins at least one Hatch env to a single ``python``
+   version (``[tool.hatch.envs.<name>] python = "X.Y"``); and
+2. the workflow declares a ``python-version`` matrix with 2+ distinct
+   versions; and
+3. that workflow routes the test run through Hatch (``hatch run`` or a
+   ``make`` target known to wrap Hatch: ``install`` / ``check-all`` /
+   ``check`` / ``test`` / ``coverage``); and
+4. the workflow does NOT carry an interpreter-match guard -- a step that
+   asserts the runtime ``sys.version_info`` equals ``matrix.python-version``
+   (the belt-and-braces assertion added by the reference fix). A repo that
+   runs tests directly on the matrix interpreter (``python -m pytest``) or
+   proves the interpreter with such a guard is considered safe.
+
+Stdlib-only on purpose (mirrors ``tools/lint_workflow_pins.py``): the lint must
+not itself depend on a package that can drift. Exit code 0 = clean, 1 = drift.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+WORKFLOWS_DIR = ".github/workflows"
+PYPROJECT = "pyproject.toml"
+
+# ``make`` targets that (in this fleet's Makefiles) execute through ``hatch run``.
+_HATCH_MAKE_TARGETS = ("check-all", "install", "check", "test", "coverage")
+
+# [tool.hatch.envs.<name>] section header.
+_HATCH_ENV_HEADER_RE = re.compile(r"^\s*\[tool\.hatch\.envs\.(?P<name>[^\].]+)\]\s*$")
+# A single pinned interpreter: python = "3.10". A matrix/list value is not a pin.
+_PYTHON_PIN_RE = re.compile(r"""^\s*python\s*=\s*["'](?P<ver>\d+\.\d+)["']\s*$""")
+# Any other section header ends the current section.
+_SECTION_RE = re.compile(r"^\s*\[")
+
+# Routes tests through Hatch: a bare ``hatch run`` or a Hatch-wrapping make target.
+_HATCH_RUN_RE = re.compile(r"\bhatch\s+run\b")
+_HATCH_MAKE_RE = re.compile(r"\bmake\s+(?:" + "|".join(_HATCH_MAKE_TARGETS) + r")\b")
+
+# An interpreter-match guard proves the runtime interpreter equals the matrix cell.
+_GUARD_VERSION_INFO_RE = re.compile(r"\bversion_info\b")
+_GUARD_MATRIX_REF_RE = re.compile(r"matrix\.python-version")
+
+# Inline matrix list: python-version: ["3.10", "3.11"].
+_MATRIX_INLINE_RE = re.compile(r"""python-version:\s*\[(?P<body>[^\]]*)\]""")
+# Block matrix key: python-version:  (followed by "- x.y" items on later lines).
+_MATRIX_BLOCK_KEY_RE = re.compile(r"""^(?P<indent>\s*)python-version:\s*$""")
+_QUOTED_VER_RE = re.compile(r"""["'](?P<ver>\d+(?:\.\d+)+)["']""")
+_DASH_VER_RE = re.compile(r"""^\s*-\s*["']?(?P<ver>\d+(?:\.\d+)+)["']?\s*$""")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def parse_pinned_hatch_envs(pyproject_text: str) -> dict[str, str]:
+    """Return ``{env_name: version}`` for every Hatch env pinned to one interpreter."""
+    pinned: dict[str, str] = {}
+    current: str | None = None
+    for line in pyproject_text.splitlines():
+        header = _HATCH_ENV_HEADER_RE.match(line)
+        if header:
+            current = header.group("name")
+            continue
+        if _SECTION_RE.match(line):
+            # Some other TOML table began; leave the hatch-env context.
+            current = None
+            continue
+        if current is not None:
+            pin = _PYTHON_PIN_RE.match(line)
+            if pin:
+                pinned[current] = pin.group("ver")
+    return pinned
+
+
+def matrix_python_versions(workflow_text: str) -> list[str]:
+    """Return the distinct interpreter versions declared in a ``python-version`` matrix.
+
+    Recognizes both inline (``["3.10", "3.11"]``) and block (``- "3.10"``) forms.
+    ``${{ matrix.python-version }}`` *references* are ignored -- only declarations
+    of an actual version list count.
+    """
+    versions: list[str] = []
+    lines = workflow_text.splitlines()
+    for idx, line in enumerate(lines):
+        inline = _MATRIX_INLINE_RE.search(line)
+        if inline:
+            versions.extend(m.group("ver") for m in _QUOTED_VER_RE.finditer(inline.group("body")))
+            continue
+        block = _MATRIX_BLOCK_KEY_RE.match(line)
+        if block:
+            base_indent = len(block.group("indent"))
+            for follow in lines[idx + 1 :]:
+                if not follow.strip():
+                    continue
+                indent = len(follow) - len(follow.lstrip())
+                dash = _DASH_VER_RE.match(follow)
+                if dash and indent > base_indent:
+                    versions.append(dash.group("ver"))
+                    continue
+                # Dedent or a non-item line closes the block list.
+                if indent <= base_indent or not follow.lstrip().startswith("-"):
+                    break
+    # Distinct, order-preserving.
+    seen: set[str] = set()
+    distinct: list[str] = []
+    for ver in versions:
+        if ver not in seen:
+            seen.add(ver)
+            distinct.append(ver)
+    return distinct
+
+
+def routes_tests_through_hatch(workflow_text: str) -> bool:
+    """True when the workflow runs tests via ``hatch run`` or a Hatch-wrapping make target."""
+    return bool(_HATCH_RUN_RE.search(workflow_text) or _HATCH_MAKE_RE.search(workflow_text))
+
+
+def has_interpreter_guard(workflow_text: str) -> bool:
+    """True when the workflow asserts the runtime interpreter matches the matrix cell."""
+    return bool(
+        _GUARD_VERSION_INFO_RE.search(workflow_text) and _GUARD_MATRIX_REF_RE.search(workflow_text)
+    )
+
+
+def check_workflow(workflow_text: str, rel_path: str, pinned: dict[str, str]) -> list[str]:
+    """Flag a workflow whose multi-version matrix is silently forced by a Hatch pin."""
+    if not pinned:
+        return []
+    versions = matrix_python_versions(workflow_text)
+    if len(versions) < 2:
+        return []
+    if not routes_tests_through_hatch(workflow_text):
+        return []
+    if has_interpreter_guard(workflow_text):
+        return []
+    env_desc = ", ".join(f"{name}={ver}" for name, ver in sorted(pinned.items()))
+    return [
+        f"{rel_path}: python-version matrix {versions} runs tests through Hatch, "
+        f"but [tool.hatch.envs] pins the interpreter ({env_desc}); every matrix "
+        f"cell would execute on the pinned version. Run tests directly on the "
+        f"matrix interpreter (python -m pytest) or add a sys.version_info guard "
+        f"asserting it equals matrix.python-version."
+    ]
+
+
+def lint(root: Path | None = None) -> list[str]:
+    """Run the hatch-pin/matrix conflict check; return human-readable violations."""
+    root = root or _repo_root()
+    pyproject = root / PYPROJECT
+    if not pyproject.is_file():
+        return [f"{PYPROJECT}: expected pyproject.toml is missing"]
+    pinned = parse_pinned_hatch_envs(pyproject.read_text(encoding="utf-8"))
+    errors: list[str] = []
+    workflows = root / WORKFLOWS_DIR
+    if not workflows.is_dir():
+        return errors
+    for path in sorted(workflows.glob("*.yml")) + sorted(workflows.glob("*.yaml")):
+        rel = path.relative_to(root).as_posix()
+        errors.extend(check_workflow(path.read_text(encoding="utf-8"), rel, pinned))
+    return errors
+
+
+def main() -> int:
+    errors = lint()
+    if errors:
+        print("Hatch default-env pin vs. CI matrix conflict detected:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print("Hatch/matrix hygiene: no multi-version matrix is silently forced by a Hatch env pin.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Context
Completes the hatch-matrix hygiene rollout across the DX Toolkit for this repo. The interpreter guard in `ci-test.yml` already prevents the `python = "3.10"`-pinned hatch env from silently running every matrix cell (3.10–3.14) on 3.10, but there was no static check to keep that guard in place. This adds the stdlib-only `lint_hatch_matrix.py` lint (wired into `lint-workflows`) so the build fails if the guard is ever removed or a new pinned multi-version matrix is introduced without one.

## Changes
- Add `tools/lint_hatch_matrix.py` (stdlib-only) + `tests/test_hatch_matrix_lint.py`.
- Wire the lint into the existing `lint-workflows` Makefile target (alongside `lint_release_workflows.py` and `lint_workflow_pins.py`).

No workflow change needed — the runtime interpreter guard already exists in `ci-test.yml`.

Closes #432