### PR TITLE
ci: ignore major bumps for pinned artifact actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Artifact actions are deliberately pinned at v4 in the release-gated
+      # workflows (publish-pypi.yml, e2e-azure.yml); major bumps break the
+      # v4 artifact contract and must be handled as an explicit migration.
+      - dependency-name: "actions/upload-artifact"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "actions/download-artifact"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Artifact actions (upload-artifact, download-artifact) are deliberately pinned at v4 in the release-gated workflows (publish-pypi.yml, e2e-azure.yml). The v4->v7/v8 jump breaks the artifact contract and must be an explicit migration. Adds semver-major ignore rules so Dependabot stops re-opening those PRs. Closing #298 and #299 accordingly.